### PR TITLE
Use accurate mingcute Apple logo for download buttons

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,8 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.45.1",
+        "@egoist/tailwindcss-icons": "^1.9.2",
+        "@iconify-json/mingcute": "^1.2.7",
         "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
@@ -40,6 +42,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -124,6 +128,8 @@
 
     "@dotenvx/primitives": ["@dotenvx/primitives@0.8.0", "", {}, "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg=="],
 
+    "@egoist/tailwindcss-icons": ["@egoist/tailwindcss-icons@1.9.2", "", { "dependencies": { "@iconify/utils": "^3.1.0" }, "peerDependencies": { "tailwindcss": "*" } }, "sha512-I6XsSykmhu2cASg5Hp/ICLsJ/K/1aXPaSKjgbWaNp2xYnb4We/arWMmkhhV+9CglOFCUbqx0A3mM2kWV32ZIhw=="],
+
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -195,6 +201,12 @@
     "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.3.0", "", {}, "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@iconify-json/mingcute": ["@iconify-json/mingcute@1.2.7", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-bp4z6F53KAQp99aSL7qPCHL7HWUNGMNKIhfo/dx9pwVHiad/WusUbTOFXEZfpA44syJPzSOxa3O6Pwiq7qZz1g=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -672,6 +684,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
@@ -828,6 +842,8 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
@@ -971,6 +987,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,8 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.45.1",
+    "@egoist/tailwindcss-icons": "^1.9.2",
+    "@iconify-json/mingcute": "^1.2.7",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 import {
-  Apple,
   ArrowDown,
   Command,
   Cpu,
@@ -151,7 +150,7 @@ function SiteNav({ latest }: { latest: Release }) {
             className="ml-2 h-8 gap-1.5 rounded-md font-mono text-[13px]"
             render={<a href={latest.dmg} />}
           >
-            <Apple className="size-4" />
+            <span className="i-mingcute-apple-fill size-4" />
             download
           </Button>
         </nav>
@@ -203,7 +202,7 @@ function Hero({ latest }: { latest: Release }) {
               className="h-11 gap-2 rounded-md px-5 font-mono text-[13px]"
               render={<a href={latest.dmg} />}
             >
-              <Apple className="size-[18px]" />
+              <span className="i-mingcute-apple-fill size-[18px]" />
               Download for macOS
             </Button>
             <Button
@@ -420,7 +419,7 @@ function FinalCta({ latest }: { latest: Release }) {
             className="h-11 gap-2 rounded-md px-6 font-mono text-[13px]"
             render={<a href={latest.dmg} />}
           >
-            <Apple className="size-[18px]" />
+            <span className="i-mingcute-apple-fill size-[18px]" />
             Download for macOS
           </Button>
         </div>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4,6 +4,10 @@
 @import '@fontsource-variable/geist';
 @import '@fontsource-variable/geist-mono';
 
+/* Iconify collections as `i-{set}-{name}` utilities (mingcute installed for the
+   accurate Apple logo). Auto-detects any installed @iconify-json/* package. */
+@plugin '@egoist/tailwindcss-icons';
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
## What

The download buttons on the landing page (nav, hero, and final CTA) used lucide's `Apple` icon — which draws a **fruit apple**, not the Apple Inc. brand mark. This swaps them for mingcute's `apple-fill` logo so the "Download for macOS" CTAs show the correct, recognizable mark.

| | Before | After |
|---|---|---|
| Icon | lucide `Apple` (fruit) | mingcute `apple-fill` (brand logo) |

## How

Rather than inline a one-off SVG, this wires up the [`@egoist/tailwindcss-icons`](https://github.com/hyoban/tailwindcss-icons) plugin so any Iconify icon is available as a utility class going forward:

- Added devDeps `@egoist/tailwindcss-icons` + `@iconify-json/mingcute`.
- Registered the plugin via the Tailwind v4 CSS directive in `web/src/styles/app.css`: `@plugin '@egoist/tailwindcss-icons';`. No `tailwind.config.js` is needed — the plugin auto-detects installed `@iconify-json/*` collections.
- Replaced `<Apple className="size-*" />` with `<span className="i-mingcute-apple-fill size-*" />` in all three buttons and removed the now-unused lucide import.

The icon renders as a `currentColor` mask, so it inherits button text color exactly like the old lucide icon did, and the existing `size-4` / `size-[18px]` classes still control its size (the utilities win the cascade over the plugin's default `1em`).

## Verification

- `bun run build` passes; the compiled CSS contains the expected rule:
  `.i-mingcute-apple-fill { mask-image: <apple svg>; background-color: currentColor; display: inline-block; … }`
- Confirmed on the dev server that the real Apple logo renders white-on-dark in the nav `download` button and dark-on-white in the hero / final-CTA `Download for macOS` buttons.

## Reviewer notes

- Touches `package.json` / `bun.lock`, so pulling this branch requires `bun install`.
- `@iconify-json/mingcute` is a build-time-only devDependency; only the single used icon is embedded in the CSS, so there's no client bundle bloat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
