### PR TITLE
Agent usage and limits in the info tab

### DIFF
--- a/kero/AgentUsage.swift
+++ b/kero/AgentUsage.swift
@@ -1,0 +1,126 @@
+//
+//  AgentUsage.swift
+//  kero
+//
+
+import Foundation
+
+/// A coding agent whose plan usage kero knows how to report.
+nonisolated enum AgentUsageProvider: String, CaseIterable, Identifiable, Sendable {
+    case codex
+    case claude
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .codex: "Codex"
+        case .claude: "Claude Code"
+        }
+    }
+
+    /// Executable names, as `ps` reports them, that mean this agent is running.
+    var executableNames: Set<String> {
+        switch self {
+        case .codex: ["codex"]
+        case .claude: ["claude"]
+        }
+    }
+}
+
+/// One rate-limit window — a 5-hour session, a weekly cap, a model-scoped
+/// weekly cap — as a percentage consumed plus when it refills.
+nonisolated struct AgentUsageWindow: Identifiable, Equatable, Sendable {
+    let label: String
+    /// 0–100.
+    let usedPercent: Double
+    let resetsAt: Date?
+
+    var id: String { label }
+
+    var percentLabel: String {
+        usedPercent >= 10
+            ? String(format: "%.0f%%", usedPercent)
+            : String(format: "%.1f%%", usedPercent)
+    }
+
+    /// "resets in 3h 20m", or nil when the provider didn't say.
+    func resetLabel(now: Date = Date()) -> String? {
+        guard let resetsAt else { return nil }
+        let remaining = resetsAt.timeIntervalSince(now)
+        guard remaining > 0 else { return "resetting" }
+        return "resets in " + AgentUsage.durationLabel(remaining)
+    }
+}
+
+/// What kero shows for one agent in the Info tab.
+nonisolated struct AgentUsageSnapshot: Equatable, Sendable {
+    let provider: AgentUsageProvider
+    var windows: [AgentUsageWindow] = []
+    /// e.g. "Pro" — whatever plan the provider reports, when it does.
+    var planLabel: String?
+    /// Codex reports the live context-window fill for the session; Claude
+    /// does not expose it, so this stays nil there.
+    var contextPercent: Double?
+    var contextDetail: String?
+    /// Where the numbers came from, shown as the section's footnote.
+    var sourceLabel: String?
+    var updatedAt = Date()
+
+    var isEmpty: Bool { windows.isEmpty && contextPercent == nil }
+}
+
+/// A failure worth showing in place of numbers, with the fix spelled out.
+nonisolated struct AgentUsageFailure: Equatable, Sendable {
+    let provider: AgentUsageProvider
+    let message: String
+    /// True when the user can resolve it by granting keychain access — the
+    /// panel offers a retry button in that case.
+    var isRecoverable = false
+}
+
+nonisolated enum AgentUsage {
+    /// Compact "3h 20m" / "6d 4h" / "45m" for countdowns.
+    static func durationLabel(_ interval: TimeInterval) -> String {
+        let total = Int(interval.rounded())
+        let days = total / 86_400
+        let hours = (total % 86_400) / 3_600
+        let minutes = (total % 3_600) / 60
+
+        if days > 0 {
+            return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
+        }
+        if hours > 0 {
+            return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
+        }
+        return minutes > 0 ? "\(minutes)m" : "under a minute"
+    }
+
+    /// Names a rate-limit window by its length, since providers label the
+    /// same window inconsistently ("primary", "five_hour", …).
+    static func windowLabel(minutes: Int) -> String {
+        switch minutes {
+        case ..<60:
+            return "\(minutes)m limit"
+        case ..<1_440:
+            return "\(minutes / 60)h limit"
+        case 10_080:
+            return "Weekly limit"
+        default:
+            let days = minutes / 1_440
+            return days == 1 ? "Daily limit" : "\(days)d limit"
+        }
+    }
+
+    /// 1.2M / 34.5K / 812 — token counts at a glance.
+    static func tokenLabel(_ tokens: Int) -> String {
+        switch tokens {
+        case 1_000_000...:
+            return String(format: "%.1fM", Double(tokens) / 1_000_000)
+        case 1_000...:
+            return String(format: "%.1fK", Double(tokens) / 1_000)
+        default:
+            return "\(tokens)"
+        }
+    }
+}

--- a/kero/AgentUsageModel.swift
+++ b/kero/AgentUsageModel.swift
@@ -1,0 +1,180 @@
+//
+//  AgentUsageModel.swift
+//  kero
+//
+
+import Combine
+import Foundation
+
+/// Tracks plan usage for the coding agents running in the selected session.
+///
+/// The two providers have very different costs, so they refresh on different
+/// clocks: Codex is a local file read and can follow the panel's poll, while
+/// Claude is a network call against a rate-limited endpoint and is both
+/// opt-in and throttled hard.
+@MainActor
+final class AgentUsageModel: nonisolated ObservableObject {
+    /// Persisted so the keychain prompt is a one-time, user-initiated event
+    /// rather than something kero does on every launch.
+    private static let claudeEnabledKey = "agentUsage.claudeEnabled"
+
+    private static let codexInterval: TimeInterval = 3
+    private static let claudeInterval: TimeInterval = 120
+    /// Backoff after a failed Claude fetch, so a bad token or a 429 doesn't
+    /// turn into a retry loop against Anthropic.
+    private static let claudeFailureBackoff: TimeInterval = 300
+
+    @Published private(set) var snapshots: [AgentUsageSnapshot] = []
+    @Published private(set) var failures: [AgentUsageFailure] = []
+    /// Agents seen running under the session's shell, in display order.
+    @Published private(set) var detected: [AgentUsageProvider] = []
+    @Published private(set) var isClaudeLoading = false
+
+    @Published var isClaudeEnabled: Bool {
+        didSet {
+            guard isClaudeEnabled != oldValue else { return }
+            UserDefaults.standard.set(isClaudeEnabled, forKey: Self.claudeEnabledKey)
+            if isClaudeEnabled {
+                claudeNextAllowedRefresh = .distantPast
+                refreshClaude()
+            } else {
+                snapshots.removeAll { $0.provider == .claude }
+                failures.removeAll { $0.provider == .claude }
+            }
+        }
+    }
+
+    private var cwd = ""
+    private var codexLastRefresh = Date.distantPast
+    private var isCodexRefreshing = false
+    private var claudeNextAllowedRefresh = Date.distantPast
+
+    init() {
+        isClaudeEnabled = UserDefaults.standard.bool(forKey: Self.claudeEnabledKey)
+    }
+
+    // MARK: - Syncing
+
+    /// Called from the Info panel's poll with the session's live process list.
+    func sync(processNames: [String], cwd: String) {
+        if self.cwd != cwd {
+            self.cwd = cwd
+            // A different directory means a different Codex session; drop the
+            // stale context gauge instead of showing another pane's numbers.
+            codexLastRefresh = .distantPast
+        }
+
+        let names = Set(processNames)
+        let detected = AgentUsageProvider.allCases.filter { provider in
+            !provider.executableNames.isDisjoint(with: names)
+        }
+        if self.detected != detected {
+            self.detected = detected
+            // Clear anything for agents that are no longer running.
+            snapshots.removeAll { !detected.contains($0.provider) }
+            failures.removeAll { !detected.contains($0.provider) }
+        }
+
+        if detected.contains(.codex) { refreshCodex() }
+        if detected.contains(.claude), isClaudeEnabled { refreshClaude() }
+    }
+
+    /// Explicit user refresh — bypasses both throttles.
+    func refreshNow() {
+        codexLastRefresh = .distantPast
+        claudeNextAllowedRefresh = .distantPast
+        if detected.contains(.codex) { refreshCodex() }
+        if detected.contains(.claude), isClaudeEnabled { refreshClaude() }
+    }
+
+    // MARK: - Codex
+
+    private func refreshCodex() {
+        guard !isCodexRefreshing,
+              Date().timeIntervalSince(codexLastRefresh) >= Self.codexInterval
+        else { return }
+        isCodexRefreshing = true
+        codexLastRefresh = Date()
+
+        let cwd = self.cwd
+        Task.detached(priority: .utility) { [weak self] in
+            let snapshot = CodexUsageReader.snapshot(cwd: cwd)
+            await self?.applyCodex(snapshot, cwd: cwd)
+        }
+    }
+
+    private func applyCodex(_ snapshot: AgentUsageSnapshot?, cwd: String) {
+        isCodexRefreshing = false
+        // A tab switch may have re-targeted us while the log was being read.
+        guard self.cwd == cwd, detected.contains(.codex) else { return }
+        if let snapshot {
+            store(snapshot)
+            failures.removeAll { $0.provider == .codex }
+        } else {
+            store(
+                AgentUsageFailure(
+                    provider: .codex,
+                    message: "No usage recorded yet — it appears after Codex's first reply."
+                )
+            )
+        }
+    }
+
+    // MARK: - Claude
+
+    private func refreshClaude() {
+        guard isClaudeEnabled, !isClaudeLoading, Date() >= claudeNextAllowedRefresh else { return }
+        isClaudeLoading = true
+
+        Task { [weak self] in
+            do {
+                let snapshot = try await ClaudeUsageReader.fetchSnapshot()
+                guard let self else { return }
+                self.isClaudeLoading = false
+                self.claudeNextAllowedRefresh = Date().addingTimeInterval(Self.claudeInterval)
+                guard self.detected.contains(.claude) else { return }
+                self.store(snapshot)
+                self.failures.removeAll { $0.provider == .claude }
+            } catch {
+                guard let self else { return }
+                self.isClaudeLoading = false
+                self.claudeNextAllowedRefresh = Date()
+                    .addingTimeInterval(Self.claudeFailureBackoff)
+                let readerError = error as? ClaudeUsageReader.ReaderError
+                self.snapshots.removeAll { $0.provider == .claude }
+                self.store(
+                    AgentUsageFailure(
+                        provider: .claude,
+                        message: readerError?.errorDescription
+                            ?? error.localizedDescription,
+                        isRecoverable: readerError?.isRecoverable ?? true
+                    )
+                )
+            }
+        }
+    }
+
+    // MARK: - Storage
+
+    private func store(_ snapshot: AgentUsageSnapshot) {
+        var updated = snapshots.filter { $0.provider != snapshot.provider }
+        updated.append(snapshot)
+        updated.sort { lhs, rhs in
+            order(of: lhs.provider) < order(of: rhs.provider)
+        }
+        if snapshots != updated { snapshots = updated }
+    }
+
+    private func store(_ failure: AgentUsageFailure) {
+        var updated = failures.filter { $0.provider != failure.provider }
+        updated.append(failure)
+        updated.sort { lhs, rhs in
+            order(of: lhs.provider) < order(of: rhs.provider)
+        }
+        if failures != updated { failures = updated }
+    }
+
+    private func order(of provider: AgentUsageProvider) -> Int {
+        AgentUsageProvider.allCases.firstIndex(of: provider) ?? 0
+    }
+}

--- a/kero/AgentUsageModel.swift
+++ b/kero/AgentUsageModel.swift
@@ -18,7 +18,11 @@ final class AgentUsageModel: nonisolated ObservableObject {
     /// rather than something kero does on every launch.
     private static let claudeEnabledKey = "agentUsage.claudeEnabled"
 
-    private static let codexInterval: TimeInterval = 3
+    /// Both providers poll on the same relaxed clock. Plan limits move slowly,
+    /// so a tighter loop just re-reads unchanged rollout files (and, for
+    /// Claude, spends requests against a rate-limited endpoint). Opening the
+    /// panel, switching directory, and the refresh button all bypass this.
+    private static let codexInterval: TimeInterval = 120
     private static let claudeInterval: TimeInterval = 120
     /// Backoff after a failed Claude fetch, so a bad token or a 429 doesn't
     /// turn into a retry loop against Anthropic.
@@ -48,6 +52,8 @@ final class AgentUsageModel: nonisolated ObservableObject {
     private var codexLastRefresh = Date.distantPast
     private var isCodexRefreshing = false
     private var claudeNextAllowedRefresh = Date.distantPast
+    /// Set only by a 429, and respected even by an explicit user refresh.
+    private var claudeRateLimitedUntil: Date?
 
     init() {
         isClaudeEnabled = UserDefaults.standard.bool(forKey: Self.claudeEnabledKey)
@@ -68,21 +74,28 @@ final class AgentUsageModel: nonisolated ObservableObject {
         let detected = AgentUsageProvider.allCases.filter { provider in
             !provider.executableNames.isDisjoint(with: names)
         }
-        if self.detected != detected {
-            self.detected = detected
-            // Clear anything for agents that are no longer running.
-            snapshots.removeAll { !detected.contains($0.provider) }
-            failures.removeAll { !detected.contains($0.provider) }
-        }
+        // Deliberately keeps snapshots for agents that just left `detected`.
+        // The process list is polled a tick behind and momentarily reads empty
+        // on tab switches, so clearing here blanked the card on every flap —
+        // and the refresh throttle then held it blank. The section only renders
+        // while an agent is detected, so stale entries stay invisible until the
+        // agent returns, at which point last-known numbers beat an empty card.
+        if self.detected != detected { self.detected = detected }
 
         if detected.contains(.codex) { refreshCodex() }
         if detected.contains(.claude), isClaudeEnabled { refreshClaude() }
     }
 
-    /// Explicit user refresh — bypasses both throttles.
+    /// Explicit user refresh — bypasses the polling throttles, but never an
+    /// active rate limit: hammering a 429 only extends it.
     func refreshNow() {
         codexLastRefresh = .distantPast
-        claudeNextAllowedRefresh = .distantPast
+        if let claudeRateLimitedUntil, claudeRateLimitedUntil > Date() {
+            claudeNextAllowedRefresh = claudeRateLimitedUntil
+        } else {
+            claudeRateLimitedUntil = nil
+            claudeNextAllowedRefresh = .distantPast
+        }
         if detected.contains(.codex) { refreshCodex() }
         if detected.contains(.claude), isClaudeEnabled { refreshClaude() }
     }
@@ -131,6 +144,7 @@ final class AgentUsageModel: nonisolated ObservableObject {
                 let snapshot = try await ClaudeUsageReader.fetchSnapshot()
                 guard let self else { return }
                 self.isClaudeLoading = false
+                self.claudeRateLimitedUntil = nil
                 self.claudeNextAllowedRefresh = Date().addingTimeInterval(Self.claudeInterval)
                 guard self.detected.contains(.claude) else { return }
                 self.store(snapshot)
@@ -138,10 +152,21 @@ final class AgentUsageModel: nonisolated ObservableObject {
             } catch {
                 guard let self else { return }
                 self.isClaudeLoading = false
-                self.claudeNextAllowedRefresh = Date()
-                    .addingTimeInterval(Self.claudeFailureBackoff)
                 let readerError = error as? ClaudeUsageReader.ReaderError
-                self.snapshots.removeAll { $0.provider == .claude }
+                // Honour Anthropic's own Retry-After when it sends one; a
+                // fixed guess otherwise.
+                if case let .rateLimited(retryAfter) = readerError {
+                    let until = retryAfter
+                        ?? Date().addingTimeInterval(Self.claudeFailureBackoff)
+                    self.claudeRateLimitedUntil = until
+                    self.claudeNextAllowedRefresh = until
+                } else {
+                    self.claudeNextAllowedRefresh = Date()
+                        .addingTimeInterval(Self.claudeFailureBackoff)
+                }
+                // The previous reading stays on screen: a transient network
+                // blip shouldn't throw away numbers that are still roughly
+                // true. The failure shows as a warning beneath them.
                 self.store(
                     AgentUsageFailure(
                         provider: .claude,

--- a/kero/ClaudeUsageReader.swift
+++ b/kero/ClaudeUsageReader.swift
@@ -1,0 +1,237 @@
+//
+//  ClaudeUsageReader.swift
+//  kero
+//
+
+import Foundation
+import Security
+
+/// Reads Claude Code plan usage from Anthropic's OAuth usage endpoint.
+///
+/// Unlike Codex, Claude Code keeps no local record of its rate-limit windows —
+/// transcripts carry token counts but not plan utilization — so the numbers
+/// have to be fetched, reusing the token the CLI already stores.
+///
+/// The token lives in `~/.claude/.credentials.json` on some installs and in
+/// the login keychain (service `Claude Code-credentials`) on others. Reading
+/// the keychain item prompts for permission the first time because kero isn't
+/// the app that created it, which is why the caller gates this behind an
+/// explicit opt-in rather than polling on launch.
+nonisolated enum ClaudeUsageReader {
+    private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+    private static let betaHeader = "oauth-2025-04-20"
+    private static let userAgent = "claude-code/2.1.0"
+    private static let keychainService = "Claude Code-credentials"
+
+    // MARK: - Errors
+
+    enum ReaderError: LocalizedError, Equatable {
+        case notSignedIn
+        case keychainAccessDenied
+        case tokenExpired
+        case unauthorized
+        case rateLimited
+        case server(Int)
+        case network(String)
+        case malformedResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .notSignedIn:
+                "No Claude credentials found. Run `claude` and sign in."
+            case .keychainAccessDenied:
+                "kero needs permission to read the Claude Code keychain item."
+            case .tokenExpired:
+                "Claude login expired. Run `claude` to refresh it."
+            case .unauthorized:
+                "Claude rejected the stored token. Run `claude` to sign in again."
+            case .rateLimited:
+                "Anthropic is rate limiting usage checks. Try again in a few minutes."
+            case let .server(code):
+                "Anthropic returned HTTP \(code)."
+            case let .network(message):
+                "Network error: \(message)"
+            case .malformedResponse:
+                "Could not read Anthropic's usage response."
+            }
+        }
+
+        /// Whether retrying — possibly after a permission grant — could work.
+        var isRecoverable: Bool {
+            switch self {
+            case .keychainAccessDenied, .rateLimited, .network, .server:
+                true
+            case .notSignedIn, .tokenExpired, .unauthorized, .malformedResponse:
+                false
+            }
+        }
+    }
+
+    // MARK: - Entry point
+
+    static func fetchSnapshot() async throws -> AgentUsageSnapshot {
+        let credentials = try loadCredentials()
+        if let expiresAt = credentials.expiresAt, expiresAt <= Date() {
+            // Refreshing would rotate the token the CLI itself depends on, so
+            // kero reports the expiry and lets Claude Code own its own login.
+            throw ReaderError.tokenExpired
+        }
+
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 20
+        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(betaHeader, forHTTPHeaderField: "anthropic-beta")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ReaderError.network(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ReaderError.malformedResponse
+        }
+        switch http.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw ReaderError.unauthorized
+        case 429:
+            throw ReaderError.rateLimited
+        default:
+            throw ReaderError.server(http.statusCode)
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ReaderError.malformedResponse
+        }
+        var snapshot = parse(object)
+        snapshot.planLabel = credentials.subscriptionType?.capitalized
+        return snapshot
+    }
+
+    // MARK: - Response parsing
+
+    private static func parse(_ object: [String: Any]) -> AgentUsageSnapshot {
+        var snapshot = AgentUsageSnapshot(provider: .claude)
+        snapshot.sourceLabel = "Anthropic OAuth usage API"
+
+        // Older shape: one key per window.
+        let named: [(key: String, label: String)] = [
+            ("five_hour", "5h limit"),
+            ("seven_day", "Weekly limit"),
+            ("seven_day_opus", "Weekly (Opus)"),
+            ("seven_day_sonnet", "Weekly (Sonnet)"),
+        ]
+        var windows: [AgentUsageWindow] = named.compactMap { entry in
+            guard let raw = object[entry.key] as? [String: Any] else { return nil }
+            return window(from: raw, label: entry.label)
+        }
+
+        // Newer shape: a flat `limits` array where weekly caps name the model
+        // they scope to. Entries here supersede same-labelled keys above.
+        if let limits = object["limits"] as? [[String: Any]] {
+            for limit in limits {
+                guard limit["is_active"] as? Bool != false,
+                      let percent = limit["percent"] as? Double
+                else { continue }
+                let scopedModel = ((limit["scope"] as? [String: Any])?["model"] as? [String: Any])?["display_name"] as? String
+                let group = (limit["group"] as? String) ?? (limit["kind"] as? String) ?? "limit"
+                let label: String = if let scopedModel, !scopedModel.isEmpty {
+                    "\(group.capitalized) (\(scopedModel))"
+                } else {
+                    "\(group.capitalized) limit"
+                }
+                let resetsAt = parseDate(limit["resets_at"] as? String)
+                windows.removeAll { $0.label == label }
+                windows.append(
+                    AgentUsageWindow(label: label, usedPercent: percent, resetsAt: resetsAt)
+                )
+            }
+        }
+
+        snapshot.windows = windows
+        return snapshot
+    }
+
+    private static func window(from raw: [String: Any], label: String) -> AgentUsageWindow? {
+        guard let utilization = raw["utilization"] as? Double else { return nil }
+        return AgentUsageWindow(
+            label: label,
+            usedPercent: utilization,
+            resetsAt: parseDate(raw["resets_at"] as? String)
+        )
+    }
+
+    private static func parseDate(_ string: String?) -> Date? {
+        guard let string, !string.isEmpty else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+
+    // MARK: - Credentials
+
+    struct Credentials {
+        let accessToken: String
+        let expiresAt: Date?
+        let subscriptionType: String?
+    }
+
+    /// File first — it never prompts — then the login keychain.
+    static func loadCredentials() throws -> Credentials {
+        let fileURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/.credentials.json")
+        if let data = try? Data(contentsOf: fileURL),
+           let credentials = decode(data) {
+            return credentials
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data, let credentials = decode(data) else {
+                throw ReaderError.notSignedIn
+            }
+            return credentials
+        case errSecItemNotFound:
+            throw ReaderError.notSignedIn
+        case errSecUserCanceled, errSecAuthFailed, errSecInteractionNotAllowed, errSecInteractionRequired:
+            throw ReaderError.keychainAccessDenied
+        default:
+            throw ReaderError.keychainAccessDenied
+        }
+    }
+
+    private static func decode(_ data: Data) -> Credentials? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = root["claudeAiOauth"] as? [String: Any],
+              let token = (oauth["accessToken"] as? String)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty
+        else { return nil }
+        // `expiresAt` is milliseconds since epoch.
+        let expiresAt = (oauth["expiresAt"] as? Double).map {
+            Date(timeIntervalSince1970: $0 / 1000)
+        }
+        return Credentials(
+            accessToken: token,
+            expiresAt: expiresAt,
+            subscriptionType: oauth["subscriptionType"] as? String
+        )
+    }
+}

--- a/kero/ClaudeUsageReader.swift
+++ b/kero/ClaudeUsageReader.swift
@@ -30,7 +30,9 @@ nonisolated enum ClaudeUsageReader {
         case keychainAccessDenied
         case tokenExpired
         case unauthorized
-        case rateLimited
+        /// Carries Anthropic's own `Retry-After` when it sends one, so the
+        /// backoff matches what the server asked for instead of guessing.
+        case rateLimited(retryAfter: Date?)
         case server(Int)
         case network(String)
         case malformedResponse
@@ -45,8 +47,13 @@ nonisolated enum ClaudeUsageReader {
                 "Claude login expired. Run `claude` to refresh it."
             case .unauthorized:
                 "Claude rejected the stored token. Run `claude` to sign in again."
-            case .rateLimited:
-                "Anthropic is rate limiting usage checks. Try again in a few minutes."
+            case let .rateLimited(retryAfter):
+                if let retryAfter, retryAfter > Date() {
+                    "Anthropic is rate limiting usage checks. Try again in "
+                        + AgentUsage.durationLabel(retryAfter.timeIntervalSinceNow) + "."
+                } else {
+                    "Anthropic is rate limiting usage checks. Try again in a few minutes."
+                }
             case let .server(code):
                 "Anthropic returned HTTP \(code)."
             case let .network(message):
@@ -102,7 +109,7 @@ nonisolated enum ClaudeUsageReader {
         case 401, 403:
             throw ReaderError.unauthorized
         case 429:
-            throw ReaderError.rateLimited
+            throw ReaderError.rateLimited(retryAfter: retryAfterDate(from: http))
         default:
             throw ReaderError.server(http.statusCode)
         }
@@ -166,6 +173,22 @@ nonisolated enum ClaudeUsageReader {
             usedPercent: utilization,
             resetsAt: parseDate(raw["resets_at"] as? String)
         )
+    }
+
+    /// `Retry-After` is either a delay in seconds or an HTTP date.
+    private static func retryAfterDate(from response: HTTPURLResponse, now: Date = Date()) -> Date? {
+        guard let raw = response.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty
+        else { return nil }
+
+        if let seconds = TimeInterval(raw), seconds >= 0 {
+            return now.addingTimeInterval(seconds)
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss zzz"
+        return formatter.date(from: raw)
     }
 
     private static func parseDate(_ string: String?) -> Date? {

--- a/kero/CodexUsageReader.swift
+++ b/kero/CodexUsageReader.swift
@@ -1,0 +1,199 @@
+//
+//  CodexUsageReader.swift
+//  kero
+//
+
+import Foundation
+
+/// Reads Codex plan usage out of the CLI's own session logs.
+///
+/// Codex writes a `token_count` event into its rollout file after every turn,
+/// and each one carries the account's current `rate_limits`. That makes usage
+/// a local file read — no credentials, no network, nothing to authorize.
+///
+/// Rollouts live at `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`.
+nonisolated enum CodexUsageReader {
+    /// Newest-first candidates to consider when looking for the session that
+    /// belongs to a pane. Bounded so a long-lived `~/.codex` stays cheap.
+    private static let candidateLimit = 60
+    /// Rate limits sit in the last few events, so only the tail is parsed.
+    private static let tailByteLimit = 512 * 1024
+
+    static func snapshot(cwd: String) -> AgentUsageSnapshot? {
+        let candidates = recentRollouts()
+        guard !candidates.isEmpty else { return nil }
+
+        // Prefer the rollout started in this pane's directory so the context
+        // gauge describes the session on screen. Rate limits are account-wide,
+        // so any recent rollout carries usable numbers if that lookup misses.
+        let preferred = candidates.first { sessionDirectory(of: $0) == cwd }
+        for url in [preferred].compactMap({ $0 }) + candidates {
+            if let snapshot = parse(rollout: url, isSessionMatch: url == preferred) {
+                return snapshot
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Locating rollouts
+
+    private static var sessionsRoot: URL? {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let root = (codexHome?.isEmpty == false)
+            ? URL(fileURLWithPath: codexHome!)
+            : home.appendingPathComponent(".codex")
+        let sessions = root.appendingPathComponent("sessions")
+        return FileManager.default.fileExists(atPath: sessions.path) ? sessions : nil
+    }
+
+    /// Rollout files sorted newest-modified first.
+    ///
+    /// The tree is date-partitioned, so descending only the newest day
+    /// directories keeps this bounded no matter how much history has piled up.
+    private static func recentRollouts() -> [URL] {
+        guard let sessionsRoot else { return [] }
+        let fileManager = FileManager.default
+
+        // sessions/YYYY/MM/DD — walk the three levels newest-first by name,
+        // which is chronological given the zero-padded numeric components.
+        var dayDirectories: [URL] = []
+        for year in sortedChildren(of: sessionsRoot).prefix(2) {
+            for month in sortedChildren(of: year).prefix(2) {
+                dayDirectories.append(contentsOf: sortedChildren(of: month).prefix(7))
+            }
+            if dayDirectories.count >= 7 { break }
+        }
+
+        var entries: [(url: URL, modified: Date)] = []
+        for directory in dayDirectories.prefix(14) {
+            let contents = (try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for url in contents where url.pathExtension == "jsonl" {
+                let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                entries.append((url, modified))
+            }
+        }
+
+        return entries
+            .sorted { $0.modified > $1.modified }
+            .prefix(candidateLimit)
+            .map(\.url)
+    }
+
+    private static func sortedChildren(of directory: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return contents
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+    }
+
+    /// The `cwd` recorded in the rollout's `session_meta` header line.
+    private static func sessionDirectory(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        // The header is line one; 64 KB comfortably covers it.
+        guard let data = try? handle.read(upToCount: 64 * 1024),
+              let newline = data.firstIndex(of: 0x0A) ?? data.indices.last.map({ $0 + 1 }),
+              let object = try? JSONSerialization.jsonObject(
+                  with: data[data.startIndex..<newline]
+              ) as? [String: Any],
+              let payload = object["payload"] as? [String: Any]
+        else { return nil }
+        return payload["cwd"] as? String
+    }
+
+    // MARK: - Parsing
+
+    private static func parse(rollout url: URL, isSessionMatch: Bool) -> AgentUsageSnapshot? {
+        guard let tail = tailLines(of: url) else { return nil }
+
+        // The newest `token_count` wins; scanning backwards finds it first.
+        for line in tail.reversed() {
+            guard line.contains("\"token_count\""),
+                  let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let payload = object["payload"] as? [String: Any],
+                  payload["type"] as? String == "token_count"
+            else { continue }
+
+            var snapshot = AgentUsageSnapshot(provider: .codex)
+            snapshot.sourceLabel = "Codex session log"
+
+            if let limits = payload["rate_limits"] as? [String: Any] {
+                snapshot.windows = windows(from: limits)
+                if let plan = limits["plan_type"] as? String, !plan.isEmpty {
+                    snapshot.planLabel = plan.capitalized
+                }
+            }
+
+            // Only meaningful when this rollout is the pane's own session.
+            if isSessionMatch, let info = payload["info"] as? [String: Any] {
+                applyContext(from: info, to: &snapshot)
+            }
+
+            return snapshot.isEmpty ? nil : snapshot
+        }
+        return nil
+    }
+
+    private static func windows(from limits: [String: Any]) -> [AgentUsageWindow] {
+        ["primary", "secondary"].compactMap { key in
+            guard let window = limits[key] as? [String: Any],
+                  let usedPercent = window["used_percent"] as? Double
+            else { return nil }
+            let minutes = (window["window_minutes"] as? Int) ?? 0
+            let resetsAt = (window["resets_at"] as? Double).map {
+                Date(timeIntervalSince1970: $0)
+            }
+            return AgentUsageWindow(
+                label: minutes > 0 ? AgentUsage.windowLabel(minutes: minutes) : key.capitalized,
+                usedPercent: usedPercent,
+                resetsAt: resetsAt
+            )
+        }
+    }
+
+    private static func applyContext(
+        from info: [String: Any], to snapshot: inout AgentUsageSnapshot
+    ) {
+        // `last_token_usage`, not `total_token_usage`: the latter sums every
+        // turn in the session and runs into the millions, while the context
+        // window only ever holds what the most recent request carried.
+        guard let contextWindow = info["model_context_window"] as? Int, contextWindow > 0,
+              let usage = info["last_token_usage"] as? [String: Any],
+              let total = usage["total_tokens"] as? Int
+        else { return }
+        snapshot.contextPercent = min(Double(total) / Double(contextWindow) * 100, 100)
+        snapshot.contextDetail =
+            "\(AgentUsage.tokenLabel(total)) / \(AgentUsage.tokenLabel(contextWindow)) tokens"
+    }
+
+    /// The last `tailByteLimit` bytes as whole lines — enough to hold the most
+    /// recent `token_count` without reading a long session end to end.
+    private static func tailLines(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        guard let size = try? handle.seekToEnd() else { return nil }
+        let offset = size > UInt64(tailByteLimit) ? size - UInt64(tailByteLimit) : 0
+        try? handle.seek(toOffset: offset)
+        guard var data = try? handle.readToEnd() else { return nil }
+
+        // A non-zero offset almost certainly lands mid-line; drop the partial.
+        if offset > 0, let newline = data.firstIndex(of: 0x0A) {
+            data = data[(newline + 1)...]
+        }
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        return text.split(separator: "\n").map(String.init)
+    }
+}

--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -2213,6 +2213,12 @@ private struct AgentUsageCard: View {
                 optInPrompt
             } else if let snapshot, !snapshot.isEmpty {
                 meters(for: snapshot)
+                // Numbers we already have outrank a fresh failure, so the
+                // failure demotes to a warning under them rather than
+                // replacing readings that are still roughly true.
+                if let failure {
+                    staleWarning(failure)
+                }
             } else if let failure {
                 message(failure.message, showsRetry: failure.isRecoverable)
             } else if isLoading {
@@ -2300,6 +2306,22 @@ private struct AgentUsageCard: View {
                     .contentShape(RoundedRectangle(cornerRadius: 5))
             }
             .buttonStyle(.plain)
+        }
+    }
+
+    /// Shown under readings that are still on screen but could not be
+    /// refreshed — the numbers are real, just possibly out of date.
+    private func staleWarning(_ failure: AgentUsageFailure) -> some View {
+        HStack(alignment: .top, spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 8))
+                .foregroundStyle(.orange)
+                .padding(.top, 1)
+            Text(failure.message)
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
         }
     }
 

--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -15,6 +15,7 @@ struct RightSidebarView: View {
     @StateObject private var fileTree = FileTreeModel()
     @StateObject private var git = GitStatusModel()
     @StateObject private var info = SessionInfoModel()
+    @StateObject private var agentUsage = AgentUsageModel()
     @AppStorage("rightSidebarWidth") private var width: Double = 240
 
     private let refreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
@@ -64,7 +65,10 @@ struct RightSidebarView: View {
                             }
                         )
                     case .info:
-                        InfoPanel(model: info, session: manager.selectedSession)
+                        InfoPanel(
+                            model: info, usage: agentUsage,
+                            session: manager.selectedSession
+                        )
                     }
                 }
                 .frame(width: width)
@@ -150,6 +154,11 @@ struct RightSidebarView: View {
             info.sync(
                 root: cwd, projectRoot: root, projectRootIsAutomatic: isAutoRoot,
                 shellName: session.shellName, shellPid: session.shellPid
+            )
+            // Reuses the process list `info` just polled, so detecting a
+            // running agent costs no extra `ps`.
+            agentUsage.sync(
+                processNames: info.processes.map(\.name), cwd: cwd
             )
         }
     }
@@ -1794,11 +1803,13 @@ private struct GitEntryRow: View {
 /// processes running under the shell, and ports they are listening on.
 private struct InfoPanel: View {
     @ObservedObject var model: SessionInfoModel
+    @ObservedObject var usage: AgentUsageModel
     @ObservedObject private var themeChanges = Theme.changes
     let session: TerminalSession?
 
     @State private var currentDirectoryCollapsed = false
     @State private var projectDirectoryCollapsed = false
+    @State private var agentUsageCollapsed = false
     @State private var processesCollapsed = false
     @State private var portsCollapsed = false
 
@@ -1812,6 +1823,7 @@ private struct InfoPanel: View {
                 LazyVStack(alignment: .leading, spacing: 1) {
                     currentDirectorySection
                     projectDirectorySection
+                    agentUsageSection
                     processesSection
                     portsSection
                 }
@@ -1834,6 +1846,7 @@ private struct InfoPanel: View {
             )
             Button {
                 model.refresh()
+                usage.refreshNow()
             } label: {
                 Image(systemName: "arrow.clockwise")
                     .font(.system(size: 10, weight: .medium))
@@ -1952,6 +1965,40 @@ private struct InfoPanel: View {
         }
         .buttonStyle(.plain)
         .help(title == "Copy" ? "Copy Path" : "Open in \(title)")
+    }
+
+    // MARK: Agent usage
+
+    /// Plan limits for Claude Code / Codex, shown only while one of them is
+    /// actually running under this session's shell.
+    @ViewBuilder
+    private var agentUsageSection: some View {
+        if !usage.detected.isEmpty {
+            GitSectionHeader(
+                title: "AGENT USAGE",
+                count: usage.detected.count,
+                isCollapsed: $agentUsageCollapsed,
+                actions: [],
+                helpText: "Plan limits for the coding agents running in this "
+                    + "session. Codex numbers come from its local session log. "
+                    + "Claude numbers come from Anthropic's usage API and need "
+                    + "one-time permission to read the token Claude Code "
+                    + "already stored."
+            )
+            if !agentUsageCollapsed {
+                ForEach(usage.detected) { provider in
+                    AgentUsageCard(
+                        provider: provider,
+                        snapshot: usage.snapshots.first { $0.provider == provider },
+                        failure: usage.failures.first { $0.provider == provider },
+                        needsOptIn: provider == .claude && !usage.isClaudeEnabled,
+                        isLoading: provider == .claude && usage.isClaudeLoading,
+                        enable: { usage.isClaudeEnabled = true },
+                        retry: { usage.refreshNow() }
+                    )
+                }
+            }
+        }
     }
 
     // MARK: Processes
@@ -2140,4 +2187,197 @@ private struct InfoPortRow: View {
 
 private func shellQuote(_ path: String) -> String {
     "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+
+// MARK: - Agent usage
+
+/// One agent's block: its limit windows as meters, or the reason there are
+/// none to show yet.
+private struct AgentUsageCard: View {
+    let provider: AgentUsageProvider
+    let snapshot: AgentUsageSnapshot?
+    let failure: AgentUsageFailure?
+    let needsOptIn: Bool
+    let isLoading: Bool
+    let enable: () -> Void
+    let retry: () -> Void
+
+    /// Countdowns are only correct if something re-renders them.
+    @State private var now = Date()
+    private let tick = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            header
+            if needsOptIn {
+                optInPrompt
+            } else if let snapshot, !snapshot.isEmpty {
+                meters(for: snapshot)
+            } else if let failure {
+                message(failure.message, showsRetry: failure.isRecoverable)
+            } else if isLoading {
+                message("Checking usage…", showsRetry: false)
+            } else {
+                message("Waiting for usage data…", showsRetry: false)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.primary.opacity(0.04))
+        )
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .onReceive(tick) { now = $0 }
+    }
+
+    private var header: some View {
+        HStack(spacing: 5) {
+            Text(provider.displayName)
+                .font(.system(size: 11, weight: .semibold))
+            if let plan = snapshot?.planLabel, !plan.isEmpty {
+                Text(plan)
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color(nsColor: Theme.accent).opacity(0.15))
+                    )
+            }
+            Spacer(minLength: 0)
+            if isLoading {
+                ProgressView()
+                    .controlSize(.mini)
+                    .scaleEffect(0.7)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func meters(for snapshot: AgentUsageSnapshot) -> some View {
+        ForEach(snapshot.windows) { window in
+            AgentUsageMeter(
+                label: window.label,
+                percent: window.usedPercent,
+                detail: window.resetLabel(now: now)
+            )
+        }
+        if let contextPercent = snapshot.contextPercent {
+            AgentUsageMeter(
+                label: "Context",
+                percent: contextPercent,
+                detail: snapshot.contextDetail
+            )
+        }
+        if let source = snapshot.sourceLabel {
+            Text(source)
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var optInPrompt: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Usage needs one-time permission to read the token Claude "
+                + "Code saved in your keychain. macOS will ask; choose "
+                + "Always Allow to avoid repeat prompts.")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(action: enable) {
+                Text("Show Claude Usage")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color(nsColor: Theme.accent))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(Color(nsColor: Theme.accent).opacity(0.15))
+                    )
+                    .contentShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func message(_ text: String, showsRetry: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(text)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if showsRetry {
+                Button(action: retry) {
+                    Text("Retry")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color(nsColor: Theme.accent))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+/// A labelled progress bar: "5h limit — 12% — resets in 3h 20m".
+private struct AgentUsageMeter: View {
+    let label: String
+    /// 0–100.
+    let percent: Double
+    let detail: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Text(label)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Text(percentLabel)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(fill)
+            }
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.primary.opacity(0.08))
+                    Capsule()
+                        .fill(fill)
+                        .frame(
+                            width: max(
+                                geometry.size.width * clamped / 100,
+                                clamped > 0 ? 2 : 0
+                            )
+                        )
+                }
+            }
+            .frame(height: 4)
+            if let detail, !detail.isEmpty {
+                Text(detail)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var clamped: Double { min(max(percent, 0), 100) }
+
+    private var percentLabel: String {
+        clamped >= 10
+            ? String(format: "%.0f%%", clamped)
+            : String(format: "%.1f%%", clamped)
+    }
+
+    /// Neutral until the window is most of the way gone, then a warning.
+    private var fill: Color {
+        switch clamped {
+        case ..<75: Color(nsColor: Theme.accent)
+        case ..<90: .orange
+        default: .red
+        }
+    }
 }


### PR DESCRIPTION
Adds an **AGENT USAGE** section to the Info tab showing plan limits for the coding agent running in the current session. Supports Claude Code and Codex.

<img width="982" height="1560" alt="image" src="https://github.com/user-attachments/assets/7fa8f7b9-dae3-47e3-bba1-8e333b5de6ab" />

The section only renders while `claude` or `codex` is actually running under that pane's shell. Detection reuses the process list `SessionInfoModel` already polls, so it costs no extra `ps` call.

## Where the numbers come from

The two providers are quite different, which drives most of the design:

**Codex — local, no credentials, no network.** The CLI writes a `token_count` event into its rollout log (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) after every turn, and each one carries the account's current `rate_limits`. Reading usage is a file read. Rate limits are account-wide, but the rollout header records a `cwd`, so the pane's own session is preferred in order to show its context-window fill; if no rollout matches the directory, the most recent one still supplies valid account-wide limits.

**Claude Code — needs a fetch, and is opt-in.** Claude transcripts carry token counts but no plan utilization, so there is no local equivalent. The numbers come from `GET https://api.anthropic.com/api/oauth/usage`, reusing the OAuth token Claude Code already stores — in `~/.claude/.credentials.json` on some installs, in the login keychain (`Claude Code-credentials`) on others.

Because reading that keychain item prompts for permission the first time, **nothing happens until the user clicks "Show Claude Usage"**. No keychain access and no network request occur on launch, or ever, unless that button is pressed. The choice persists in `UserDefaults`.

On an expired token kero reports it and tells the user to run `claude`, rather than refreshing. Refreshing would rotate the token the CLI itself depends on, so Claude Code keeps ownership of its own login.

## Polling

Both providers refresh every 2 minutes, and only while the sidebar is open on the Info tab. Opening the panel, changing directory, and the refresh button all update immediately. Plan limits move slowly, so a tighter loop would just re-read unchanged files and spend requests against a rate-limited endpoint.

## Error handling

Failures are shown in place of numbers with the fix spelled out — not signed in, expired login, rate limited, keychain permission denied — with a Retry button on the recoverable ones.

A few specifics worth noting:

- A failed refresh keeps the previous readings on screen and demotes the error to a warning line beneath them. A transient network blip shouldn't discard numbers that are still roughly true.
- `429` honours Anthropic's `Retry-After` header rather than guessing a fixed backoff, and an explicit refresh will not bypass an active rate limit.
- Snapshots survive the agent stopping and restarting. The process list is polled a tick behind and briefly reads empty on tab switches, so clearing on every change blanked the card spuriously.

## Notes

- Anthropic's usage endpoint is undocumented, so the response parser tolerates both the older per-window shape (`five_hour`, `seven_day`, …) and the newer `limits` array, and degrades to showing nothing rather than failing if the shape changes again.
- Endpoint details for both providers were derived from [CodexBar](https://github.com/steipete/CodexBar) (MIT), which solves the same problem for a menu bar app.
- Adds four files (`AgentUsage`, `AgentUsageModel`, `CodexUsageReader`, `ClaudeUsageReader`) plus the Info panel section in `RightSidebarView`. No changes outside the Info tab.
