### PR TITLE
Add "Session Contents Restored" divider to restored terminals

### DIFF
--- a/kero/TerminalHistory.swift
+++ b/kero/TerminalHistory.swift
@@ -45,6 +45,29 @@ enum TerminalHistorySerializer {
         return lines.joined(separator: "\r\n")
     }
 
+    /// A single-line divider fed into the terminal directly beneath replayed
+    /// scrollback, marking where the restored output ends and the live shell
+    /// begins. Rendered with default colors so it tracks the light/dark theme:
+    /// dim rule characters bracket a normal-weight, centered label across
+    /// `width` columns (the terminal's column count at replay time). When the
+    /// terminal is too narrow to bracket the label, the label alone is shown.
+    static func restoredBanner(width: Int) -> String {
+        let label = "Session Contents Restored"
+        let dim = "\u{1b}[2m"
+        let normal = "\u{1b}[22m"
+        let reset = "\u{1b}[0m"
+
+        // Layout: <rule> <space> <label> <space> <rule>. Keep at least two rule
+        // cells per side; below that a divider reads as noise, so drop it.
+        let fixed = label.count + 2
+        guard width - fixed >= 4 else { return dim + label + reset }
+
+        let ruleCells = width - fixed
+        let left = ruleCells / 2
+        let rule = { (count: Int) in String(repeating: "\u{2500}", count: count) }
+        return dim + rule(left) + " " + normal + label + dim + " " + rule(ruleCells - left) + reset
+    }
+
     /// Encodes one buffer line: the shortest run of SGR escapes that reproduces
     /// its per-cell colors and styles, followed by the characters. Trailing
     /// blank cells are dropped and a reset is appended only when the line ends

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -146,10 +146,13 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         // Replay previous scrollback into the emulator before the shell
         // launches, so restored history sits above the first prompt. Feeding
         // here is safe — `startProcess` starts the PTY without resetting the
-        // buffer. A trailing newline drops the new prompt onto its own line.
+        // buffer. A divider banner marks where the replayed output ends, and
+        // the trailing newline drops the new prompt onto its own line.
         if AppSettings.shared.restoreTerminalHistory,
            let restoredHistory, !restoredHistory.isEmpty {
-            terminalView.feed(text: restoredHistory + "\r\n")
+            let banner = TerminalHistorySerializer.restoredBanner(
+                width: terminalView.getTerminal().cols)
+            terminalView.feed(text: restoredHistory + "\r\n" + banner + "\r\n")
         }
         restoredHistory = nil
         terminalView.startProcess(


### PR DESCRIPTION
## What

When terminal history restore is enabled, a relaunched session replays its previous scrollback above the new shell prompt. This adds a one-line divider banner directly beneath that replayed output:

```
────────────────────────── Session Contents Restored ───────────────────────────
```

## Why

Nothing previously marked where the replayed scrollback ended and the live shell began, so restored text could be mistaken for fresh output. The divider makes the boundary obvious.

## How

- `TerminalHistorySerializer.restoredBanner(width:)` builds the ANSI divider — dim rule characters (`─`) bracketing a normal-weight, centered label, sized to the terminal's column count. Narrow terminals (< ~31 cols) fall back to the bare label.
- `TerminalSession.start()` feeds the banner on its own line immediately after the restored history, before the shell launches.

## Reviewer notes

- Emitted as ANSI into the scrollback buffer rather than a SwiftUI overlay, so it stays anchored to the divider point and scrolls with the content.
- Uses **default** foreground color, so it adapts to the light/dark terminal theme automatically.
- Only appears when restore is on *and* there was history to restore — never over an empty session.
- Verified with `xcodebuild` (BUILD SUCCEEDED). No test target exists in the project, so no automated coverage was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)