### PR TITLE
Add ⌘F find bar to the terminal

### DIFF
--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -434,6 +434,9 @@ private struct PaneView: View {
         case .session(let session):
             TerminalHostView(session: session, isFocused: isFocused, onFocused: focus, onSplit: splitFromMenu)
                 .background(Color(nsColor: Theme.background))
+                .overlay(alignment: .topTrailing) {
+                    TerminalFindOverlay(find: session.find)
+                }
         case .file(let file):
             FileViewerView(file: file, isFocused: isFocused, onFocused: focus, onSplit: splitFromMenu)
                 .background(Color(nsColor: Theme.background))
@@ -532,6 +535,19 @@ private struct PaneView: View {
                 key: PaneFramePreferenceKey.self,
                 value: [pane.id: proxy.frame(in: .global)]
             )
+        }
+    }
+}
+
+/// Mounts a session's find bar only while it is open, so a closed bar never
+/// sits over the terminal swallowing clicks. Separate from `PaneView` so that
+/// opening and closing it re-renders nothing but the overlay.
+private struct TerminalFindOverlay: View {
+    @ObservedObject var find: TerminalFind
+
+    var body: some View {
+        if find.isPresented {
+            TerminalFindBar(find: find)
         }
     }
 }

--- a/kero/TerminalFind.swift
+++ b/kero/TerminalFind.swift
@@ -1,0 +1,201 @@
+//
+//  TerminalFind.swift
+//  kero
+//
+
+import AppKit
+import Combine
+import Foundation
+import GhosttyTerminal
+
+/// One Find menu command, routed from the menu bar to the focused pane's
+/// find bar.
+enum TerminalFindAction {
+    case show
+    case hide
+    case next
+    case previous
+    case useSelection
+}
+
+/// Find-in-terminal state for one session.
+///
+/// Ghostty owns the search itself — it scans the screen and scrollback on its
+/// own thread, highlights every match in its renderer, and moves the selection
+/// as you navigate — so this holds only what the find bar draws and forwards
+/// the user's intent as surface search actions. Match counts arrive back
+/// asynchronously through `TerminalSurfaceSearchDelegate`.
+@MainActor
+final class TerminalFind: nonisolated ObservableObject {
+    @Published private(set) var isPresented = false
+
+    /// The needle. Every edit restarts Ghostty's search, so the bar searches
+    /// as you type.
+    @Published var query = "" {
+        didSet {
+            guard query != oldValue, !isApplyingReportedNeedle else { return }
+            runSearch()
+        }
+    }
+
+    /// Matches found so far, or nil while a count for the current needle has
+    /// not been reported yet.
+    @Published private(set) var total: Int?
+    /// Zero-based index of the highlighted match, nil when none is.
+    @Published private(set) var selected: Int?
+
+    /// Bumped whenever the bar should take (or retake) keyboard focus, so ⌘F
+    /// on an already-open bar re-selects the term the way the system find bar
+    /// does. A counter rather than a flag: repeated requests must each land.
+    @Published private(set) var focusRequest = 0
+
+    /// The session owning this also owns the terminal view, so an unowned
+    /// reference is safe and keeps the session's object graph acyclic.
+    private unowned let terminal: KeroTerminalView
+
+    /// Set while a needle Ghostty resolved for us (⌘E's selection) is being
+    /// written into `query`, so echoing it back as a fresh search — which
+    /// would restart the one already running — is suppressed.
+    private var isApplyingReportedNeedle = false
+
+    /// Bumped per search so a deferred reveal belonging to an older needle can
+    /// tell it has been superseded. Ghostty reports each restart as a burst of
+    /// counts, several per keystroke.
+    private var searchGeneration = 0
+    /// Whether the current needle has already jumped to a match.
+    private var hasRevealedMatch = false
+
+    init(terminal: KeroTerminalView) {
+        self.terminal = terminal
+    }
+
+    // MARK: - Find menu
+
+    func perform(_ action: TerminalFindAction) {
+        switch action {
+        case .show: present()
+        case .hide: dismiss()
+        case .next: navigate(forward: true)
+        case .previous: navigate(forward: false)
+        case .useSelection: searchSelection()
+        }
+    }
+
+    // MARK: - Commands
+
+    /// Shows the bar and focuses its field. The needle survives a close, so
+    /// reopening offers the previous term again, pre-selected.
+    func present() {
+        isPresented = true
+        focusRequest += 1
+        runSearch()
+    }
+
+    /// Closes the bar, clears Ghostty's highlights, and hands typing back to
+    /// the terminal.
+    func dismiss() {
+        guard isPresented else { return }
+        isPresented = false
+        clearCounts()
+        terminal.endSearch()
+    }
+
+    /// Returns first responder to the terminal. Called once the find bar has
+    /// actually left the view tree, because claiming it any earlier loses the
+    /// race with SwiftUI tearing down the find field: AppKit resigns that
+    /// field editor afterwards and the window is left without a first
+    /// responder, so the terminal silently stops receiving keystrokes.
+    func restoreTerminalFocus() {
+        DispatchQueue.main.async { [terminal] in
+            guard NSApp.isActive,
+                  let window = terminal.window,
+                  window.isKeyWindow,
+                  window.firstResponder !== terminal
+            else { return }
+            window.makeFirstResponder(terminal)
+        }
+    }
+
+    func navigate(forward: Bool) {
+        guard !query.isEmpty else { return }
+        // ⌘G with the bar closed resumes the last search rather than doing
+        // nothing, matching how Find Next behaves elsewhere on macOS.
+        guard isPresented else {
+            present()
+            return
+        }
+        terminal.navigateSearch(forward: forward)
+    }
+
+    /// ⌘E. Ghostty resolves the needle from the grid selection and reports it
+    /// back through ``started(needle:)``, so the selection never has to be
+    /// read out and re-escaped here.
+    func searchSelection() {
+        guard terminal.hasSelection else { return }
+        terminal.searchSelection()
+    }
+
+    // MARK: - Reports from libghostty
+
+    func started(needle: String) {
+        // Only claim keyboard focus when this actually opens the bar. Ghostty
+        // may report a start for a search already under way, and re-selecting
+        // the field mid-edit would eat what the user is typing.
+        if !isPresented {
+            isPresented = true
+            focusRequest += 1
+        }
+        guard !needle.isEmpty, needle != query else { return }
+        isApplyingReportedNeedle = true
+        query = needle
+        isApplyingReportedNeedle = false
+    }
+
+    /// Ghostty ended the search on its own. Mirror it without sending
+    /// `end_search` straight back at it.
+    func ended() {
+        isPresented = false
+        clearCounts()
+    }
+
+    func update(total: Int?) {
+        self.total = total
+        revealFirstMatchIfNeeded()
+    }
+
+    func update(selected: Int?) {
+        self.selected = selected
+    }
+
+    /// Ghostty tallies matches but selects none until asked, so the first
+    /// non-empty result for a needle jumps to one — typing in the find bar is
+    /// meant to reveal the hit, not merely count it. Deferred so it never
+    /// re-enters libghostty from inside its own action callback, and dropped
+    /// when the needle has moved on by the time it runs.
+    private func revealFirstMatchIfNeeded() {
+        guard !hasRevealedMatch, let total, total > 0 else { return }
+        hasRevealedMatch = true
+        let generation = searchGeneration
+        DispatchQueue.main.async { [weak self] in
+            guard let self, isPresented, searchGeneration == generation else { return }
+            terminal.navigateSearch(forward: true)
+        }
+    }
+
+    // MARK: - Search
+
+    /// Restarts Ghostty's search for the current needle. Counts are dropped
+    /// first so the bar never shows a tally belonging to the previous term.
+    private func runSearch() {
+        guard isPresented else { return }
+        searchGeneration += 1
+        hasRevealedMatch = false
+        clearCounts()
+        terminal.search(query)
+    }
+
+    private func clearCounts() {
+        total = nil
+        selected = nil
+    }
+}

--- a/kero/TerminalFindBar.swift
+++ b/kero/TerminalFindBar.swift
@@ -1,0 +1,122 @@
+//
+//  TerminalFindBar.swift
+//  kero
+//
+
+import AppKit
+import SwiftUI
+
+/// Compact find bar floating over a terminal pane's top-right corner. Ghostty
+/// draws the match highlights inside the grid itself, so this only carries the
+/// field, the tally, and the navigation controls.
+struct TerminalFindBar: View {
+    @ObservedObject var find: TerminalFind
+
+    @FocusState private var fieldFocused: Bool
+
+    private var hasMatches: Bool { (find.total ?? 0) > 0 }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            TextField("Find", text: $find.query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .frame(width: 150)
+                .focused($fieldFocused)
+                .onKeyPress(.escape) {
+                    find.dismiss()
+                    return .handled
+                }
+                .onKeyPress(keys: [.return], phases: .down) { press in
+                    find.navigate(forward: !press.modifiers.contains(.shift))
+                    return .handled
+                }
+
+            Text(counterText)
+                .font(.system(size: 11).monospacedDigit())
+                .foregroundStyle(find.total == 0 ? AnyShapeStyle(.red) : AnyShapeStyle(.tertiary))
+                // Fixed width so typing doesn't shuffle the controls sideways
+                // as the tally grows and shrinks.
+                .frame(width: 52, alignment: .trailing)
+
+            navigationButton("chevron.up", forward: false)
+            navigationButton("chevron.down", forward: true)
+
+            Button {
+                find.dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 18)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .help("Close find bar")
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 30)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(nsColor: Theme.background))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.primary.opacity(0.12))
+        )
+        .shadow(color: .black.opacity(0.22), radius: 12, y: 4)
+        .padding(.top, 10)
+        .padding(.trailing, 16)
+        // Same deferral the command palette needs: focus assigned inside the
+        // appearance pass is dropped before the field editor exists.
+        .onAppear { focusField() }
+        .onChange(of: find.focusRequest) { focusField() }
+        // Hand keyboard focus back only once this bar has actually left the
+        // view tree, so AppKit cannot resign the field editor afterwards and
+        // undo it.
+        .onDisappear { find.restoreTerminalFocus() }
+    }
+
+    private func navigationButton(_ symbol: String, forward: Bool) -> some View {
+        Button {
+            find.navigate(forward: forward)
+        } label: {
+            Image(systemName: symbol)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(hasMatches ? AnyShapeStyle(.secondary) : AnyShapeStyle(.quaternary))
+                .frame(width: 18, height: 18)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .disabled(!hasMatches)
+        .help(forward ? "Next match" : "Previous match")
+    }
+
+    /// Blank while a count for the current needle is still pending, so a tally
+    /// belonging to the previous term is never shown.
+    private var counterText: String {
+        guard !find.query.isEmpty, let total = find.total else { return "" }
+        guard total > 0 else { return "0/0" }
+        guard let selected = find.selected else { return "\(total)" }
+        return "\(min(selected + 1, total))/\(total)"
+    }
+
+    private func focusField() {
+        DispatchQueue.main.async {
+            fieldFocused = true
+            selectQuery()
+        }
+    }
+
+    /// Selects the whole term, so reopening the bar over an existing needle
+    /// lets you type straight over it.
+    private func selectQuery() {
+        DispatchQueue.main.async {
+            NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
+        }
+    }
+}

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -233,6 +233,18 @@ final class TerminalManager: nonisolated ObservableObject {
         return false
     }
 
+    /// Routes a Find menu command to the focused pane's terminal. Driven off
+    /// the focused pane rather than the first responder, so ⌘F and ⌘G keep
+    /// working while the find bar's own field holds keyboard focus.
+    func performFindAction(_ action: TerminalFindAction) {
+        if case .session(let session)? = selectedProject?.focusedContent {
+            session.find.perform(action)
+        }
+    }
+
+    /// Whether the Find menu has a terminal on screen to act on right now.
+    var canFindInActiveTerminal: Bool { canClearActiveTerminal }
+
     /// Closes the focused pane (⌘W). When it's the last pane in its tab the
     /// tab closes too — matching the old single-content-tab behavior. Once the
     /// project has no tabs left, ⌘W closes the project itself.

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -22,6 +22,8 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
 
     let terminalView: KeroTerminalView
     let overlayScrollbar = OverlayScrollbarView()
+    /// Find-in-terminal state for this session's pane (⌘F).
+    let find: TerminalFind
     var onExited: ((TerminalSession) -> Void)?
 
     private static let persistedHistoryLineLimit = 500
@@ -59,9 +61,11 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
             theme: Self.ghosttyTheme(),
             terminalConfiguration: Self.terminalConfiguration(command: launchCommand)
         )
-        terminalView = KeroTerminalView(
+        let terminalView = KeroTerminalView(
             frame: NSRect(x: 0, y: 0, width: 800, height: 600)
         )
+        self.terminalView = terminalView
+        find = TerminalFind(terminal: terminalView)
         lastHistorySnapshot = restoredHistory
         super.init()
 
@@ -493,6 +497,24 @@ extension TerminalSession: TerminalSurfacePwdDelegate {
         guard !path.isEmpty else { return }
         workingDirectory = path.hasPrefix("/")
             ? URL(fileURLWithPath: path).absoluteString : path
+    }
+}
+
+extension TerminalSession: TerminalSurfaceSearchDelegate {
+    func terminalDidStartSearch(needle: String) {
+        find.started(needle: needle)
+    }
+
+    func terminalDidEndSearch() {
+        find.ended()
+    }
+
+    func terminalDidUpdateSearchTotal(_ total: Int?) {
+        find.update(total: total)
+    }
+
+    func terminalDidUpdateSearchSelected(_ selected: Int?) {
+        find.update(selected: selected)
     }
 }
 

--- a/kero/keroApp.swift
+++ b/kero/keroApp.swift
@@ -107,6 +107,38 @@ private struct KeroCommands: Commands {
         }
 
         CommandGroup(after: .pasteboard) {
+            // SwiftUI's Edit menu ships no Find submenu, so Kero owns these
+            // outright. They act on the focused pane's terminal rather than
+            // the first responder, which keeps them live while the find bar's
+            // text field has keyboard focus. ⇧⌘G is already Toggle Git Panel,
+            // so Find Previous is reachable by ⇧↩ in the bar instead.
+            Menu("Find") {
+                Button("Find…") {
+                    manager?.performFindAction(.show)
+                }
+                .keyboardShortcut("f", modifiers: .command)
+                .disabled(manager?.canFindInActiveTerminal != true)
+
+                Button("Find Next") {
+                    manager?.performFindAction(.next)
+                }
+                .keyboardShortcut("g", modifiers: .command)
+                .disabled(manager?.canFindInActiveTerminal != true)
+
+                Button("Find Previous") {
+                    manager?.performFindAction(.previous)
+                }
+                .disabled(manager?.canFindInActiveTerminal != true)
+
+                Button("Use Selection for Find") {
+                    manager?.performFindAction(.useSelection)
+                }
+                .keyboardShortcut("e", modifiers: .command)
+                .disabled(manager?.canFindInActiveTerminal != true)
+            }
+
+            Divider()
+
             Button("Clear Terminal") {
                 manager?.clearActiveTerminal()
             }


### PR DESCRIPTION
Adds find-in-terminal to terminal panes, built on libghostty 1.3.2's **native** search: Ghostty scans the screen and scrollback on its own thread and highlights every match in its Metal renderer, so no text is scraped out of the grid. The app only owns the bar, the tally, and the navigation intent.

Depends on egoist-labs/libghostty-spm@05c81fa, which surfaces the search actions and callbacks (they existed in the C API but were unreachable from Swift). That commit is picked up by the submodule bump here.

## Behavior

- **⌘F** opens the bar over the pane's top-right, pre-selecting the previous term
- Searches as you type, and scrolls the viewport to the match
- **↩ / ⇧↩** and **⌘G** move between matches; **⌘E** searches the current selection
- **Esc** closes, clears Ghostty's highlights, and hands typing back to the terminal
- Counter reads `2/6`, or a red `0/0` when nothing matches

Find state is per session, so each pane keeps its own needle.

## Two things worth a reviewer's attention

**SwiftUI generates no Find submenu.** This was first implemented the idiomatic macOS way — `performTextFinderAction:` down the responder chain — before dumping the running app's menu bar showed the Edit menu has no Find items at all, so nothing would ever have fired it. The commands are now declared outright and routed to the *focused pane* rather than the first responder, which also makes ⌘F/⌘G/⌘E keep working while the find field itself holds keyboard focus. Related: the comment at `kero/SourceTextEditor.swift:62` claims the file editor gets ⌘F "via the Edit ▸ Find menu" — that menu does not exist, so that appears to be inaccurate today. Not touched here.

**⇧⌘G is already Toggle Git Panel**, so Find Previous has no menu shortcut; ⇧↩ and the bar's ▲ control cover it. Say the word if you'd rather Find Previous take ⇧⌘G and the git panel move.

## Verification

Built and driven as a real app, reading libghostty's own action log:

- `search:alpha` → `total=6`; `navigate_search:next` → `selected=0,1,2`; `previous` → `1` (0-based, matching the displayed `n/total`)
- `end_search` → `total=-1, selected=-1`, both mapped to "unknown" rather than rendered
- Searching a marker ~300 lines up moved the viewport `offset` from 283 → 6
- ↩ and ⇧↩ confirmed to issue `navigate_search:next` / `:previous`

That run also caught a focus bug worth calling out: restoring first responder inside `dismiss()` raced SwiftUI tearing down the text field — AppKit resigned it afterwards and left the window with *no* first responder, so the terminal silently stopped accepting keystrokes after closing the bar. It now restores from the bar's `onDisappear`, verified by typing a command that touches a file after dismissing.

Package side has 6 new tests for the callback dispatch; the full suite passes (114 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)