### PR TITLE
Require confirmation for terminal clipboard access (OSC 52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ set in the Xcode project.
 
 ## [unreleased]
 
+- Security: stop terminal programs from silently reading your clipboard — an OSC 52 escape sequence (for example from a remote SSH host) could previously read the macOS clipboard without any prompt; kero now asks for confirmation first, matching the Ghostty app default (#8)
+- Warn before pasting text that looks like it could execute commands, matching Ghostty's paste protection
 - Fix fuzzy-looking terminal text: font thickening was unintentionally always on, making glyphs heavier and softer than stock Ghostty
 - Add a "Thicken font strokes" toggle in Settings → Font for those who prefer the heavier rendering
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of Kero receives security fixes. Updates ship
+through the in-app updater and https://kero.sh.
+
+## Reporting a Vulnerability
+
+Please use GitHub private vulnerability reporting:
+https://github.com/egoist/kero/security/advisories/new
+
+If that doesn't work for you, email hi@egoist.dev.
+
+Please don't open a public issue for anything you believe is
+exploitable before it has been fixed. Include reproduction steps and
+the Kero version (Kero → About Kero) you tested.
+
+## Scope
+
+Kero embeds libghostty (vendored in `Vendor/libghostty-spm`) for
+terminal emulation. In scope here: Kero's configuration and host
+integration of it — clipboard access, escape-sequence handling that
+crosses a trust boundary, the update chain, and anything that lets
+terminal output reach data outside the session. Vulnerabilities in
+upstream Ghostty itself should also be reported to the Ghostty
+project: https://github.com/ghostty-org/ghostty/security.

--- a/Vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController+Callbacks.swift
+++ b/Vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController+Callbacks.swift
@@ -12,6 +12,39 @@ import GhosttyKit
     import AppKit
 #endif
 
+/// System pasteboard access and libghostty request completion used by
+/// the clipboard callbacks. Injectable so tests can verify the security
+/// contract — escalated requests must never complete with clipboard
+/// data — without a live surface.
+enum TerminalClipboardIO {
+    nonisolated(unsafe) static var readString: () -> String? = {
+        #if canImport(UIKit)
+            UIPasteboard.general.string
+        #elseif canImport(AppKit)
+            NSPasteboard.general.string(forType: .string)
+        #endif
+    }
+
+    nonisolated(unsafe) static var writeString: (String) -> Void = { string in
+        #if canImport(UIKit)
+            UIPasteboard.general.string = string
+        #elseif canImport(AppKit)
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(string, forType: .string)
+        #endif
+    }
+
+    nonisolated(unsafe) static var complete: (
+        _ surface: ghostty_surface_t,
+        _ string: UnsafePointer<CChar>,
+        _ state: UnsafeMutableRawPointer,
+        _ confirmed: Bool
+    ) -> Void = { surface, string, state, confirmed in
+        ghostty_surface_complete_clipboard_request(surface, string, state, confirmed)
+    }
+}
+
 private enum TerminalCallbacks {
     static func wakeup(userdata: UnsafeMutableRawPointer?) {
         guard let userdata else { return }
@@ -59,20 +92,24 @@ private enum TerminalCallbacks {
         clipboard _: ghostty_clipboard_e,
         contents: UnsafePointer<ghostty_clipboard_content_s>?,
         contentsLen: Int,
-        confirm _: Bool
+        confirm: Bool
     ) {
+        // `confirm` is set when configuration (`clipboard-write = ask`)
+        // requires a user decision before the pasteboard changes. This
+        // bridge has no confirmation UI, so deny the write rather than
+        // silently performing it.
+        guard !confirm else {
+            TerminalDebugLog.log(
+                .input,
+                "clipboard write denied: confirmation required but no UI exists"
+            )
+            return
+        }
         guard contentsLen > 0 else { return }
         guard let content = contents?.pointee else { return }
         guard let data = content.data else { return }
-        let string = String(cString: data)
 
-        #if canImport(UIKit)
-            UIPasteboard.general.string = string
-        #elseif canImport(AppKit)
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(string, forType: .string)
-        #endif
+        TerminalClipboardIO.writeString(String(cString: data))
     }
 
     static func readClipboard(
@@ -87,13 +124,7 @@ private enum TerminalCallbacks {
             .takeUnretainedValue()
         guard let surface = bridge.rawSurface else { return false }
 
-        #if canImport(UIKit)
-            let string = UIPasteboard.general.string
-        #elseif canImport(AppKit)
-            let string = NSPasteboard.general.string(forType: .string)
-        #endif
-
-        guard let string else {
+        guard let string = TerminalClipboardIO.readString() else {
             TerminalDebugLog.log(.input, "clipboard paste read empty")
             return false
         }
@@ -101,13 +132,22 @@ private enum TerminalCallbacks {
             .input,
             "clipboard paste read bytes=\(string.utf8.count) lines=\(TerminalInputText.lineCount(in: string))"
         )
+        // Complete unconfirmed: Ghostty re-checks configuration and
+        // escalates to confirmReadClipboard when a user decision is
+        // required (unsafe paste, `clipboard-read = ask`).
         string.withCString { cString in
-            ghostty_surface_complete_clipboard_request(surface, cString, opaquePtr, false)
+            TerminalClipboardIO.complete(surface, cString, opaquePtr, false)
         }
         TerminalDebugLog.log(.input, "clipboard paste complete")
         return true
     }
 
+    /// Ghostty escalates a clipboard request here when configuration
+    /// demands a user decision: `clipboard-read = ask` for an OSC 52
+    /// read, or paste protection for an unsafe paste. The request is
+    /// routed to the surface delegate, which presents a prompt and
+    /// resolves it; without a confirmation delegate it is denied (see
+    /// ``TerminalCallbackBridge/handleClipboardConfirmation``).
     static func confirmReadClipboard(
         userdata: UnsafeMutableRawPointer?,
         string: UnsafePointer<CChar>?,
@@ -119,17 +159,30 @@ private enum TerminalCallbacks {
         let bridge = Unmanaged<TerminalCallbackBridge>
             .fromOpaque(userdata)
             .takeUnretainedValue()
-        guard let surface = bridge.rawSurface else { return }
 
-        let text = String(cString: string)
-        TerminalDebugLog.log(
-            .input,
-            "clipboard paste confirm request=\(request.rawValue) bytes=\(text.utf8.count) lines=\(TerminalInputText.lineCount(in: text))"
-        )
-        text.withCString { cString in
-            ghostty_surface_complete_clipboard_request(surface, cString, opaquePtr, true)
+        // OSC 52 writes never escalate through this callback (the write
+        // callback's `confirm` flag covers them), and completing one
+        // would push text onto the system pasteboard.
+        guard request != GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE else { return }
+
+        let kind: TerminalClipboardConfirmationRequest.Kind =
+            request == GHOSTTY_CLIPBOARD_REQUEST_PASTE ? .unsafePaste : .osc52Read
+        // Copy out of the C buffer before hopping threads: the string
+        // pointer is only valid for the duration of this callback,
+        // while the decision may arrive much later. The request state
+        // pointer stays valid until the request is completed.
+        let contents = String(cString: string)
+        let stateBits = UInt(bitPattern: opaquePtr)
+        terminalRunOnMain {
+            guard let state = UnsafeMutableRawPointer(bitPattern: stateBits) else {
+                return
+            }
+            bridge.handleClipboardConfirmation(
+                contents: contents,
+                kind: kind,
+                state: state
+            )
         }
-        TerminalDebugLog.log(.input, "clipboard paste confirmed")
     }
 }
 

--- a/Vendor/libghostty-spm/Sources/GhosttyTerminal/InMemory/TerminalCallbackBridge.swift
+++ b/Vendor/libghostty-spm/Sources/GhosttyTerminal/InMemory/TerminalCallbackBridge.swift
@@ -227,6 +227,40 @@ final class TerminalCallbackBridge {
         return false
     }
 
+    /// Routes a clipboard request that Ghostty escalated for a user
+    /// decision to the delegate's prompt. Without a delegate that
+    /// adopts ``TerminalSurfaceClipboardConfirmationDelegate`` the only
+    /// safe answer is no: auto-confirming would hand the system
+    /// clipboard to any program that can write terminal output.
+    func handleClipboardConfirmation(
+        contents: String,
+        kind: TerminalClipboardConfirmationRequest.Kind,
+        state: UnsafeMutableRawPointer
+    ) {
+        let request = TerminalClipboardConfirmationRequest(
+            bridge: self,
+            kind: kind,
+            contents: contents,
+            state: state
+        )
+        guard
+            let delegate = delegate
+                as? any TerminalSurfaceClipboardConfirmationDelegate
+        else {
+            TerminalDebugLog.log(
+                .input,
+                "clipboard confirm denied: no confirmation delegate"
+            )
+            request.deny()
+            return
+        }
+        TerminalDebugLog.log(
+            .input,
+            "clipboard confirm escalated kind=\(kind) bytes=\(contents.utf8.count)"
+        )
+        delegate.terminalDidRequestClipboardConfirmation(request)
+    }
+
     func handleClose(processAlive: Bool) {
         TerminalDebugLog.log(
             .lifecycle,

--- a/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalClipboardConfirmationRequest.swift
+++ b/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalClipboardConfirmationRequest.swift
@@ -1,0 +1,83 @@
+//
+//  TerminalClipboardConfirmationRequest.swift
+//  libghostty-spm
+//
+
+import Foundation
+import GhosttyKit
+
+/// A clipboard request that Ghostty escalated for a user decision:
+/// an OSC 52 read under `clipboard-read = ask`, or a paste that paste
+/// protection flagged as unsafe. The host presents a visible prompt
+/// and calls ``approve()`` or ``deny()`` exactly once; later calls are
+/// ignored.
+@MainActor
+public final class TerminalClipboardConfirmationRequest {
+    public enum Kind: Sendable {
+        /// Paste protection flagged the pending paste as unsafe.
+        case unsafePaste
+        /// A terminal program wants the clipboard via OSC 52 with
+        /// `clipboard-read = ask`.
+        case osc52Read
+    }
+
+    public let kind: Kind
+
+    /// The text under decision: what would be pasted for
+    /// ``Kind/unsafePaste``, or what the program would receive for
+    /// ``Kind/osc52Read``.
+    public let contents: String
+
+    private weak var bridge: TerminalCallbackBridge?
+    private let state: UnsafeMutableRawPointer
+    private var resolved = false
+
+    init(
+        bridge: TerminalCallbackBridge,
+        kind: Kind,
+        contents: String,
+        state: UnsafeMutableRawPointer
+    ) {
+        self.bridge = bridge
+        self.kind = kind
+        self.contents = contents
+        self.state = state
+    }
+
+    /// Completes with the requested contents: the paste proceeds, or
+    /// the OSC 52 reply carries the clipboard.
+    public func approve() {
+        resolve(text: contents, outcome: "approved")
+    }
+
+    /// Completes with no data, mirroring upstream Ghostty's cancel
+    /// action: the paste becomes a no-op and an OSC 52 read replies
+    /// empty.
+    public func deny() {
+        resolve(text: "", outcome: "denied")
+    }
+
+    private func resolve(text: String, outcome: String) {
+        guard !resolved else { return }
+        resolved = true
+
+        // Completing hands `state` back to the surface, which frees it.
+        // Teardown nils `rawSurface` before freeing the surface, so a
+        // decision arriving after the surface died is dropped instead
+        // of touching freed memory.
+        guard let surface = bridge?.rawSurface else {
+            TerminalDebugLog.log(
+                .input,
+                "clipboard confirm \(outcome) after surface teardown; dropped"
+            )
+            return
+        }
+        TerminalDebugLog.log(
+            .input,
+            "clipboard confirm \(outcome) kind=\(kind) bytes=\(text.utf8.count)"
+        )
+        text.withCString { cString in
+            TerminalClipboardIO.complete(surface, cString, state, true)
+        }
+    }
+}

--- a/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceViewDelegate.swift
+++ b/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceViewDelegate.swift
@@ -179,6 +179,18 @@ public protocol TerminalSurfaceTextSelectionRequestDelegate: TerminalSurfaceView
     func terminalDidRequestTextSelection(_ request: TerminalTextSelectionRequest)
 }
 
+/// Receives clipboard requests that Ghostty escalates for a user
+/// decision (see ``TerminalClipboardConfirmationRequest``). The host is
+/// expected to present a visible prompt and resolve the request. When
+/// a surface's delegate does not adopt this protocol every escalated
+/// request is denied.
+@MainActor
+public protocol TerminalSurfaceClipboardConfirmationDelegate: TerminalSurfaceViewDelegate {
+    func terminalDidRequestClipboardConfirmation(
+        _ request: TerminalClipboardConfirmationRequest
+    )
+}
+
 /// Notifies a delegate when the underlying ``TerminalSurface`` is created or
 /// torn down. Useful when a consumer needs surface-level APIs (e.g.
 /// ``TerminalSurface/sendText(_:)``) reachable from outside the platform view.

--- a/Vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalClipboardCallbackTests.swift
+++ b/Vendor/libghostty-spm/Tests/GhosttyKitTest/TerminalClipboardCallbackTests.swift
@@ -1,0 +1,349 @@
+import GhosttyKit
+@testable import GhosttyTerminal
+import Testing
+
+/// Regression coverage for the clipboard callback security contract:
+/// a request that Ghostty escalates for user confirmation must never
+/// complete with real clipboard data unless a host confirmation
+/// delegate explicitly approves it. Serialized because the tests swap
+/// the injectable `TerminalClipboardIO` hooks.
+@Suite(.serialized)
+@MainActor
+struct TerminalClipboardCallbackTests {
+    @Test
+    func `escalated OSC 52 read without a delegate is denied with an empty confirmed reply`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var recorded: (string: String, confirmed: Bool)?
+        TerminalClipboardIO.complete = { _, string, _, confirmed in
+            recorded = (String(cString: string), confirmed)
+        }
+
+        let bridge = makeBridge()
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "secret from the pasteboard",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+        }
+
+        #expect(recorded?.string == "")
+        #expect(recorded?.confirmed == true)
+    }
+
+    @Test
+    func `escalated unsafe paste without a delegate is denied with an empty confirmed reply`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var recorded: (string: String, confirmed: Bool)?
+        TerminalClipboardIO.complete = { _, string, _, confirmed in
+            recorded = (String(cString: string), confirmed)
+        }
+
+        let bridge = makeBridge()
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "rm -rf /\n",
+                request: GHOSTTY_CLIPBOARD_REQUEST_PASTE,
+                state: state
+            )
+        }
+
+        #expect(recorded?.string == "")
+        #expect(recorded?.confirmed == true)
+    }
+
+    @Test
+    func `escalated OSC 52 write is dropped without completing`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var completed = false
+        TerminalClipboardIO.complete = { _, _, _, _ in
+            completed = true
+        }
+
+        let bridge = makeBridge()
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "attacker text",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE,
+                state: state
+            )
+        }
+
+        #expect(!completed)
+    }
+
+    @Test
+    func `escalated request routes to the confirmation delegate`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var completed = false
+        TerminalClipboardIO.complete = { _, _, _, _ in
+            completed = true
+        }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "clipboard text",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+
+            #expect(recorder.requests.count == 1)
+            #expect(recorder.requests.first?.kind == .osc52Read)
+            #expect(recorder.requests.first?.contents == "clipboard text")
+            // Nothing completes until the delegate decides.
+            #expect(!completed)
+            recorder.requests.first?.deny()
+        }
+
+        #expect(completed)
+    }
+
+    @Test
+    func `escalated paste maps to the unsafe paste kind`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        TerminalClipboardIO.complete = { _, _, _, _ in }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "multi\nline",
+                request: GHOSTTY_CLIPBOARD_REQUEST_PASTE,
+                state: state
+            )
+            #expect(recorder.requests.first?.kind == .unsafePaste)
+            recorder.requests.first?.deny()
+        }
+    }
+
+    @Test
+    func `approving completes with the original contents`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var recorded: (string: String, confirmed: Bool)?
+        TerminalClipboardIO.complete = { _, string, _, confirmed in
+            recorded = (String(cString: string), confirmed)
+        }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "approved text",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+            recorder.requests.first?.approve()
+        }
+
+        #expect(recorded?.string == "approved text")
+        #expect(recorded?.confirmed == true)
+    }
+
+    @Test
+    func `denying completes with an empty confirmed reply`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var recorded: (string: String, confirmed: Bool)?
+        TerminalClipboardIO.complete = { _, string, _, confirmed in
+            recorded = (String(cString: string), confirmed)
+        }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "never delivered",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+            recorder.requests.first?.deny()
+        }
+
+        #expect(recorded?.string == "")
+        #expect(recorded?.confirmed == true)
+    }
+
+    @Test
+    func `a request resolves at most once`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var completions = 0
+        TerminalClipboardIO.complete = { _, _, _, _ in
+            completions += 1
+        }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "text",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+            recorder.requests.first?.approve()
+            recorder.requests.first?.deny()
+            recorder.requests.first?.approve()
+        }
+
+        #expect(completions == 1)
+    }
+
+    @Test
+    func `a decision after surface teardown is dropped`() {
+        let original = TerminalClipboardIO.complete
+        defer { TerminalClipboardIO.complete = original }
+        var completed = false
+        TerminalClipboardIO.complete = { _, _, _, _ in
+            completed = true
+        }
+
+        let recorder = ClipboardConfirmationRecorder()
+        let bridge = makeBridge(delegate: recorder)
+        withTestState { state in
+            invokeConfirmCallback(
+                bridge: bridge,
+                contents: "text",
+                request: GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
+                state: state
+            )
+            bridge.rawSurface = nil
+            recorder.requests.first?.approve()
+        }
+
+        #expect(!completed)
+    }
+
+    @Test
+    func `write requiring confirmation never reaches the pasteboard`() {
+        let original = TerminalClipboardIO.writeString
+        defer { TerminalClipboardIO.writeString = original }
+        var written: String?
+        TerminalClipboardIO.writeString = { written = $0 }
+
+        invokeWriteCallback("attacker text", confirm: true)
+
+        #expect(written == nil)
+    }
+
+    @Test
+    func `unconfirmed write reaches the pasteboard`() {
+        let original = TerminalClipboardIO.writeString
+        defer { TerminalClipboardIO.writeString = original }
+        var written: String?
+        TerminalClipboardIO.writeString = { written = $0 }
+
+        invokeWriteCallback("copied text", confirm: false)
+
+        #expect(written == "copied text")
+    }
+
+    @Test
+    func `paste read completes unconfirmed so core keeps paste authority`() {
+        let originalRead = TerminalClipboardIO.readString
+        let originalComplete = TerminalClipboardIO.complete
+        defer {
+            TerminalClipboardIO.readString = originalRead
+            TerminalClipboardIO.complete = originalComplete
+        }
+        TerminalClipboardIO.readString = { "line one\nline two" }
+        var recorded: (string: String, confirmed: Bool)?
+        TerminalClipboardIO.complete = { _, string, _, confirmed in
+            recorded = (String(cString: string), confirmed)
+        }
+
+        let bridge = makeBridge()
+        var state = 0
+        let handled = withUnsafeMutablePointer(to: &state) { statePtr in
+            terminalControllerReadClipboardCallback(
+                userdata: Unmanaged.passUnretained(bridge).toOpaque(),
+                clipboard: GHOSTTY_CLIPBOARD_STANDARD,
+                opaquePtr: UnsafeMutableRawPointer(statePtr)
+            )
+        }
+
+        #expect(handled)
+        #expect(recorded?.string == "line one\nline two")
+        #expect(recorded?.confirmed == false)
+    }
+
+    // MARK: - Helpers
+
+    /// Bridge with a dummy surface pointer; the injected hooks
+    /// intercept every path that would dereference it.
+    private func makeBridge(
+        delegate: (any TerminalSurfaceViewDelegate)? = nil
+    ) -> TerminalCallbackBridge {
+        let bridge = TerminalCallbackBridge(delegate: delegate)
+        bridge.rawSurface = UnsafeMutableRawPointer(bitPattern: 0x1)
+        return bridge
+    }
+
+    /// Heap-allocated stand-in for the request state Ghostty passes to
+    /// the confirm callback, valid for the whole decision lifetime.
+    private func withTestState(_ body: (UnsafeMutableRawPointer) -> Void) {
+        let state = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        defer { state.deallocate() }
+        body(state)
+    }
+
+    private func invokeConfirmCallback(
+        bridge: TerminalCallbackBridge,
+        contents: String,
+        request: ghostty_clipboard_request_e,
+        state: UnsafeMutableRawPointer
+    ) {
+        contents.withCString { cString in
+            terminalControllerConfirmReadClipboardCallback(
+                userdata: Unmanaged.passUnretained(bridge).toOpaque(),
+                string: cString,
+                opaquePtr: state,
+                request: request
+            )
+        }
+    }
+
+    private func invokeWriteCallback(_ text: String, confirm: Bool) {
+        text.withCString { data in
+            "text/plain".withCString { mime in
+                let content = ghostty_clipboard_content_s(mime: mime, data: data)
+                withUnsafePointer(to: content) { contentsPtr in
+                    terminalControllerWriteClipboardCallback(
+                        userdata: nil,
+                        clipboard: GHOSTTY_CLIPBOARD_STANDARD,
+                        contents: contentsPtr,
+                        contentsLen: 1,
+                        confirm: confirm
+                    )
+                }
+            }
+        }
+    }
+}
+
+@MainActor
+private final class ClipboardConfirmationRecorder:
+    TerminalSurfaceClipboardConfirmationDelegate {
+    private(set) var requests: [TerminalClipboardConfirmationRequest] = []
+
+    func terminalDidRequestClipboardConfirmation(
+        _ request: TerminalClipboardConfirmationRequest
+    ) {
+        requests.append(request)
+    }
+}

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -294,9 +294,21 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
             builder.withCustom("scrollback-limit", "4194304")
             builder.withCustom("macos-option-as-alt", "true")
             builder.withCustom("scrollbar", "never")
-            builder.withCustom("clipboard-read", "allow")
+            // Terminal-program clipboard access via OSC 52, matching the
+            // Ghostty app defaults: reads prompt the user per request
+            // (TerminalSession presents the confirmation sheet), writes
+            // are allowed so OSC 52 copy from remote tmux/vim works, and
+            // paste protection warns before pastes that look like they
+            // could execute commands. Never `allow` reads without a
+            // prompt — that lets any program whose output reaches the
+            // terminal, including a remote SSH host, silently exfiltrate
+            // the macOS clipboard through the PTY. Set explicitly so the
+            // wrapper's base config can never drift them. Cmd-C/Cmd-V are
+            // host-initiated and stay prompt-free (unless an unsafe paste
+            // trips protection).
+            builder.withCustom("clipboard-read", "ask")
             builder.withCustom("clipboard-write", "allow")
-            builder.withCustom("clipboard-paste-protection", "false")
+            builder.withCustom("clipboard-paste-protection", "true")
         }
     }
 
@@ -519,6 +531,62 @@ extension TerminalSession: TerminalSurfaceSearchDelegate {
 
     func terminalDidUpdateSearchSelected(_ selected: Int?) {
         find.update(selected: selected)
+    }
+}
+
+extension TerminalSession: TerminalSurfaceClipboardConfirmationDelegate {
+    func terminalDidRequestClipboardConfirmation(
+        _ request: TerminalClipboardConfirmationRequest
+    ) {
+        guard let window = terminalView.window else {
+            request.deny()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        switch request.kind {
+        case .unsafePaste:
+            alert.messageText = "Warning: Potentially Unsafe Paste"
+            alert.informativeText =
+                "Pasting this text to the terminal may be dangerous as it looks like some commands may be executed."
+        case .osc52Read:
+            alert.messageText = "Authorize Clipboard Access"
+            alert.informativeText =
+                "A program is attempting to read from the clipboard. The current clipboard contents are shown below."
+        }
+        alert.accessoryView = Self.clipboardPreview(request.contents)
+        alert.addButton(withTitle: request.kind == .unsafePaste ? "Paste" : "Allow")
+        let cancel = alert.addButton(
+            withTitle: request.kind == .unsafePaste ? "Cancel" : "Deny"
+        )
+        cancel.keyEquivalent = "\u{1b}"
+
+        Task { @MainActor in
+            let response = await alert.beginSheetModal(for: window)
+            if response == .alertFirstButtonReturn {
+                request.approve()
+            } else {
+                request.deny()
+            }
+        }
+    }
+
+    /// Bounded, read-only preview of the text under decision, mirroring
+    /// the preview area in Ghostty's own confirmation dialog.
+    private static func clipboardPreview(_ contents: String) -> NSView {
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 120))
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+        let text = NSTextView(frame: NSRect(origin: .zero, size: scroll.contentSize))
+        text.isEditable = false
+        text.font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        // A pathological clipboard can be arbitrarily large; the decision
+        // only needs a glimpse.
+        text.string = String(contents.prefix(4096))
+        text.autoresizingMask = [.width]
+        scroll.documentView = text
+        return scroll
     }
 }
 


### PR DESCRIPTION
Fixes the clipboard confidentiality issue reported in #8: `clipboard-read` was hardcoded to `allow`, and the host bridge auto-confirmed every escalated clipboard request — so any program whose output reaches the terminal (including a remote SSH host) could silently read the macOS clipboard via OSC 52 and receive it through the PTY.

Closes #8

## What changed

**Config ([kero/TerminalSession.swift](https://github.com/egoist/kero/blob/clipboard-confirmation/kero/TerminalSession.swift))** — now matches the Ghostty app defaults, set explicitly: `clipboard-read = ask`, `clipboard-write = allow`, `clipboard-paste-protection = true`. Cmd+C/Cmd+V stay prompt-free; `ask` gates only terminal-initiated (OSC 52) reads, and paste protection only fires for pastes that aren't bracketed-paste-safe.

**Vendored bridge (`Vendor/libghostty-spm`)** — makes `ask` mean something:
- The confirm callback no longer auto-confirms. It copies the content out of the C buffer, hops to the main actor, and hands the delegate a `TerminalClipboardConfirmationRequest` (`approve()` / `deny()`, call-once, teardown-safe — teardown nils `rawSurface` before freeing the surface, so a late decision is dropped instead of touching freed memory).
- Without a delegate adopting `TerminalSurfaceClipboardConfirmationDelegate`, requests are denied by completing with an empty string + `confirmed=true`, byte-for-byte upstream Ghostty's cancel semantics (paste becomes a no-op; OSC 52 read replies empty).
- The write callback now honors its `confirm` flag (`clipboard-write = ask` would deny instead of writing silently).

**Kero UI** — `TerminalSession` presents the same dialog the Ghostty app shows: "Authorize Clipboard Access" (Allow/Deny) for OSC 52 reads, "Warning: Potentially Unsafe Paste" (Paste/Cancel) for risky pastes, with a bounded monospaced content preview and Esc mapped to deny. Surfaces without a window (background sessions) deny rather than prompting invisibly.

Also adds `SECURITY.md` (private vulnerability reporting is already enabled on the repo) and changelog entries for the release notes.

## Deliberate deviations from the issue's suggested remediation

- `clipboard-write` stays `allow`: it matches Ghostty's shipped default, it's an integrity (clipboard-priming) concern rather than a confidentiality leak, and denying it would break OSC 52 copy from remote tmux/nvim.
- Instead of a hard `deny` for reads, `ask` + a real prompt keeps legitimate OSC 52 use possible with per-request consent (the issue's option 2, including its requirement that the auto-confirming callback be replaced first).

## Testing

- 126 package tests pass, including 12 new ones in `TerminalClipboardCallbackTests` pinning the contract: escalated requests never complete with clipboard data unless explicitly approved; deny completes empty; requests resolve at most once; decisions after surface teardown are dropped; unconfirmed writes still work.
- Kero app builds (Debug, arm64).
- Not yet exercised visually: the sheet itself (the running dev instance predates this change). Manual check after relaunch: `printf '\e]52;c;?\a'` should show the Authorize Clipboard Access prompt; Deny should produce an empty reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)