### PR TITLE
Fix session spinner freezing after project rename

### DIFF
--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -40,10 +40,61 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     }
 
     var name: String {
-        if let customName, !customName.isEmpty {
+        if let customName = Self.normalizedCustomName(customName) {
             return customName
         }
-        return selectedSession?.title ?? fallbackName
+        guard let title = selectedSession?.title else { return fallbackName }
+        let titleName = Self.terminalTitleParts(title).name
+        return titleName.isEmpty ? fallbackName : titleName
+    }
+
+    /// A transient activity frame supplied through the selected terminal's
+    /// title (for example `⠸` in `⠸ repo`). The sidebar renders this beside
+    /// the stable project name so it keeps animating even with a custom name.
+    var activityIndicator: String? {
+        guard let title = selectedSession?.title else { return nil }
+        return Self.terminalTitleParts(title).activity
+    }
+
+    /// Stable text to seed the inline project rename field. A live terminal
+    /// title can begin with a Braille spinner frame (for example `⠸ repo`);
+    /// copying that transient title into `customName` freezes that one frame.
+    /// Prefer the current directory label and normalize legacy custom names
+    /// that were saved before this distinction existed.
+    var renameDraftName: String {
+        if let customName = Self.normalizedCustomName(customName) {
+            return customName
+        }
+        return selectedSession?.directoryLabel ?? name
+    }
+
+    /// Trims a user-assigned project name and removes a transient leading
+    /// terminal spinner frame. Also used while restoring snapshots so names
+    /// accidentally persisted as `⠸ repo` repair themselves on next launch.
+    static func normalizedCustomName(_ name: String?) -> String? {
+        guard let name else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let normalized = terminalTitleParts(trimmed).name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func terminalTitleParts(
+        _ title: String
+    ) -> (activity: String?, name: String) {
+        guard let first = title.first,
+              first.unicodeScalars.allSatisfy({
+                  (UInt32(0x2800)...UInt32(0x28FF)).contains($0.value)
+              }),
+              let next = title.index(
+                  title.startIndex, offsetBy: 1, limitedBy: title.endIndex
+              ),
+              next < title.endIndex,
+              title[next].isWhitespace
+        else { return (nil, title) }
+        let name = title[next...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (String(first), name)
     }
 
     /// Every terminal session across every pane in every tab.

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -198,23 +198,31 @@ private struct SidebarProjectRow: View {
                 .foregroundStyle(isSelected ? Color(nsColor: Theme.cursor) : .secondary)
 
             VStack(alignment: .leading, spacing: 1) {
-                if isRenaming {
-                    TextField("", text: $renameDraft)
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 12, weight: .medium))
-                        .focused($renameFocused)
-                        .onSubmit(commitRename)
-                        .onExitCommand { isRenaming = false }
-                        .onChange(of: renameFocused) {
-                            if !renameFocused, isRenaming {
-                                commitRename()
+                HStack(spacing: 3) {
+                    if let activity = project.activityIndicator {
+                        Text(activity)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(isSelected ? .primary : .secondary)
+                            .accessibilityHidden(true)
+                    }
+                    if isRenaming {
+                        TextField("", text: $renameDraft)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 12, weight: .medium))
+                            .focused($renameFocused)
+                            .onSubmit(commitRename)
+                            .onExitCommand { isRenaming = false }
+                            .onChange(of: renameFocused) {
+                                if !renameFocused, isRenaming {
+                                    commitRename()
+                                }
                             }
-                        }
-                } else {
-                    Text(project.name)
-                        .font(.system(size: 12))
-                        .foregroundStyle(isSelected ? .primary : .secondary)
-                        .lineLimit(1)
+                    } else {
+                        Text(project.name)
+                            .font(.system(size: 12))
+                            .foregroundStyle(isSelected ? .primary : .secondary)
+                            .lineLimit(1)
+                    }
                 }
                 subtitle
             }
@@ -242,7 +250,7 @@ private struct SidebarProjectRow: View {
     }
 
     private func beginRename() {
-        renameDraft = project.name
+        renameDraft = project.renameDraftName
         isRenaming = true
         DispatchQueue.main.async {
             renameFocused = true
@@ -250,8 +258,7 @@ private struct SidebarProjectRow: View {
     }
 
     private func commitRename() {
-        let trimmed = renameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        project.customName = trimmed.isEmpty ? nil : trimmed
+        project.customName = Project.normalizedCustomName(renameDraft)
         isRenaming = false
     }
 

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -576,7 +576,7 @@ final class TerminalManager: nonisolated ObservableObject {
     private func restore(from snapshot: SessionSnapshot) -> Bool {
         for saved in snapshot.projects where !saved.tabs.isEmpty {
             let project = makeProject(createInitialSession: false)
-            project.customName = saved.customName
+            project.customName = Project.normalizedCustomName(saved.customName)
             for tab in saved.tabs {
                 project.restoreTab(from: tab, histories: Self.pendingHistories)
             }


### PR DESCRIPTION
## Summary

- separate the transient Braille activity frame from the editable project name
- keep the session spinner updating while a project is being renamed and after a custom name is saved
- normalize renamed projects and repair legacy snapshots that captured a spinner frame in `customName`

## Root cause

The sidebar used the complete terminal title as the project name. When a running session published a title such as `⠸ repo`, inline rename copied that transient spinner frame into the text field and then persisted it as the custom project name. The captured frame could no longer update, so the activity indicator appeared frozen.

## Impact

The activity frame is now rendered independently from the stable project name and is no longer editable. Existing persisted names with a leading Braille spinner frame are cleaned during restoration.

## Validation

- `xcodebuild -project kero.xcodeproj -scheme kero -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/kero-derived-data CODE_SIGNING_ALLOWED=NO build`
- `xcrun swiftc -frontend -parse kero/*.swift`
- `git diff HEAD^ HEAD --check`
