### PR TITLE
Follow the terminal's foreground job into its git worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unrelease]
 
+- Follow the terminal's foreground job into another checkout: when an agent
+  switches to its own git worktree, Files, Git and Info re-root to it
+
 ## [0.1.32]
 
 - Add native English, Simplified Chinese, and Japanese localization throughout the app, with a language picker in Settings

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -2425,18 +2425,18 @@
         }
       }
     },
-    "Files and Git anchor to this directory. When automatic, it follows the closest Git repository containing the shell’s current directory; a directory set manually from the project’s context menu is always used as-is." : {
+    "Files and Git anchor to this directory. When automatic, it follows the closest Git repository containing the shell’s current directory, or the one the terminal’s foreground job moved to — a coding agent that switched to its own worktree. A directory set manually from the project’s context menu is always used as-is." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ファイルとGitはこのディレクトリを基準にします。自動の場合、シェルの現在のディレクトリを含む最も近いGitリポジトリを使います。プロジェクトのメニューで手動設定したディレクトリはそのまま使われます。"
+            "value" : "ファイルとGitはこのディレクトリを基準にします。自動の場合、シェルの現在のディレクトリを含む最も近いGitリポジトリ、またはターミナルのフォアグラウンドジョブが移動した先のリポジトリ——自分のワークツリーに切り替えたコーディングエージェントなど——を使います。プロジェクトのメニューで手動設定したディレクトリはそのまま使われます。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文件与 Git 以此目录为基准。自动模式下，会跟随包含 Shell 当前目录的最近 Git 仓库；若从项目菜单手动指定了目录，则始终使用该目录。"
+            "value" : "文件与 Git 以此目录为基准。自动模式下，会跟随包含 Shell 当前目录的最近 Git 仓库，或终端前台作业所切换到的仓库——例如切换到自己工作树的编码代理。若从项目菜单手动指定了目录，则始终使用该目录。"
           }
         }
       }
@@ -2757,6 +2757,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件夹名称"
+          }
+        }
+      }
+    },
+    "Following the terminal job’s directory" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ターミナルジョブのディレクトリを追従中"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在跟随终端作业的目录"
+          }
+        }
+      }
+    },
+    "Following the terminal job’s worktree" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ターミナルジョブのワークツリーを追従中"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在跟随终端作业的工作树"
           }
         }
       }
@@ -3125,6 +3157,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法写入磁盘。"
+          }
+        }
+      }
+    },
+    "job" : {
+      "comment" : "Files header badge: the panels follow a directory the terminal’s foreground job moved to, outside any worktree of the shell’s repository.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジョブ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作业"
           }
         }
       }
@@ -4403,6 +4452,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "项目目录（自动）"
+          }
+        }
+      }
+    },
+    "PROJECT DIRECTORY (JOB)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロジェクトディレクトリ（ジョブ）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "项目目录（作业）"
+          }
+        }
+      }
+    },
+    "PROJECT DIRECTORY (WORKTREE)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロジェクトディレクトリ（ワークツリー）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "项目目录（工作树）"
           }
         }
       }
@@ -6884,6 +6965,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "工作区干净，尚有同步待完成"
+          }
+        }
+      }
+    },
+    "worktree" : {
+      "comment" : "Files header badge: the panels follow a Git worktree the terminal’s foreground job moved to.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークツリー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作树"
           }
         }
       }

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -97,19 +97,57 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
 
     // MARK: - Project directory
 
+    /// Which rule produced the panel root, so labels can describe it
+    /// truthfully instead of just saying "automatic".
+    enum PanelRootSource: Equatable {
+        /// The directory pinned on the project row.
+        case pinned
+        /// The repository the shell itself sits in.
+        case shell
+        /// The repository the terminal's foreground job sits in — a coding
+        /// agent that moved to another checkout of the same project. Whether
+        /// that checkout is a linked worktree is resolved here, once per
+        /// refresh, so views can label it without touching the disk.
+        case foreground(isWorktree: Bool)
+    }
+
     /// Root for the file tree and git panels: the pinned directory when the
-    /// user set one (and it still exists on disk), else the closest git
-    /// repository containing `cwd`, else `cwd` itself — the
+    /// user set one (and it still exists on disk), else the repository the
+    /// terminal's foreground job moved to (an agent's worktree), else the
+    /// closest git repository containing `cwd`, else `cwd` itself — the
     /// follow-the-terminal behavior used before projects had a directory.
-    /// The automatic repository root is re-derived on every call, so it
-    /// tracks the session in and out of repositories without sticking.
-    /// `isAutomatic` reports which branch produced the root, so labels can
-    /// say "(AUTO)" truthfully even when a vanished pin forced the fallback.
-    func panelRoot(followingSessionAt cwd: String) -> (root: String, isAutomatic: Bool) {
+    /// Everything but the pin is re-derived on every call, so the panels
+    /// track the session in and out of repositories without sticking.
+    func panelRoot(
+        followingSessionAt cwd: String, foregroundAt foregroundCwd: String? = nil
+    ) -> (root: String, source: PanelRootSource) {
         if let pinned = customDirectory, FileManager.default.fileExists(atPath: pinned) {
-            return (pinned, false)
+            return (pinned, .pinned)
         }
-        return (Self.closestGitRepository(containing: cwd) ?? cwd, true)
+        let shellRoot = Self.closestGitRepository(containing: cwd) ?? cwd
+        // Only a *different repository* re-roots the panels. A foreground job
+        // running in a subdirectory of the shell's own checkout resolves to
+        // the same root and is ignored, which keeps the file tree from
+        // collapsing its expanded rows every time a command runs.
+        if let foregroundCwd,
+           let foregroundRoot = Self.closestGitRepository(containing: foregroundCwd),
+           foregroundRoot != shellRoot {
+            return (foregroundRoot, .foreground(isWorktree: Self.isLinkedWorktree(foregroundRoot)))
+        }
+        return (shellRoot, .shell)
+    }
+
+    /// Whether `root` is a linked worktree rather than a normal checkout: its
+    /// `.git` is a file pointing into the main repository's `worktrees`
+    /// directory (a submodule's points into `modules` instead).
+    private static func isLinkedWorktree(_ root: String) -> Bool {
+        let gitPath = (root as NSString).appendingPathComponent(".git")
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: gitPath, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              let contents = try? String(contentsOfFile: gitPath, encoding: .utf8)
+        else { return false }
+        return contents.contains("/worktrees/")
     }
 
     /// The directory of the nearest enclosing git repository: walks up from

--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -16,6 +16,8 @@ struct RightSidebarView: View {
     @StateObject private var git = GitStatusModel()
     @StateObject private var info = SessionInfoModel()
     @State private var applicationIsActive = NSApp.isActive
+    /// Which rule produced the current panel root; drives the Files badge.
+    @State private var rootSource = Project.PanelRootSource.shell
     @AppStorage("rightSidebarWidth") private var width: Double = 240
 
     private var pollsSelectedPanel: Bool {
@@ -58,6 +60,7 @@ struct RightSidebarView: View {
                         FileTreePanel(
                             model: fileTree,
                             session: manager.selectedSession,
+                            rootBadge: rootBadge,
                             currentFilePath: openFilePath,
                             openFile: { manager.openFile($0) },
                             openToSide: { manager.openFileToSide($0) },
@@ -204,19 +207,49 @@ struct RightSidebarView: View {
         else { return }
         let cwd = session.currentDirectoryPath
         // Files and Git anchor to the project directory — pinned when the
-        // user set one, else the cwd's closest git repository — so they
-        // don't re-root as the terminal cds around a repo; Info describes
-        // the shell itself, showing its live cwd next to that root.
-        let (root, isAutoRoot) = project.panelRoot(followingSessionAt: cwd)
+        // user set one, else the repository the session is working in — so
+        // they don't re-root as the terminal cds around a repo; Info
+        // describes the shell itself, showing its live cwd next to that root.
+        // An agent that moves to its own worktree changes only its own
+        // process directory, so the foreground job's cwd is passed in too.
+        let (root, source) = project.panelRoot(
+            followingSessionAt: cwd, foregroundAt: session.foregroundDirectoryPath
+        )
+        if rootSource != source { rootSource = source }
         switch manager.panelTab {
         case .files: fileTree.sync(root: root)
         case .git: git.sync(root: root)
         case .info:
             info.sync(
-                root: cwd, projectRoot: root, projectRootIsAutomatic: isAutoRoot,
+                root: cwd, projectRoot: root, projectRootSource: source,
                 shellName: session.shellName, shellPid: session.shellPid
             )
         }
+    }
+
+    /// Text badge for the Files header while the panels follow the foreground
+    /// job instead of the shell — the agent's worktree in the common case, a
+    /// plain "job" when it moved somewhere that isn't a linked worktree.
+    /// The label and its spoken description travel together so neither is
+    /// assembled from translated fragments.
+    private var rootBadge: (text: String, description: String)? {
+        guard case .foreground(let isWorktree) = rootSource else { return nil }
+        if isWorktree {
+            return (
+                String(
+                    localized: "worktree",
+                    comment: "Files header badge: the panels follow a Git worktree the terminal’s foreground job moved to."
+                ),
+                String(localized: "Following the terminal job’s worktree")
+            )
+        }
+        return (
+            String(
+                localized: "job",
+                comment: "Files header badge: the panels follow a directory the terminal’s foreground job moved to, outside any worktree of the shell’s repository."
+            ),
+            String(localized: "Following the terminal job’s directory")
+        )
     }
 }
 
@@ -248,6 +281,9 @@ private struct PanelHeader: View {
 private struct FileTreePanel: View {
     @ObservedObject var model: FileTreeModel
     let session: TerminalSession?
+    /// Set while the tree follows the terminal's foreground job into another
+    /// checkout, so the header says why the root moved.
+    let rootBadge: (text: String, description: String)?
     let currentFilePath: String?
     let openFile: (String) -> Void
     let openToSide: (String) -> Void
@@ -257,6 +293,18 @@ private struct FileTreePanel: View {
         VStack(spacing: 0) {
             HStack {
                 PanelHeader(title: model.rootName, subtitle: model.rootPath)
+                if let rootBadge {
+                    Text(verbatim: rootBadge.text)
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.primary.opacity(0.09))
+                        )
+                        .accessibilityLabel(rootBadge.description)
+                }
                 Button {
                     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: model.rootPath)])
                 } label: {
@@ -2028,16 +2076,30 @@ private struct InfoPanel: View {
     private var projectDirectorySection: some View {
         if !model.projectRootPath.isEmpty {
             GitSectionHeader(
-                title: model.projectRootIsAutomatic
-                    ? String(localized: "PROJECT DIRECTORY (AUTO)")
-                    : String(localized: "PROJECT DIRECTORY"),
+                title: projectDirectoryTitle,
                 count: 0,
                 isCollapsed: $projectDirectoryCollapsed, actions: [],
-                helpText: String(localized: "Files and Git anchor to this directory. When automatic, it follows the closest Git repository containing the shell’s current directory; a directory set manually from the project’s context menu is always used as-is.")
+                helpText: String(localized: "Files and Git anchor to this directory. When automatic, it follows the closest Git repository containing the shell’s current directory, or the one the terminal’s foreground job moved to — a coding agent that switched to its own worktree. A directory set manually from the project’s context menu is always used as-is.")
             )
             if !projectDirectoryCollapsed {
                 directoryGroup(path: model.projectRootPath)
             }
+        }
+    }
+
+    /// Names the rule behind the project directory: a root taken from the
+    /// foreground job says so rather than passing itself off as the shell's
+    /// own repository.
+    private var projectDirectoryTitle: String {
+        switch model.projectRootSource {
+        case .pinned:
+            return String(localized: "PROJECT DIRECTORY")
+        case .shell:
+            return String(localized: "PROJECT DIRECTORY (AUTO)")
+        case .foreground(let isWorktree):
+            return isWorktree
+                ? String(localized: "PROJECT DIRECTORY (WORKTREE)")
+                : String(localized: "PROJECT DIRECTORY (JOB)")
         }
     }
 

--- a/kero/SessionInfoModel.swift
+++ b/kero/SessionInfoModel.swift
@@ -44,9 +44,9 @@ final class SessionInfoModel: nonisolated ObservableObject {
     /// The project directory the file tree and git panels anchor to —
     /// shown alongside the live cwd so both are visible at a glance.
     @Published private(set) var projectRootPath = ""
-    /// Whether that directory was derived (closest git repository / cwd)
-    /// rather than pinned by the user.
-    @Published private(set) var projectRootIsAutomatic = true
+    /// Which rule produced that directory — pinned, the shell's repository,
+    /// or the repository the foreground job moved to.
+    @Published private(set) var projectRootSource = Project.PanelRootSource.shell
     @Published private(set) var shellName = ""
     @Published private(set) var shellPid: pid_t = 0
     @Published private(set) var processes: [ProcessItem] = []
@@ -57,14 +57,14 @@ final class SessionInfoModel: nonisolated ObservableObject {
     func sync(
         root: String,
         projectRoot: String,
-        projectRootIsAutomatic: Bool,
+        projectRootSource: Project.PanelRootSource,
         shellName: String,
         shellPid: pid_t?
     ) {
         if rootPath != root { rootPath = root }
         if projectRootPath != projectRoot { projectRootPath = projectRoot }
-        if self.projectRootIsAutomatic != projectRootIsAutomatic {
-            self.projectRootIsAutomatic = projectRootIsAutomatic
+        if self.projectRootSource != projectRootSource {
+            self.projectRootSource = projectRootSource
         }
         if self.shellName != shellName { self.shellName = shellName }
         let pid = shellPid ?? 0

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -205,6 +205,20 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         return launchWorkingDirectory
     }
 
+    /// Working directory of the terminal's foreground job, when that job is
+    /// something other than the shell itself. Coding agents change their own
+    /// process directory when they move to another checkout — Claude Code's
+    /// worktree switch is a `chdir` inside the running `claude` process — and
+    /// the shell never moves, so no OSC 7 arrives and `currentDirectoryPath`
+    /// keeps describing the old tree. This is deliberately a separate fact:
+    /// `currentDirectoryPath` must stay true to the shell.
+    var foregroundDirectoryPath: String? {
+        guard let foreground = surface.foregroundPid, foreground > 0,
+              foreground != shellPid
+        else { return nil }
+        return processWorkingDirectory(pid: foreground)
+    }
+
     func sendCommand(_ text: String) {
         surface.sendText(text)
     }


### PR DESCRIPTION
## Problem

When a coding agent switches to a git worktree it changes **its own process directory** — Claude Code's worktree switch is a `chdir` inside the running `claude` process. The shell never moves, so no OSC 7 arrives and Files/Git/Info stay anchored to the main checkout while the agent works somewhere else.

Observed on Claude Code 2.1.219, polling the process's kernel cwd while it entered a worktree:

```
t=9s   cwd=…/probe
t=12s  cwd=…/probe/.claude/worktrees/probe-work
```

## Change

`TerminalSession.foregroundDirectoryPath` reads the working directory of the terminal's foreground job via `proc_pidinfo` — the same call already used for the shell. `Project.panelRoot` re-roots the panels there **only when it resolves to a different git repository than the shell's**. A job running in a subdirectory of the same checkout resolves to the same root and is ignored, so the file tree never loses its expanded rows.

- A pinned project directory still wins.
- Live-derived: the root snaps back when the job exits. Nothing is stored, nothing to unwind.
- `currentDirectoryPath` is untouched. Info's CURRENT DIRECTORY keeps describing the shell; PROJECT DIRECTORY says where the panels are anchored, so both facts stay visible.
- Headers name the rule instead of re-rooting silently: a `worktree` badge in Files (`job` when the destination isn't a linked worktree) and `PROJECT DIRECTORY (WORKTREE)` in Info.
- No new timers — the existing 2s panel refresh drives it.

## Verification

Debug build, shell parked in the main checkout, a foreground job chdir'd into a linked worktree:

- **Files** — worktree name, worktree path, `worktree` badge
- **Git** — the worktree's branch and its changes
- **Info** — CURRENT DIRECTORY = the shell's directory, PROJECT DIRECTORY (WORKTREE) = the worktree
- **Snap-back** — kill the job, the root returns to the main checkout within one refresh tick
- **180pt** (minimum sidebar width) — the title truncates, badge and Finder button both stay intact

Screenshots of each state available if useful.

## Note

The badge and the `(WORKTREE)` label are ~20 lines of the diff. Happy to drop them and land behavior only if you'd rather leave the headers untouched — though silent re-rooting seemed like the worse trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBBYwbtnWxXxvVjywqfQ3e