### PR TITLE
feat req: Drag panes out to the tab strip, tabs into a layout, and name panes.

### DIFF
--- a/kero/CommandPaletteView.swift
+++ b/kero/CommandPaletteView.swift
@@ -129,6 +129,9 @@ struct CommandPaletteView: View {
             PaletteCommand(id: "resize-pane-right", title: "Resize Pane Right", systemImage: "arrow.right.to.line", shortcut: "⌃⌘→") {
                 manager.resizePaneRight()
             },
+            PaletteCommand(id: "rename-pane", title: "Rename Pane…", systemImage: "pencil", shortcut: "⌃⌘R") {
+                manager.beginRenamingFocusedPane()
+            },
             PaletteCommand(id: "new-project", title: "New Project", systemImage: "folder.badge.plus", shortcut: "⌘N") {
                 manager.newProject()
             },
@@ -197,18 +200,20 @@ struct CommandPaletteView: View {
     }
 
     /// Every open terminal session across all projects, as a jump-to entry.
-    /// The directory shows as a subtitle and the project name folds into the
-    /// searchable text, so typing a repo or folder name finds its sessions.
+    /// A named pane reads "zsh · build" so two shells with the same title can
+    /// be told apart; the directory shows as a subtitle, and the name and
+    /// project fold into the searchable text, so typing a pane name, a repo or
+    /// a folder finds its sessions.
     private var sessionCommands: [PaletteCommand] {
         manager.projects.flatMap { project in
-            project.sessions.map { session in
+            project.namedSessions.map { session, name in
                 let directory = sessionDirectory(session)
-                let search = [session.title, project.name, directory]
+                let search = [session.title, name, project.name, directory]
                     .compactMap { $0 }
                     .joined(separator: " ")
                 return PaletteCommand(
                     id: "session-\(session.id)",
-                    title: session.title,
+                    title: name.map { "\(session.title) · \($0)" } ?? session.title,
                     systemImage: "terminal",
                     subtitle: directory,
                     section: .session,

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -10,6 +10,9 @@ struct ContentView: View {
     @ObservedObject private var themeChanges = Theme.changes
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var tabSwitcher = TabSwitcherController()
+    /// Shared geometry and in-flight state for the drags that cross between
+    /// the tab strip and the pane layout.
+    @StateObject private var dragging = PaneDragCoordinator()
 
     var body: some View {
         HStack(spacing: 0) {
@@ -43,8 +46,16 @@ struct ContentView: View {
                         }
                     }
                     Group {
-                        if let tab = manager.selectedProject?.selectedTab {
-                            PaneLayoutView(tab: tab, onSplit: { manager.split(toward: $0) })
+                        if let project = manager.selectedProject, let tab = project.selectedTab {
+                            PaneLayoutView(
+                                tab: tab,
+                                onSplit: { manager.split(toward: $0) },
+                                onExtractPane: { paneID, index in
+                                    project.extractPane(paneID, from: tab, at: index)
+                                },
+                                onCloseContent: { project.closeContent($0) },
+                                tabOrder: project.tabs.map(\.id)
+                            )
                         } else {
                             emptyState
                         }
@@ -85,6 +96,7 @@ struct ContentView: View {
                 .frame(width: 0, height: 0)
         }
         .background(WindowChromeAccessor { manager.attach(to: $0) })
+        .environmentObject(dragging)
         .onChange(of: colorScheme) {
             manager.refreshAppearance()
         }
@@ -220,6 +232,7 @@ private struct MainHeaderView: View {
 /// plus a "+" button.
 private struct SessionTabsView: View {
     @ObservedObject var project: Project
+    @EnvironmentObject private var dragging: PaneDragCoordinator
     let maxStripWidth: CGFloat
     @State private var overflow = StripOverflow()
     @State private var draggedTabID: UUID?
@@ -238,7 +251,10 @@ private struct SessionTabsView: View {
             ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 3) {
-                    ForEach(project.tabs) { tab in
+                    ForEach(Array(project.tabs.enumerated()), id: \.element.id) { index, tab in
+                        // Caret marking where a pane carried up from the layout
+                        // would be inserted as a tab.
+                        insertionCaret(at: index)
                         PaneTabItem(
                             tab: tab,
                             isSelected: tab.id == project.selectedTabID,
@@ -263,10 +279,11 @@ private struct SessionTabsView: View {
                                 .onChanged { value in
                                     updateTabDrag(source: tab.id, location: value.location)
                                 }
-                                .onEnded { _ in endTabDrag() },
+                                .onEnded { _ in endTabDrag(source: tab.id) },
                             including: renamingTabID == tab.id ? .subviews : .all
                         )
                     }
+                    insertionCaret(at: project.tabs.count)
                 }
             }
             .onScrollGeometryChange(for: StripOverflow.self) { geo in
@@ -322,24 +339,87 @@ private struct SessionTabsView: View {
             .buttonStyle(.plain)
             .tooltip("New Session (⌘T)", edge: .below)
         }
-        .onPreferenceChange(TabFramePreferenceKey.self) { tabFrames = $0 }
-    }
-
-    /// Reorders immediately as the pointer crosses another tab. This direct
-    /// gesture deliberately avoids a pasteboard drag session, which the
-    /// hidden title bar can otherwise claim as a window move first.
-    private func updateTabDrag(source: UUID, location: CGPoint) {
-        draggedTabID = source
-        NSCursor.closedHand.set()
-        guard let target = tabFrames.first(where: {
-            $0.key != source && $0.value.contains(location)
-        })?.key else { return }
-        withAnimation(.easeInOut(duration: 0.12)) {
-            project.moveTab(source, to: target)
+        .onPreferenceChange(TabFramePreferenceKey.self) { frames in
+            tabFrames = frames
+            dragging.tabFrames = frames
+        }
+        // The strip's own frame is the drop region for a pane carried up out of
+        // the layout — anywhere in the header row counts, so the gesture
+        // doesn't demand pixel accuracy on the tabs themselves.
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .onAppear { dragging.stripFrame = headerRegion(of: proxy) }
+                    .onChange(of: proxy.frame(in: .global)) {
+                        dragging.stripFrame = headerRegion(of: proxy)
+                    }
+            }
         }
     }
 
-    private func endTabDrag() {
+    /// The strip stretched across the full header row: a pane dropped anywhere
+    /// along that row becomes a tab, rather than only over the tabs themselves
+    /// (which occupy a fraction of it, and scroll). Widened past both window
+    /// edges and given a little vertical slack so the drop is forgiving; only
+    /// the row's height really distinguishes it from the layout below.
+    private func headerRegion(of proxy: GeometryProxy) -> CGRect {
+        proxy.frame(in: .global).insetBy(dx: -10_000, dy: -8)
+    }
+
+    /// A pane being carried up onto the strip lands between two tabs; this is
+    /// the marker for that spot. Zero-width the rest of the time.
+    @ViewBuilder
+    private func insertionCaret(at index: Int) -> some View {
+        if dragging.paneDrag?.tabDropIndex == index {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(Color(nsColor: Theme.accent))
+                .frame(width: 2, height: 20)
+        }
+    }
+
+    /// Drives a tab drag. Inside the strip it reorders immediately as the
+    /// pointer crosses another tab; dragged down over the pane layout it
+    /// instead previews merging this tab's panes into the pane under the
+    /// cursor. This direct gesture deliberately avoids a pasteboard drag
+    /// session, which the hidden title bar can otherwise claim as a window move
+    /// first.
+    private func updateTabDrag(source: UUID, location: CGPoint) {
+        draggedTabID = source
+        NSCursor.closedHand.set()
+
+        if dragging.stripFrame.contains(location) {
+            dragging.tabDrag = nil
+            guard let target = tabFrames.first(where: {
+                $0.key != source && $0.value.contains(location)
+            })?.key else { return }
+            withAnimation(.easeInOut(duration: 0.12)) {
+                project.moveTab(source, to: target)
+            }
+            return
+        }
+
+        // Below the strip: over the layout of whichever tab is on screen. Only
+        // offered when the two tabs can actually be merged (no diffs either
+        // side), so there is never a highlight the drop won't honor.
+        var drag = PaneDragCoordinator.TabDrag(tabID: source, location: location)
+        if let dragged = project.tabs.first(where: { $0.id == source }),
+           let selected = project.selectedTab,
+           project.canMerge(dragged, into: selected),
+           let target = dragging.pane(at: location) {
+            drag.targetPaneID = target.id
+            drag.edge = dragging.dropEdge(at: location, in: target.frame)
+        } else {
+            NSCursor.operationNotAllowed.set()
+        }
+        dragging.tabDrag = drag
+    }
+
+    private func endTabDrag(source: UUID) {
+        if let drag = dragging.tabDrag, drag.tabID == source,
+           let target = drag.targetPaneID, let edge = drag.edge {
+            project.mergeTab(source, into: target, edge: edge)
+        }
+        dragging.tabDrag = nil
         draggedTabID = nil
         NSCursor.arrow.set()
     }
@@ -368,16 +448,6 @@ private struct SessionTabsView: View {
             .disabled(project.tabs.last?.id == tab.id)
         Divider()
         Button("Close All") { project.closeAll() }
-    }
-}
-
-/// Collects each tab's global frame so a direct drag gesture can hit-test the
-/// pointer even while the horizontal strip is moving under it.
-private struct TabFramePreferenceKey: PreferenceKey {
-    static let defaultValue: [UUID: CGRect] = [:]
-
-    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
-        value.merge(nextValue()) { $1 }
     }
 }
 

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -54,7 +54,11 @@ struct ContentView: View {
                                     project.extractPane(paneID, from: tab, at: index)
                                 },
                                 onCloseContent: { project.closeContent($0) },
-                                tabOrder: project.tabs.map(\.id)
+                                onMovePaneToProject: { paneID, projectID in
+                                    manager.movePane(paneID, toProject: projectID)
+                                },
+                                tabOrder: project.tabs.map(\.id),
+                                currentProjectID: project.id
                             )
                         } else {
                             emptyState
@@ -177,6 +181,9 @@ private struct MainHeaderView: View {
                     // and the exit-zoom button (24 + 8 spacing) while shown.
                     SessionTabsView(
                         project: project,
+                        moveTabToProject: { tabID, projectID in
+                            manager.moveTab(tabID, toProject: projectID)
+                        },
                         maxStripWidth: max(0, geo.size.width - leadingInset - 74 - (manager.isPaneZoomed ? 32 : 0))
                     )
                 }
@@ -233,6 +240,8 @@ private struct MainHeaderView: View {
 private struct SessionTabsView: View {
     @ObservedObject var project: Project
     @EnvironmentObject private var dragging: PaneDragCoordinator
+    /// Moves a tab into another project, dropped on its sidebar row.
+    var moveTabToProject: (UUID, UUID) -> Void = { _, _ in }
     let maxStripWidth: CGFloat
     @State private var overflow = StripOverflow()
     @State private var draggedTabID: UUID?
@@ -395,6 +404,16 @@ private struct SessionTabsView: View {
         draggedTabID = source
         NSCursor.closedHand.set()
 
+        // A sidebar row wins over everything else: it sits outside both the
+        // strip and the layout, and the strip's drop region deliberately
+        // reaches past the window's edges.
+        if let target = dragging.project(at: location, excluding: project.id) {
+            dragging.tabDrag = PaneDragCoordinator.TabDrag(
+                tabID: source, location: location, targetProjectID: target
+            )
+            return
+        }
+
         if dragging.stripFrame.contains(location) {
             dragging.tabDrag = nil
             guard let target = tabFrames.first(where: {
@@ -423,9 +442,12 @@ private struct SessionTabsView: View {
     }
 
     private func endTabDrag(source: UUID) {
-        if let drag = dragging.tabDrag, drag.tabID == source,
-           let target = drag.targetPaneID, let edge = drag.edge {
-            project.mergeTab(source, into: target, edge: edge)
+        if let drag = dragging.tabDrag, drag.tabID == source {
+            if let destination = drag.targetProjectID {
+                moveTabToProject(source, destination)
+            } else if let target = drag.targetPaneID, let edge = drag.edge {
+                project.mergeTab(source, into: target, edge: edge)
+            }
         }
         dragging.tabDrag = nil
         draggedTabID = nil

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -339,6 +339,14 @@ private struct SessionTabsView: View {
             .buttonStyle(.plain)
             .tooltip("New Session (⌘T)", edge: .below)
         }
+        // A rename asked for from outside the strip (palette, Info panel) opens
+        // the same inline field the tab's context menu does — this is where a
+        // single-pane tab's rename lands, since it has no pane header.
+        .onChange(of: project.pendingRenameTabID) { _, requested in
+            guard let requested else { return }
+            renamingTabID = requested
+            DispatchQueue.main.async { project.pendingRenameTabID = nil }
+        }
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
             tabFrames = frames
             dragging.tabFrames = frames

--- a/kero/PaneDragCoordinator.swift
+++ b/kero/PaneDragCoordinator.swift
@@ -33,8 +33,14 @@ final class PaneDragCoordinator: ObservableObject {
         /// Where it would land in the tab strip, when the cursor is up there
         /// instead — the index the extracted tab is inserted at.
         var tabDropIndex: Int?
+        /// The sidebar project it would move to, when the cursor is over a
+        /// project row.
+        var targetProjectID: UUID?
 
         var isOverStrip: Bool { tabDropIndex != nil }
+        /// Over the strip or a project row, the pane becomes a tab either way,
+        /// so the thumbnail previews a tab rather than the pane.
+        var previewsTab: Bool { tabDropIndex != nil || targetProjectID != nil }
     }
 
     /// A tab being carried out of the strip and over the pane layout.
@@ -43,6 +49,9 @@ final class PaneDragCoordinator: ObservableObject {
         var location: CGPoint
         var targetPaneID: UUID?
         var edge: PaneDropEdge?
+        /// The sidebar project it would move to, when the cursor is over a
+        /// project row.
+        var targetProjectID: UUID?
     }
 
     @Published var paneDrag: PaneDrag?
@@ -55,6 +64,8 @@ final class PaneDragCoordinator: ObservableObject {
     /// header row counts, so the gesture doesn't demand pixel accuracy.
     var tabFrames: [UUID: CGRect] = [:]
     var stripFrame: CGRect = .zero
+    /// Global-space frame of every sidebar project row, from `SidebarView`.
+    var projectFrames: [UUID: CGRect] = [:]
 
     /// The pane under `location`, if any — excluding `excluding`, which is the
     /// pane being carried.
@@ -62,6 +73,21 @@ final class PaneDragCoordinator: ObservableObject {
         paneFrames
             .first { $0.key != excluding && $0.value.contains(location) }
             .map { (id: $0.key, frame: $0.value) }
+    }
+
+    /// The sidebar project row under `location`, if any — excluding
+    /// `excluding`, the project the dragged tab already belongs to, so its own
+    /// row never lights up as a destination.
+    func project(at location: CGPoint, excluding: UUID? = nil) -> UUID? {
+        projectFrames
+            .first { $0.key != excluding && $0.value.contains(location) }?
+            .key
+    }
+
+    /// The project row being previewed as a drop target right now, from
+    /// whichever drag is in flight.
+    func isDropTarget(project projectID: UUID) -> Bool {
+        paneDrag?.targetProjectID == projectID || tabDrag?.targetProjectID == projectID
     }
 
     /// Where a pane dropped at `location` would be inserted in the strip: the

--- a/kero/PaneDragCoordinator.swift
+++ b/kero/PaneDragCoordinator.swift
@@ -1,0 +1,121 @@
+//
+//  PaneDragCoordinator.swift
+//  kero
+//
+
+import Combine
+import Foundation
+import SwiftUI
+
+/// Shared state for the two drags that cross between the tab strip and the
+/// pane layout: carrying a pane up onto the strip (it becomes its own tab) and
+/// carrying a tab down onto a pane (its panes merge into that layout).
+///
+/// The two live in different parts of the view tree — `SessionTabsView` in the
+/// header, `PaneLayoutView` in the content area — and each needs the other's
+/// geometry to hit-test the cursor, so the frames and the in-flight drag meet
+/// here rather than in either view's `@State`.
+///
+/// Frames are deliberately *not* `@Published`: they are written from
+/// `onPreferenceChange` during layout, and republishing them there would feed
+/// straight back into another layout pass. Only the drags publish, and only
+/// this small pair of views observes them — a per-frame change never reaches
+/// the manager, so it never re-renders the window.
+@MainActor
+final class PaneDragCoordinator: ObservableObject {
+    /// A pane being carried by its header strip.
+    struct PaneDrag {
+        let paneID: UUID
+        var location: CGPoint
+        /// The pane it is hovering over, and which edge of it — a split.
+        var targetPaneID: UUID?
+        var edge: PaneDropEdge?
+        /// Where it would land in the tab strip, when the cursor is up there
+        /// instead — the index the extracted tab is inserted at.
+        var tabDropIndex: Int?
+
+        var isOverStrip: Bool { tabDropIndex != nil }
+    }
+
+    /// A tab being carried out of the strip and over the pane layout.
+    struct TabDrag {
+        let tabID: UUID
+        var location: CGPoint
+        var targetPaneID: UUID?
+        var edge: PaneDropEdge?
+    }
+
+    @Published var paneDrag: PaneDrag?
+    @Published var tabDrag: TabDrag?
+
+    /// Global-space frame of every mounted pane, from `PaneLayoutView`.
+    var paneFrames: [UUID: CGRect] = [:]
+    /// Global-space frame of every tab item, and of the strip as a whole, from
+    /// `SessionTabsView`. The strip frame is the drop region: anywhere in the
+    /// header row counts, so the gesture doesn't demand pixel accuracy.
+    var tabFrames: [UUID: CGRect] = [:]
+    var stripFrame: CGRect = .zero
+
+    /// The pane under `location`, if any — excluding `excluding`, which is the
+    /// pane being carried.
+    func pane(at location: CGPoint, excluding: UUID? = nil) -> (id: UUID, frame: CGRect)? {
+        paneFrames
+            .first { $0.key != excluding && $0.value.contains(location) }
+            .map { (id: $0.key, frame: $0.value) }
+    }
+
+    /// Where a pane dropped at `location` would be inserted in the strip: the
+    /// number of tabs whose midpoint the cursor has passed. Nil when the cursor
+    /// isn't over the strip at all.
+    func tabInsertionIndex(at location: CGPoint, in order: [UUID]) -> Int? {
+        guard stripFrame.contains(location) else { return nil }
+        return order.filter { id in
+            guard let frame = tabFrames[id] else { return false }
+            return location.x > frame.midX
+        }.count
+    }
+
+    /// Which edge of `frame` the pointer is nearest — the target is cut into
+    /// four triangular quadrants by its diagonals, the standard drop-zone
+    /// scheme (VS Code, Ghostty).
+    func dropEdge(at location: CGPoint, in frame: CGRect) -> PaneDropEdge {
+        let dx = (location.x - frame.midX) / max(frame.width, 1)
+        let dy = (location.y - frame.midY) / max(frame.height, 1)
+        if abs(dx) > abs(dy) {
+            return dx < 0 ? .left : .right
+        } else {
+            return dy < 0 ? .top : .bottom
+        }
+    }
+
+    /// The drop edge being previewed on `paneID` right now, from whichever of
+    /// the two drags is in flight. Drives the half-pane highlight.
+    func dropEdge(previewedOn paneID: UUID) -> PaneDropEdge? {
+        if let paneDrag, paneDrag.targetPaneID == paneID { return paneDrag.edge }
+        if let tabDrag, tabDrag.targetPaneID == paneID { return tabDrag.edge }
+        return nil
+    }
+
+    func clear() {
+        paneDrag = nil
+        tabDrag = nil
+    }
+}
+
+/// Collects each pane's global-space frame so a drag can hit-test the cursor
+/// against them.
+struct PaneFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [UUID: CGRect] = [:]
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue()) { $1 }
+    }
+}
+
+/// Collects each tab item's global frame, so a direct drag gesture can
+/// hit-test the pointer even while the horizontal strip scrolls under it.
+struct TabFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [UUID: CGRect] = [:]
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue()) { $1 }
+    }
+}

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -21,9 +21,14 @@ struct PaneLayoutView: View {
     var onExtractPane: (UUID, Int?) -> Void = { _, _ in }
     /// Closes one pane's content, with the project's save prompts.
     var onCloseContent: (PaneContent) -> Void = { _ in }
+    /// Moves a pane into another project, dropped on its sidebar row.
+    var onMovePaneToProject: (UUID, UUID) -> Void = { _, _ in }
     /// The order tabs appear in the strip, so a pane dropped there can be given
     /// an insertion index.
     var tabOrder: [UUID] = []
+    /// The project this layout belongs to, so its own sidebar row isn't
+    /// offered as a destination for a pane already in it.
+    var currentProjectID: UUID?
 
     /// Gap between tiles, which doubles as the divider hit area. The same
     /// value insets the whole grid from the parent, so the spacing around the
@@ -142,7 +147,7 @@ struct PaneLayoutView: View {
                     let origin = geo.frame(in: .global).origin
                     let size = thumbnailFrame(for: paneDrag.paneID)
                     dragThumbnailView(
-                        for: paneDrag.paneID, size: size, isOverStrip: paneDrag.isOverStrip
+                        for: paneDrag.paneID, size: size, isOverStrip: paneDrag.previewsTab
                     )
                     // Centered on the pointer, both axes.
                     .offset(
@@ -261,8 +266,12 @@ struct PaneLayoutView: View {
         }
         var move = PaneDragCoordinator.PaneDrag(paneID: source, location: location)
         // Extracting needs a pane to leave behind; a lone pane is already its
-        // own tab, so the strip isn't offered as a target for it.
+        // own tab, so neither the strip nor the sidebar is offered for it.
         if tab.hasMultiplePanes,
+           let project = dragging.project(at: location, excluding: currentProjectID) {
+            move.targetProjectID = project
+            NSCursor.closedHand.set()
+        } else if tab.hasMultiplePanes,
            let index = dragging.tabInsertionIndex(at: location, in: tabOrder) {
             move.tabDropIndex = index
             NSCursor.closedHand.set()
@@ -280,7 +289,9 @@ struct PaneLayoutView: View {
     /// onto the chosen edge of another pane in this layout.
     private func commitPaneMove() {
         if let move = dragging.paneDrag {
-            if let index = move.tabDropIndex {
+            if let project = move.targetProjectID {
+                onMovePaneToProject(move.paneID, project)
+            } else if let index = move.tabDropIndex {
                 onExtractPane(move.paneID, index)
             } else if let target = move.targetPaneID, let edge = move.edge {
                 tab.movePane(move.paneID, edge, of: target)

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -513,6 +513,15 @@ private struct PaneView: View {
         // Reported even without chrome: a single-pane tab is still a legitimate
         // target for a tab dragged onto it.
         .background(frameReporter)
+        // A rename asked for from outside the pane (palette, Info panel) opens
+        // the very same field the header's own menu does. Cleared on the next
+        // tick so the flag never lingers to re-fire, and so the model isn't
+        // mutated from inside this update pass.
+        .onChange(of: tab.pendingRenamePaneID) { _, requested in
+            guard requested == pane.id else { return }
+            isRenaming = true
+            DispatchQueue.main.async { tab.pendingRenamePaneID = nil }
+        }
     }
 
     /// Focuses this pane, then acts — the context menu acts on the pane it was

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -13,8 +13,17 @@ import SwiftUI
 struct PaneLayoutView: View {
     @ObservedObject var tab: PaneTab
     @ObservedObject private var themeChanges = Theme.changes
+    @EnvironmentObject private var dragging: PaneDragCoordinator
     /// Splits the focused pane on the given edge — from a pane's context menu.
     var onSplit: (PaneDropEdge) -> Void = { _ in }
+    /// Lifts a pane out into a tab of its own, at the given index in the strip
+    /// (appended next to this tab when nil).
+    var onExtractPane: (UUID, Int?) -> Void = { _, _ in }
+    /// Closes one pane's content, with the project's save prompts.
+    var onCloseContent: (PaneContent) -> Void = { _ in }
+    /// The order tabs appear in the strip, so a pane dropped there can be given
+    /// an insertion index.
+    var tabOrder: [UUID] = []
 
     /// Gap between tiles, which doubles as the divider hit area. The same
     /// value insets the whole grid from the parent, so the spacing around the
@@ -34,12 +43,6 @@ struct PaneLayoutView: View {
     /// Committed back to the model once, on release.
     @State private var dragColumns: [PaneColumn]?
 
-    /// Global-space frame of every pane, so a pane-move drag can tell which
-    /// pane the cursor is over.
-    @State private var paneFrames: [UUID: CGRect] = [:]
-    /// In-flight pane-move drag: which pane is being carried, where the pointer
-    /// is, and which pane it is hovering over (the drop target).
-    @State private var paneDrag: PaneMove?
     /// A snapshot of the carried pane, shown as a thumbnail under the cursor.
     @State private var dragThumbnail: NSImage?
 
@@ -53,13 +56,6 @@ struct PaneLayoutView: View {
         var weights: [CGFloat]
     }
 
-    private struct PaneMove {
-        let sourceID: UUID
-        var location: CGPoint
-        var targetID: UUID?
-        var edge: PaneDropEdge?
-    }
-
     var body: some View {
         Group {
             if tab.isZoomed, tab.hasMultiplePanes, let pane = tab.focusedPane {
@@ -70,13 +66,15 @@ struct PaneLayoutView: View {
                 PaneView(
                     tab: tab,
                     pane: pane,
-                    showFocusRing: true,
+                    showChrome: true,
                     allowsMove: false,
                     isMoveSource: false,
                     dropEdge: nil,
                     onMove: { _ in },
                     onMoveEnded: {},
-                    onSplit: onSplit
+                    onSplit: onSplit,
+                    onExtract: {},
+                    onClose: { onCloseContent(pane.content) }
                 )
             } else {
                 grid
@@ -86,15 +84,25 @@ struct PaneLayoutView: View {
         // tiles, so a split tab has even breathing room on every side. A
         // single-pane tab stays full-bleed, exactly as before splits existed.
         .padding(tab.hasMultiplePanes ? gap : 0)
-        .onPreferenceChange(PaneFramePreferenceKey.self) { paneFrames = $0 }
+        .onPreferenceChange(PaneFramePreferenceKey.self) { frames in
+            dragging.paneFrames = frames
+        }
         // A divider or pane-move drag can't deliver its ending callback once
         // toggling zoom unmounts its view — drop any in-flight drag state so a
         // stale snapshot never sticks around.
         .onChange(of: tab.isZoomed) {
             drag = nil
             dragColumns = nil
-            paneDrag = nil
+            dragging.clear()
             dragThumbnail = nil
+        }
+        .onDisappear {
+            // Switching tabs mid-drag unmounts this layout, and no ending
+            // callback arrives — drop the drag rather than leave it in flight.
+            // The frames themselves are left alone: the incoming layout's
+            // preference values replace them on the same pass, and clearing
+            // here would race that and blank them.
+            dragging.clear()
         }
     }
 
@@ -130,16 +138,18 @@ struct PaneLayoutView: View {
                 // The carried pane's thumbnail, trailing the cursor. Positioned
                 // in this grid's local space by subtracting its global origin
                 // from the (global) pointer location.
-                if let paneDrag {
+                if let paneDrag = dragging.paneDrag {
                     let origin = geo.frame(in: .global).origin
-                    let size = thumbnailFrame(for: paneDrag.sourceID)
-                    dragThumbnailView(for: paneDrag.sourceID, size: size)
-                        // Centered on the pointer, both axes.
-                        .offset(
-                            x: paneDrag.location.x - origin.x - size.width / 2,
-                            y: paneDrag.location.y - origin.y - size.height / 2
-                        )
-                        .allowsHitTesting(false)
+                    let size = thumbnailFrame(for: paneDrag.paneID)
+                    dragThumbnailView(
+                        for: paneDrag.paneID, size: size, isOverStrip: paneDrag.isOverStrip
+                    )
+                    // Centered on the pointer, both axes.
+                    .offset(
+                        x: paneDrag.location.x - origin.x - size.width / 2,
+                        y: paneDrag.location.y - origin.y - size.height / 2
+                    )
+                    .allowsHitTesting(false)
                 }
             }
         }
@@ -157,13 +167,15 @@ struct PaneLayoutView: View {
                 PaneView(
                     tab: tab,
                     pane: pane,
-                    showFocusRing: tab.hasMultiplePanes,
+                    showChrome: tab.hasMultiplePanes,
                     allowsMove: true,
-                    isMoveSource: paneDrag?.sourceID == pane.id,
-                    dropEdge: paneDrag?.targetID == pane.id ? paneDrag?.edge : nil,
+                    isMoveSource: dragging.paneDrag?.paneID == pane.id,
+                    dropEdge: dragging.dropEdge(previewedOn: pane.id),
                     onMove: { updateDropTarget(source: pane.id, location: $0) },
                     onMoveEnded: { commitPaneMove() },
-                    onSplit: onSplit
+                    onSplit: onSplit,
+                    onExtract: { onExtractPane(pane.id, nil) },
+                    onClose: { onCloseContent(pane.content) }
                 )
                 .frame(width: width, height: heights[paneIndex])
                 if paneIndex < column.panes.count - 1 {
@@ -238,30 +250,43 @@ struct PaneLayoutView: View {
     // MARK: - Moving panes
 
     /// Tracks a pane-move drag: `location` is the pointer in global space. The
-    /// drop target is whichever *other* pane's frame contains it (none over a
-    /// gap), and the edge is which quadrant of that pane the pointer is in.
-    /// Local @State, so only this grid re-renders per frame.
+    /// pane can land in two places, so they are resolved in priority order —
+    /// the tab strip first (drop it there and it leaves this layout for a tab
+    /// of its own), then whichever *other* pane's frame contains the pointer,
+    /// with the edge decided by the quadrant. Over neither, there's no drop.
     private func updateDropTarget(source: UUID, location: CGPoint) {
         // First frame of the drag: grab the thumbnail once.
-        if paneDrag == nil {
+        if dragging.paneDrag == nil {
             dragThumbnail = thumbnail(for: source)
         }
-        if let (targetID, frame) = paneFrames.first(where: { $0.key != source && $0.value.contains(location) }) {
-            paneDrag = PaneMove(sourceID: source, location: location, targetID: targetID, edge: dropEdge(at: location, in: frame))
+        var move = PaneDragCoordinator.PaneDrag(paneID: source, location: location)
+        // Extracting needs a pane to leave behind; a lone pane is already its
+        // own tab, so the strip isn't offered as a target for it.
+        if tab.hasMultiplePanes,
+           let index = dragging.tabInsertionIndex(at: location, in: tabOrder) {
+            move.tabDropIndex = index
+            NSCursor.closedHand.set()
+        } else if let target = dragging.pane(at: location, excluding: source) {
+            move.targetPaneID = target.id
+            move.edge = dragging.dropEdge(at: location, in: target.frame)
             NSCursor.closedHand.set()
         } else {
-            paneDrag = PaneMove(sourceID: source, location: location, targetID: nil, edge: nil)
             NSCursor.operationNotAllowed.set()
         }
+        dragging.paneDrag = move
     }
 
-    /// Commits a pane-move on release: splits the target on the chosen edge and
-    /// drops the carried pane there.
+    /// Commits a pane-move on release: out to the tab strip as a new tab, or
+    /// onto the chosen edge of another pane in this layout.
     private func commitPaneMove() {
-        if let paneDrag, let target = paneDrag.targetID, let edge = paneDrag.edge {
-            tab.movePane(paneDrag.sourceID, edge, of: target)
+        if let move = dragging.paneDrag {
+            if let index = move.tabDropIndex {
+                onExtractPane(move.paneID, index)
+            } else if let target = move.targetPaneID, let edge = move.edge {
+                tab.movePane(move.paneID, edge, of: target)
+            }
         }
-        paneDrag = nil
+        dragging.paneDrag = nil
         dragThumbnail = nil
         // Clear the drag cursor; the next hover/move asserts the right one.
         NSCursor.arrow.set()
@@ -270,20 +295,37 @@ struct PaneLayoutView: View {
     /// A snapshot of the carried pane's terminal (falls back to a labeled card
     /// for files), shown centered under the cursor while dragging. `size` is
     /// aspect-matched to the pane, so the whole pane scales down instead of
-    /// being cropped.
+    /// being cropped. Over the tab strip it shrinks to a tab-sized chip, so the
+    /// thumbnail itself previews what the drop produces.
     @ViewBuilder
-    private func dragThumbnailView(for sourceID: UUID, size: CGSize) -> some View {
-        let content = tab.allPanes.first { $0.id == sourceID }?.content
+    private func dragThumbnailView(
+        for sourceID: UUID, size: CGSize, isOverStrip: Bool
+    ) -> some View {
+        let pane = tab.allPanes.first { $0.id == sourceID }
         Group {
-            if let dragThumbnail {
+            if isOverStrip, let pane {
+                HStack(spacing: 5) {
+                    Image(systemName: pane.content.systemImage)
+                        .font(.system(size: 9, weight: .medium))
+                    Text(pane.displayTitle)
+                        .font(.system(size: 11.5))
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 9)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(nsColor: Theme.background))
+                )
+            } else if let dragThumbnail {
                 Image(nsImage: dragThumbnail)
                     .resizable()
                     .frame(width: size.width, height: size.height)
                     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-            } else if let content {
+            } else if let pane {
                 HStack(spacing: 6) {
-                    Image(systemName: content.systemImage)
-                    Text(content.title).lineLimit(1)
+                    Image(systemName: pane.content.systemImage)
+                    Text(pane.displayTitle).lineLimit(1)
                 }
                 .font(.system(size: 12, weight: .medium))
                 .padding(.horizontal, 12)
@@ -302,7 +344,7 @@ struct PaneLayoutView: View {
     /// The thumbnail's on-screen size: the source pane's aspect ratio scaled to
     /// fit within `thumbnailMaxSize`.
     private func thumbnailFrame(for sourceID: UUID) -> CGSize {
-        guard let frame = paneFrames[sourceID], frame.width > 0, frame.height > 0 else {
+        guard let frame = dragging.paneFrames[sourceID], frame.width > 0, frame.height > 0 else {
             return thumbnailMaxSize
         }
         let scale = min(thumbnailMaxSize.width / frame.width, thumbnailMaxSize.height / frame.height)
@@ -315,19 +357,6 @@ struct PaneLayoutView: View {
             return session.terminalView.paneSnapshot()
         case .file(let file): return file.editorView?.paneSnapshot()
         default: return nil
-        }
-    }
-
-    /// Which edge of `frame` the pointer is nearest — the target is cut into
-    /// four triangular quadrants by its diagonals, the standard drop-zone
-    /// scheme (VS Code, Ghostty).
-    private func dropEdge(at location: CGPoint, in frame: CGRect) -> PaneDropEdge {
-        let dx = (location.x - frame.midX) / max(frame.width, 1)
-        let dy = (location.y - frame.midY) / max(frame.height, 1)
-        if abs(dx) > abs(dy) {
-            return dx < 0 ? .left : .right
-        } else {
-            return dy < 0 ? .top : .bottom
         }
     }
 
@@ -402,36 +431,48 @@ private struct ResizableDivider: View {
 }
 
 /// One tile: hosts its content and, when the tab holds more than one pane,
-/// draws a focus ring (accent for the focused pane, faint otherwise), a thin
-/// top strip you can grab to move the pane onto another, and a highlight while
-/// it's the drop target.
+/// draws a focus ring (accent for the focused pane, faint otherwise), a header
+/// strip carrying the pane's title that you can grab to move it, and a
+/// highlight while it's the drop target.
 private struct PaneView: View {
     @ObservedObject var tab: PaneTab
     @ObservedObject private var themeChanges = Theme.changes
     let pane: Pane
-    let showFocusRing: Bool
-    /// Whether the top grab strip is offered at all — false while zoomed,
-    /// where there is no other pane on screen to drop onto.
+    /// Whether pane chrome — ring and header — is shown at all. False for a
+    /// single-pane tab, which is indistinguishable from a pre-splits tab and
+    /// whose title and rename already live in the tab strip.
+    let showChrome: Bool
+    /// Whether the header may be dragged — false while zoomed, where there is
+    /// no other pane on screen to drop onto.
     let allowsMove: Bool
     /// The pane currently being carried by a move drag (dimmed).
     let isMoveSource: Bool
-    /// When this pane is the drop target, the edge the carried pane will land
-    /// on — drives the half-pane preview. Nil when it isn't the target.
+    /// When this pane is the drop target, the edge the carried pane or tab will
+    /// land on — drives the half-pane preview. Nil when it isn't the target.
     let dropEdge: PaneDropEdge?
-    /// Reports the pointer (global space) as the top strip is dragged.
+    /// Reports the pointer (global space) as the header is dragged.
     let onMove: (CGPoint) -> Void
     let onMoveEnded: () -> Void
-    /// Splits the focused pane on the given edge (from the content's context
-    /// menu).
+    /// Splits the focused pane on the given edge (from the context menu).
     let onSplit: (PaneDropEdge) -> Void
+    /// Lifts this pane out into a tab of its own.
+    let onExtract: () -> Void
+    /// Closes this pane.
+    let onClose: () -> Void
 
-    /// Height of the grab strip at the pane's top.
-    private let handleHeight: CGFloat = 8
+    /// Height of the header strip at the pane's top. Tall enough to read a
+    /// title in and to hit without aiming.
+    private let headerHeight: CGFloat = 18
 
-    @State private var isHandleHovered = false
+    @State private var isHeaderHovered = false
     @State private var isDragging = false
+    @State private var isRenaming = false
 
     private var isFocused: Bool { tab.focusedPaneID == pane.id }
+
+    /// A named pane keeps its header on screen permanently, so the name is
+    /// always readable; an unnamed one only reveals it on hover.
+    private var isPinned: Bool { pane.customName?.isEmpty == false }
 
     /// Marks this pane focused — invoked when its content takes first-responder
     /// status (a click). Idempotent when already focused.
@@ -443,27 +484,39 @@ private struct PaneView: View {
 
     var body: some View {
         // Single-pane tabs render exactly as before splits existed — no ring,
-        // no handle — so nothing about the common case changes.
-        if showFocusRing {
-            content
-                // Deliberately no clip: masking an AppKit view forces an
-                // offscreen recomposite that flickers on live resize. The
-                // content background matches the surrounding gaps, so square
-                // content corners blend in and only the rounded stroke reads.
-                .overlay { focusRing }
-                .overlay(alignment: .top) {
-                    if allowsMove { moveHandle }
+        // no header — so nothing about the common case changes.
+        Group {
+            if showChrome, isPinned || isRenaming {
+                // A pinned header takes its own row: it must never sit over the
+                // terminal, where it would cover the top line of output.
+                VStack(spacing: 0) {
+                    header
+                    content
                 }
-                .overlay { dropHighlight }
-                .opacity(isMoveSource ? 0.55 : 1)
-                .background(frameReporter)
-        } else {
-            content
+            } else if showChrome {
+                // Unpinned, the header is an overlay in the terminal's own top
+                // padding — invisible until hovered, so it costs no space.
+                content.overlay(alignment: .top) {
+                    if allowsMove || isPinned { header }
+                }
+            } else {
+                content
+            }
         }
+        // Deliberately no clip: masking an AppKit view forces an offscreen
+        // recomposite that flickers on live resize. The content background
+        // matches the surrounding gaps, so square content corners blend in and
+        // only the rounded stroke reads.
+        .overlay { if showChrome { focusRing } }
+        .overlay { dropHighlight }
+        .opacity(isMoveSource ? 0.55 : 1)
+        // Reported even without chrome: a single-pane tab is still a legitimate
+        // target for a tab dragged onto it.
+        .background(frameReporter)
     }
 
-    /// Focuses this pane, then splits it — the context menu acts on the pane it
-    /// was opened over, not whatever held focus before.
+    /// Focuses this pane, then acts — the context menu acts on the pane it was
+    /// opened over, not whatever held focus before.
     private func splitFromMenu(_ edge: PaneDropEdge) {
         focus()
         onSplit(edge)
@@ -498,48 +551,99 @@ private struct PaneView: View {
             )
     }
 
-    /// Thin strip pinned to the pane's top edge — an absolutely-positioned grab
-    /// handle over the content — that you drag to move this pane onto another.
-    /// A grab bar fades in on hover so the zone is easy to find; the strip sits
-    /// in the terminal's own top padding, so it doesn't cover text. Global
-    /// coordinate space so the reported location survives the layout shifting.
-    private var moveHandle: some View {
-        Color.clear
-            .frame(height: handleHeight)
-            .frame(maxWidth: .infinity)
-            .overlay {
-                Image(systemName: "ellipsis")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.secondary)
-                    .opacity(isHandleHovered ? 0.9 : 0)
+    /// Strip across the pane's top edge showing its title, which doubles as the
+    /// grab handle for moving the pane and as the target for its context menu.
+    /// While the pane is unnamed it fades in on hover and sits over the
+    /// terminal's own top padding, so it costs no space and covers no text;
+    /// once named it is laid out above the content instead.
+    private var header: some View {
+        HStack(spacing: 5) {
+            if isRenaming {
+                PaneRenameField(
+                    initialValue: pane.customName ?? pane.content.title,
+                    commit: { tab.renamePane(pane.id, to: $0) },
+                    end: { isRenaming = false }
+                )
+            } else {
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.tertiary)
+                Text(pane.displayTitle)
+                    .font(.system(size: 10.5, weight: isPinned ? .medium : .regular))
+                    .foregroundStyle(isPinned ? .secondary : .tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
-            .contentShape(Rectangle())
-            // onContinuousHover (not onHover): re-assert the open hand on every
-            // move so it wins against the terminal re-setting its own cursor.
-            // On exit, reset explicitly — moving *up* off the handle lands in the
-            // gap, which has no cursor management to revert it otherwise. Both
-            // guarded by !isDragging so they never fight the drag cursor.
-            .onContinuousHover { phase in
-                switch phase {
-                case .active:
-                    isHandleHovered = true
-                    if !isDragging { NSCursor.openHand.set() }
-                case .ended:
-                    isHandleHovered = false
-                    if !isDragging { NSCursor.arrow.set() }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: headerHeight)
+        .frame(maxWidth: .infinity)
+        .background(headerBackground)
+        // The whole strip is grabbable, not just the text.
+        .contentShape(Rectangle())
+        // Visible only when it has something to say: a pinned name, a hover, or
+        // an in-flight rename. The shape stays hit-testable either way, so the
+        // invisible strip is still a grab handle exactly as it was at 8pt.
+        .opacity(isPinned || isHeaderHovered || isRenaming ? 1 : 0)
+        // onContinuousHover (not onHover): re-assert the open hand on every
+        // move so it wins against the terminal re-setting its own cursor.
+        // On exit, reset explicitly — moving *up* off the header lands in the
+        // gap, which has no cursor management to revert it otherwise. Both
+        // guarded by !isDragging so they never fight the drag cursor.
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                isHeaderHovered = true
+                if !isDragging, !isRenaming { NSCursor.openHand.set() }
+            case .ended:
+                isHeaderHovered = false
+                if !isDragging, !isRenaming { NSCursor.arrow.set() }
+            }
+        }
+        .contextMenu { headerMenu }
+        // Masked to .subviews while renaming so dragging in the text field
+        // selects text instead of carrying the pane off.
+        .gesture(
+            DragGesture(minimumDistance: 4, coordinateSpace: .global)
+                .onChanged { value in
+                    guard allowsMove else { return }
+                    isDragging = true
+                    onMove(value.location)
                 }
-            }
-            .gesture(
-                DragGesture(minimumDistance: 4, coordinateSpace: .global)
-                    .onChanged { value in
-                        isDragging = true
-                        onMove(value.location)
-                    }
-                    .onEnded { _ in
-                        isDragging = false
-                        onMoveEnded()
-                    }
-            )
+                .onEnded { _ in
+                    guard allowsMove else { return }
+                    isDragging = false
+                    onMoveEnded()
+                },
+            including: isRenaming ? .subviews : .all
+        )
+    }
+
+    @ViewBuilder
+    private var headerBackground: some View {
+        if isPinned || isHeaderHovered || isRenaming {
+            Rectangle().fill(Color.primary.opacity(isPinned ? 0.05 : 0.08))
+        }
+    }
+
+    @ViewBuilder
+    private var headerMenu: some View {
+        Button("Rename…") {
+            focus()
+            isRenaming = true
+        }
+        if isPinned {
+            Button("Use Automatic Title") { tab.renamePane(pane.id, to: nil) }
+        }
+        Divider()
+        Button("Move to New Tab", action: onExtract)
+            .disabled(!tab.hasMultiplePanes)
+        Divider()
+        Button("Split Right") { splitFromMenu(.right) }
+        Button("Split Down") { splitFromMenu(.bottom) }
+        Divider()
+        Button("Close Pane", action: onClose)
     }
 
     @ViewBuilder
@@ -580,6 +684,48 @@ private struct PaneView: View {
     }
 }
 
+/// Inline editor shown in the pane header while it's renamed — the same
+/// affordance as the tab strip's rename. Commits on Return or focus loss,
+/// cancels on Escape; an empty name returns the pane to its automatic title.
+private struct PaneRenameField: View {
+    let commit: (String?) -> Void
+    let end: () -> Void
+
+    @State private var draft: String
+    /// Set by the first commit/cancel so the focus-loss handler that fires
+    /// while the field is being torn down doesn't commit a second time.
+    @State private var finished = false
+    @FocusState private var focused: Bool
+
+    init(initialValue: String, commit: @escaping (String?) -> Void, end: @escaping () -> Void) {
+        self.commit = commit
+        self.end = end
+        _draft = State(initialValue: initialValue)
+    }
+
+    var body: some View {
+        TextField("", text: $draft)
+            .textFieldStyle(.plain)
+            .font(.system(size: 10.5))
+            .focused($focused)
+            .onSubmit { finish(apply: true) }
+            .onExitCommand { finish(apply: false) }
+            .onChange(of: focused) {
+                if !focused { finish(apply: true) }
+            }
+            .onAppear {
+                DispatchQueue.main.async { focused = true }
+            }
+    }
+
+    private func finish(apply: Bool) {
+        guard !finished else { return }
+        finished = true
+        if apply { commit(draft) }
+        end()
+    }
+}
+
 /// Mounts a session's find bar only while it is open, so a closed bar never
 /// sits over the terminal swallowing clicks. Separate from `PaneView` so that
 /// opening and closing it re-renders nothing but the overlay.
@@ -590,15 +736,6 @@ private struct TerminalFindOverlay: View {
         if find.isPresented {
             TerminalFindBar(find: find)
         }
-    }
-}
-
-/// Collects each pane's global-space frame so a move drag can hit-test the
-/// cursor against them.
-private struct PaneFramePreferenceKey: PreferenceKey {
-    static let defaultValue: [UUID: CGRect] = [:]
-    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
-        value.merge(nextValue()) { $1 }
     }
 }
 

--- a/kero/Panes.swift
+++ b/kero/Panes.swift
@@ -68,6 +68,18 @@ struct Pane: nonisolated Identifiable {
     /// Relative vertical share within its column. Ratios are what matter — the
     /// layout normalises against the column's total.
     var weight: CGFloat = 1
+    /// User-assigned pane name, shown in the pane's header strip; when nil the
+    /// header follows the content's own title — the same override scheme as
+    /// `PaneTab.customName` and `Project.customName`. A named pane keeps its
+    /// name when it is dragged elsewhere, and hands it to the tab it becomes
+    /// when dragged out to the strip.
+    var customName: String?
+
+    /// Header title: the assigned name when set, else the content's own.
+    @MainActor var displayTitle: String {
+        if let customName, !customName.isEmpty { return customName }
+        return content.title
+    }
 }
 
 /// A vertical stack of panes; columns tile left-to-right across the tab.
@@ -109,10 +121,21 @@ final class PaneTab: nonisolated ObservableObject, nonisolated Identifiable {
     weak var contextSession: TerminalSession?
 
     /// A fresh single-pane tab wrapping one piece of content.
-    init(content: PaneContent) {
-        let pane = Pane(content: content)
+    convenience init(content: PaneContent) {
+        self.init(pane: Pane(content: content))
+    }
+
+    /// A single-pane tab around an existing pane — how a pane dragged out of a
+    /// split layout becomes a tab of its own. The pane keeps its identity and
+    /// name; its weight resets since it now fills the tab alone.
+    init(pane: Pane) {
+        var pane = pane
+        pane.weight = 1
         columns = [PaneColumn(panes: [pane])]
         focusedPaneID = pane.id
+        // A named pane carries its name onto the tab, so the strip shows what
+        // the pane was called instead of reverting to the shell's title.
+        customName = pane.customName
     }
 
     /// Restores a saved layout.
@@ -133,7 +156,7 @@ final class PaneTab: nonisolated ObservableObject, nonisolated Identifiable {
     /// set, else the focused pane's own title.
     var displayTitle: String? {
         if let customName, !customName.isEmpty { return customName }
-        return focusedContent?.title
+        return focusedPane?.displayTitle
     }
 
     var sessions: [TerminalSession] {
@@ -277,6 +300,78 @@ final class PaneTab: nonisolated ObservableObject, nonisolated Identifiable {
             columns.insert(column, at: edge == .left ? to.col : to.col + 1)
         }
         focusedPaneID = moved.id
+    }
+
+    /// Renames a pane, or clears the name back to automatic when `name` is nil
+    /// or blank.
+    func renamePane(_ id: UUID, to name: String?) {
+        guard let (col, row) = location(of: id) else { return }
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        columns[col].panes[row].customName = (trimmed?.isEmpty ?? true) ? nil : trimmed
+    }
+
+    /// Lifts a pane out of this layout and hands it back to the caller, which
+    /// re-homes it (today: into a tab of its own). Nil when the tab holds only
+    /// that pane — there is nothing to extract it *from*, and dropping the last
+    /// pane would leave an empty tab behind.
+    func extractPane(_ id: UUID) -> Pane? {
+        guard hasMultiplePanes, let (col, row) = location(of: id) else { return nil }
+        let pane = columns[col].panes[row]
+        removePane(id)
+        return pane
+    }
+
+    /// Drops a whole layout — another tab's columns — next to `target` on the
+    /// given edge, the tab-onto-pane gesture. Left/right keeps the incoming
+    /// layout's own column structure, inserted beside the target's column;
+    /// top/bottom flattens it into the target's column, since a column is a
+    /// plain stack. Either way the arrivals share the half the target gives up,
+    /// in their original proportions. Focus lands on the first arrival.
+    func insert(_ incoming: [PaneColumn], _ edge: PaneDropEdge, of target: UUID) {
+        unzoom()
+        let panes = incoming.flatMap(\.panes)
+        guard !panes.isEmpty else { return }
+        guard let to = location(of: target) else {
+            columns.append(contentsOf: incoming)
+            focusedPaneID = panes[0].id
+            return
+        }
+
+        switch edge {
+        case .left, .right:
+            let share = columns[to.col].weight / 2
+            columns[to.col].weight = share
+            let scaled = scaled(incoming.map(\.weight), toTotal: share)
+            let arrivals = zip(incoming, scaled).map { column, weight -> PaneColumn in
+                var column = column
+                column.weight = weight
+                return column
+            }
+            columns.insert(contentsOf: arrivals, at: edge == .left ? to.col : to.col + 1)
+        case .top, .bottom:
+            let share = columns[to.col].panes[to.row].weight / 2
+            columns[to.col].panes[to.row].weight = share
+            let scaled = scaled(panes.map(\.weight), toTotal: share)
+            let arrivals = zip(panes, scaled).map { pane, weight -> Pane in
+                var pane = pane
+                pane.weight = weight
+                return pane
+            }
+            columns[to.col].panes.insert(
+                contentsOf: arrivals, at: edge == .top ? to.row : to.row + 1
+            )
+        }
+        focusedPaneID = panes[0].id
+    }
+
+    /// Rescales `weights` so they sum to `total`, keeping their proportions.
+    /// Falls back to equal shares when the input carries no usable total.
+    private func scaled(_ weights: [CGFloat], toTotal total: CGFloat) -> [CGFloat] {
+        let sum = weights.reduce(0, +)
+        guard sum > 0 else {
+            return weights.map { _ in total / CGFloat(max(weights.count, 1)) }
+        }
+        return weights.map { $0 / sum * total }
     }
 
     /// Removes the pane with `id`, dropping its column when it empties and

--- a/kero/Panes.swift
+++ b/kero/Panes.swift
@@ -112,6 +112,14 @@ final class PaneTab: nonisolated ObservableObject, nonisolated Identifiable {
     /// Deliberately not persisted.
     @Published var isZoomed = false
 
+    /// Set when something outside the pane — the command palette, the Info
+    /// panel — asks for the same inline rename the header's context menu
+    /// offers. The pane's header consumes and clears it, so a rename started
+    /// from anywhere lands in the same field with the same commit rules.
+    /// A single-pane tab has no header; its request goes to the strip instead
+    /// (see `Project.pendingRenameTabID`).
+    @Published var pendingRenamePaneID: UUID?
+
     /// The terminal whose directory this tab is oriented around when it holds
     /// no terminal of its own — captured from the focused session when a file
     /// or diff is opened into a fresh tab. Lets the file-tree / git / info

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -27,6 +27,10 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     @Published var customDirectory: String?
     @Published var tabs: [PaneTab] = []
     @Published var selectedTabID: UUID?
+    /// A tab whose strip item should open its inline rename field, requested
+    /// from outside the strip (the command palette, the Info panel). The strip
+    /// consumes and clears it. The pane-level counterpart lives on `PaneTab`.
+    @Published var pendingRenameTabID: UUID?
 
     private let fallbackName: String
     /// Sessions publish their own changes (title, directory); re-publish them
@@ -205,6 +209,60 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
 
     /// Whether the selected tab is showing a zoomed pane.
     var isPaneZoomed: Bool { selectedTab?.isZoomed ?? false }
+
+    // MARK: - Naming the focused pane
+
+    /// Every terminal in the project paired with the name its pane shows, for
+    /// listings that identify a shell by where it lives rather than by its
+    /// title alone. A pane in a split carries its own name; a pane that is its
+    /// whole tab is named by the tab, which is what the strip renames.
+    var namedSessions: [(session: TerminalSession, name: String?)] {
+        tabs.flatMap { tab in
+            tab.allPanes.compactMap { pane in
+                guard case .session(let session) = pane.content else { return nil }
+                return (session, tab.hasMultiplePanes ? pane.customName : tab.customName)
+            }
+        }
+    }
+
+    /// The name shown for the focused pane — and the place a rename of it
+    /// lands: the pane's own name inside a split, the tab's when the tab holds
+    /// a single pane. Keeping those the same field is what makes renaming from
+    /// the palette or the Info panel agree with renaming by hand, where a lone
+    /// pane is renamed through the tab strip and a split pane through its
+    /// header.
+    var focusedPaneName: String? {
+        guard let tab = selectedTab else { return nil }
+        return tab.hasMultiplePanes ? tab.focusedPane?.customName : tab.customName
+    }
+
+    /// The title the focused pane falls back to when it has no name.
+    var focusedPaneAutomaticTitle: String? {
+        selectedTab?.focusedContent?.title
+    }
+
+    /// Renames the focused pane, or clears the name back to automatic when
+    /// `name` is nil or blank.
+    func renameFocusedPane(to name: String?) {
+        guard let tab = selectedTab else { return }
+        if tab.hasMultiplePanes, let paneID = tab.focusedPane?.id {
+            tab.renamePane(paneID, to: name)
+        } else {
+            let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            tab.customName = (trimmed?.isEmpty ?? true) ? nil : trimmed
+        }
+    }
+
+    /// Opens the inline rename field on the focused pane — its header strip in
+    /// a split, its tab in the strip when it is the tab's only pane.
+    func beginRenamingFocusedPane() {
+        guard let tab = selectedTab else { return }
+        if tab.hasMultiplePanes {
+            tab.pendingRenamePaneID = tab.focusedPaneID
+        } else {
+            pendingRenameTabID = tab.id
+        }
+    }
 
     // MARK: - Moving panes between tabs
 

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -206,6 +206,54 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     /// Whether the selected tab is showing a zoomed pane.
     var isPaneZoomed: Bool { selectedTab?.isZoomed ?? false }
 
+    // MARK: - Moving panes between tabs
+
+    /// Pulls a pane out of `tab` into a tab of its own — the drag-a-pane-onto-
+    /// the-strip gesture — inserted at `index` in the strip (appended after the
+    /// source tab when nil) and selected. The pane keeps its content, so a
+    /// running shell is carried across rather than restarted. A no-op when the
+    /// pane is the tab's only one: it already *is* the whole tab.
+    func extractPane(_ paneID: UUID, from tab: PaneTab, at index: Int? = nil) {
+        guard let pane = tab.extractPane(paneID) else { return }
+        let newTab = register(PaneTab(pane: pane))
+        let fallback = tabs.firstIndex { $0.id == tab.id }.map { $0 + 1 } ?? tabs.count
+        tabs.insert(newTab, at: min(max(0, index ?? fallback), tabs.count))
+        selectedTabID = newTab.id
+    }
+
+    /// Whether a tab may be dropped into another tab's layout. Diffs keep their
+    /// own single-pane tab (their web view fills the tab), so neither side may
+    /// hold one.
+    func canMerge(_ tab: PaneTab, into target: PaneTab) -> Bool {
+        tab.id != target.id && tab.diffs.isEmpty && target.diffs.isEmpty
+    }
+
+    /// Moves every pane of the dragged tab into the tab holding `targetPaneID`,
+    /// splitting that pane on `edge`, then drops the emptied tab from the strip
+    /// — the drag-a-tab-onto-a-pane gesture. Nothing is torn down: the panes,
+    /// and the shells inside them, move across intact.
+    func mergeTab(_ draggedID: UUID, into targetPaneID: UUID, edge: PaneDropEdge) {
+        guard let dragged = tabs.first(where: { $0.id == draggedID }),
+              let target = tabs.first(where: { tab in
+                  tab.allPanes.contains { $0.id == targetPaneID }
+              }),
+              canMerge(dragged, into: target)
+        else { return }
+
+        var columns = dragged.columns
+        // A named single-pane tab hands its name down to the pane, so the label
+        // the user gave it survives as the pane's header title.
+        if let name = dragged.customName, columns.count == 1, columns[0].panes.count == 1,
+           columns[0].panes[0].customName == nil {
+            columns[0].panes[0].customName = name
+        }
+        // Detach before inserting: the panes are about to have a new home, so
+        // their sessions' observations must stay wired.
+        remove(tabID: dragged.id, keepingSessionObservations: true)
+        target.insert(columns, edge, of: targetPaneID)
+        selectedTabID = target.id
+    }
+
     // MARK: - Files
 
     /// Opens `path` as a new file tab, reusing an existing tab/pane for the
@@ -513,7 +561,8 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
                 let restoredHistory = paneSnap.historyKey.flatMap { histories[$0] }
                 panes.append(Pane(
                     content: makeContent(from: paneSnap.content, restoredHistory: restoredHistory),
-                    weight: CGFloat(paneSnap.weight)
+                    weight: CGFloat(paneSnap.weight),
+                    customName: paneSnap.customName
                 ))
             }
             guard !panes.isEmpty else { continue }
@@ -581,11 +630,16 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         }
     }
 
-    private func remove(tabID: UUID) {
+    /// Drops a tab from the strip. `keepingSessionObservations` is set when the
+    /// tab's panes are being re-homed rather than closed (a merge), so their
+    /// sessions keep re-publishing through the project.
+    private func remove(tabID: UUID, keepingSessionObservations: Bool = false) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         let tab = tabs[index]
-        for session in tab.sessions {
-            sessionObservations[session.id] = nil
+        if !keepingSessionObservations {
+            for session in tab.sessions {
+                sessionObservations[session.id] = nil
+            }
         }
         tabObservations[tabID] = nil
         tabs.remove(at: index)

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -157,6 +157,15 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
                 ?? customDirectory,
             restoredHistory: restoredHistory
         )
+        observe(session)
+        return session
+    }
+
+    /// Wires a session to this project: its exit closure and its change
+    /// re-publishing both point at whichever project currently holds it. Called
+    /// again on adoption, so a session that moves between projects reports its
+    /// exit to its new owner rather than the one that started it.
+    private func observe(_ session: TerminalSession) {
         session.onExited = { [weak self] session in
             // Already dead — just drop its pane, no second terminate.
             self?.closeContent(.session(session), terminate: false)
@@ -164,7 +173,6 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         sessionObservations[session.id] = session.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
-        return session
     }
 
     func terminateAll() {
@@ -271,12 +279,36 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     /// source tab when nil) and selected. The pane keeps its content, so a
     /// running shell is carried across rather than restarted. A no-op when the
     /// pane is the tab's only one: it already *is* the whole tab.
-    func extractPane(_ paneID: UUID, from tab: PaneTab, at index: Int? = nil) {
-        guard let pane = tab.extractPane(paneID) else { return }
+    @discardableResult
+    func extractPane(_ paneID: UUID, from tab: PaneTab, at index: Int? = nil) -> PaneTab? {
+        guard let pane = tab.extractPane(paneID) else { return nil }
         let newTab = register(PaneTab(pane: pane))
         let fallback = tabs.firstIndex { $0.id == tab.id }.map { $0 + 1 } ?? tabs.count
         tabs.insert(newTab, at: min(max(0, index ?? fallback), tabs.count))
         selectedTabID = newTab.id
+        return newTab
+    }
+
+    /// Hands a tab off to another project: drops it from the strip and clears
+    /// the bookkeeping it holds here, terminating nothing. The tab object — and
+    /// every shell inside it — lives on for `adopt(_:)` to take up.
+    func release(tabID: UUID) -> PaneTab? {
+        guard let tab = tabs.first(where: { $0.id == tabID }) else { return nil }
+        remove(tabID: tabID)
+        return tab
+    }
+
+    /// Takes in a tab released by another project. Re-wiring is the whole job:
+    /// each session's exit closure and change observation still point at the
+    /// project that made it, so without this a moved shell would report its
+    /// exit to the project it left.
+    func adopt(_ tab: PaneTab) {
+        for session in tab.sessions {
+            observe(session)
+        }
+        register(tab)
+        insertNextToSelected(tab)
+        selectedTabID = tab.id
     }
 
     /// Whether a tab may be dropped into another tab's layout. Diffs keep their

--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -64,7 +64,13 @@ struct RightSidebarView: View {
                             }
                         )
                     case .info:
-                        InfoPanel(model: info, session: manager.selectedSession)
+                        InfoPanel(
+                            model: info,
+                            session: manager.selectedSession,
+                            paneName: manager.focusedPaneName,
+                            paneAutomaticTitle: manager.focusedPaneAutomaticTitle,
+                            renamePane: { manager.renameFocusedPane(to: $0) }
+                        )
                     }
                 }
                 .frame(width: width)
@@ -1796,7 +1802,14 @@ private struct InfoPanel: View {
     @ObservedObject var model: SessionInfoModel
     @ObservedObject private var themeChanges = Theme.changes
     let session: TerminalSession?
+    /// The focused pane's assigned name, nil while its title is automatic.
+    var paneName: String?
+    /// The title that name overrides — shown as the field's placeholder, so
+    /// clearing the field visibly returns the pane to it.
+    var paneAutomaticTitle: String?
+    var renamePane: (String?) -> Void = { _ in }
 
+    @State private var nameCollapsed = false
     @State private var currentDirectoryCollapsed = false
     @State private var projectDirectoryCollapsed = false
     @State private var processesCollapsed = false
@@ -1810,6 +1823,7 @@ private struct InfoPanel: View {
             header
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 1) {
+                    nameSection
                     currentDirectorySection
                     projectDirectorySection
                     processesSection
@@ -1847,6 +1861,36 @@ private struct InfoPanel: View {
         .padding(.horizontal, 12)
         .padding(.top, 8)
         .padding(.bottom, 8)
+    }
+
+    // MARK: Name
+
+    /// The focused pane's name, editable in place. The same field the pane's
+    /// header and the tab strip offer, reachable without a right-click:
+    /// committing writes the name, emptying it returns the pane to its
+    /// automatic title (which stands in as the placeholder).
+    @ViewBuilder
+    private var nameSection: some View {
+        if let automatic = paneAutomaticTitle {
+            GitSectionHeader(
+                title: "NAME" + (paneName == nil ? " (AUTO)" : ""),
+                count: 0,
+                isCollapsed: $nameCollapsed, actions: [],
+                helpText: "The focused pane's name, shown in its header strip "
+                    + "and its tab. Leave it empty to follow the terminal's "
+                    + "own title instead."
+            )
+            if !nameCollapsed {
+                InfoNameField(
+                    name: paneName,
+                    placeholder: automatic,
+                    commit: renamePane
+                )
+                .padding(.horizontal, 9)
+                .padding(.top, 2)
+                .padding(.bottom, 10)
+            }
+        }
     }
 
     // MARK: Directories
@@ -2006,6 +2050,51 @@ private struct InfoPanel: View {
             .foregroundStyle(.tertiary)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
+    }
+}
+
+/// Text field for the focused pane's name. The draft is local while the field
+/// is being edited and re-synced from the model otherwise, so a name changed
+/// elsewhere (the pane header, the tab strip) shows here immediately without
+/// yanking text out from under someone mid-edit.
+private struct InfoNameField: View {
+    @ObservedObject private var themeChanges = Theme.changes
+    let name: String?
+    let placeholder: String
+    let commit: (String?) -> Void
+
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextField(placeholder, text: $draft)
+            .textFieldStyle(.plain)
+            .font(.system(size: 11))
+            .lineLimit(1)
+            .focused($focused)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.primary.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(
+                        focused
+                            ? Color(nsColor: Theme.accent).opacity(0.7)
+                            : Color.primary.opacity(0.08)
+                    )
+            )
+            .onSubmit { commit(draft) }
+            .onChange(of: focused) {
+                // Commit on the way out too, matching the header and strip
+                // fields — nothing is lost by clicking away.
+                if !focused { commit(draft) } else { draft = name ?? "" }
+            }
+            .onAppear { draft = name ?? "" }
+            .onChange(of: name) { if !focused { draft = name ?? "" } }
+            .onChange(of: placeholder) { if !focused { draft = name ?? "" } }
     }
 }
 

--- a/kero/SessionStore.swift
+++ b/kero/SessionStore.swift
@@ -29,6 +29,9 @@ struct SessionSnapshot: Codable {
             /// nil for files, diffs, or when history restore is off. Optional so
             /// snapshots written before this feature still decode.
             var historyKey: String?
+            /// User-assigned pane name shown in its header strip; nil when the
+            /// title is automatic. Optional so older snapshots still decode.
+            var customName: String?
         }
 
         struct ColumnSnapshot: Codable {

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SidebarView: View {
     @ObservedObject var manager: TerminalManager
     @ObservedObject private var themeChanges = Theme.changes
+    @EnvironmentObject private var dragging: PaneDragCoordinator
     @Environment(\.openSettings) private var openSettings
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("leftSidebarWidth") private var width: Double = 220
@@ -33,6 +34,7 @@ struct SidebarView: View {
                             select: { manager.selectedProjectID = project.id },
                             close: { manager.close(project) },
                             isDragging: draggedProjectID == project.id,
+                            isDropTarget: dragging.isDropTarget(project: project.id),
                             onDrag: { updateProjectDrag(source: project.id, location: $0) },
                             onDragEnded: endProjectDrag
                         )
@@ -111,7 +113,12 @@ struct SidebarView: View {
                 defaultWidth: 220
             )
         }
-        .onPreferenceChange(ProjectFramePreferenceKey.self) { projectFrames = $0 }
+        .onPreferenceChange(ProjectFramePreferenceKey.self) { frames in
+            projectFrames = frames
+            // Shared so a tab or pane dragged over from the header or the
+            // layout can hit-test these rows as a destination.
+            dragging.projectFrames = frames
+        }
     }
 
     private func updateProjectDrag(source: UUID, location: CGPoint) {
@@ -171,6 +178,9 @@ private struct SidebarProjectRow: View {
     let select: () -> Void
     let close: () -> Void
     let isDragging: Bool
+    /// A tab or pane is hovering over this row and would move into this
+    /// project on release.
+    var isDropTarget = false
     let onDrag: (CGPoint) -> Void
     let onDragEnded: () -> Void
 
@@ -198,8 +208,18 @@ private struct SidebarProjectRow: View {
         .opacity(isDragging ? 0.65 : 1)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Color.primary.opacity(0.09) : (isHovering ? Color.primary.opacity(0.04) : .clear))
+                .fill(isDropTarget
+                    ? Color(nsColor: Theme.accent).opacity(0.18)
+                    : (isSelected ? Color.primary.opacity(0.09) : (isHovering ? Color.primary.opacity(0.04) : .clear)))
         )
+        // Ring while it's the destination of a tab or pane being dragged in —
+        // the sidebar's echo of the half-pane highlight in the layout.
+        .overlay {
+            if isDropTarget {
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color(nsColor: Theme.accent), lineWidth: 2)
+            }
+        }
         .onHover { isHovering = $0 }
         .contextMenu {
             Button("Rename…") {

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -664,7 +664,8 @@ final class TerminalManager: nonisolated ObservableObject {
                                 return ProjectSnapshot.PaneSnapshot(
                                     content: Self.contentSnapshot(pane.content),
                                     weight: Double(pane.weight),
-                                    historyKey: historyKey
+                                    historyKey: historyKey,
+                                    customName: pane.customName
                                 )
                             },
                             weight: Double(column.weight)

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -438,6 +438,27 @@ final class TerminalManager: nonisolated ObservableObject {
     func focusNextPane() { selectedProject?.focusNextPane() }
     func focusPreviousPane() { selectedProject?.focusPreviousPane() }
 
+    /// The focused pane's name, the title it falls back to without one, and
+    /// the two ways to change it — read by the Info panel.
+    var focusedPaneName: String? { selectedProject?.focusedPaneName }
+    var focusedPaneAutomaticTitle: String? { selectedProject?.focusedPaneAutomaticTitle }
+    func renameFocusedPane(to name: String?) { selectedProject?.renameFocusedPane(to: name) }
+
+    /// Opens the inline rename field on the focused pane, wherever it lives —
+    /// the pane's header strip, or its tab in the strip when the tab holds a
+    /// single pane. Same field, same commit rules as renaming by hand.
+    func beginRenamingFocusedPane() {
+        // The palette is dismissed around this, and its focus restoration would
+        // put the terminal back as first responder a tick later — right on top
+        // of the rename field. Forget the displaced responder so it doesn't.
+        commandPalettePreviousResponder = nil
+        commandPaletteWindow = nil
+        selectedProject?.beginRenamingFocusedPane()
+    }
+
+    /// Whether there is a pane on screen to rename.
+    var canRenameFocusedPane: Bool { selectedProject?.selectedTab != nil }
+
     func togglePaneZoom() { selectedProject?.togglePaneZoom() }
     func equalizePanes() { selectedProject?.equalizePanes() }
     func resizePaneUp() { selectedProject?.resizePaneUp() }

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -324,6 +324,33 @@ final class TerminalManager: nonisolated ObservableObject {
         projects = reorderedProjects
     }
 
+    /// Moves a tab into another project — the drag onto a sidebar row. The tab
+    /// object itself makes the trip: the same panes, the same
+    /// `TerminalSession`s, the same shells and pids and scrollback, released by
+    /// one project and adopted by the other. Selection follows it, so the drop
+    /// shows its own result.
+    func moveTab(_ tabID: UUID, toProject projectID: UUID) {
+        guard let source = projects.first(where: { project in
+                  project.tabs.contains { $0.id == tabID }
+              }),
+              let destination = projects.first(where: { $0.id == projectID }),
+              source !== destination,
+              let tab = source.release(tabID: tabID)
+        else { return }
+        destination.adopt(tab)
+        selectedProjectID = destination.id
+    }
+
+    /// Moves a single pane into another project, by making it a tab of its own
+    /// first — the same extraction the tab strip performs — and handing that
+    /// tab over. A no-op for a pane that is already its whole tab; there the
+    /// tab itself is what you drag.
+    func movePane(_ paneID: UUID, toProject projectID: UUID) {
+        guard let project = selectedProject, let tab = project.selectedTab,
+              let extracted = project.extractPane(paneID, from: tab) else { return }
+        moveTab(extracted.id, toProject: projectID)
+    }
+
     func selectProject(index: Int) {
         guard projects.indices.contains(index) else { return }
         selectedProjectID = projects[index].id

--- a/kero/keroApp.swift
+++ b/kero/keroApp.swift
@@ -295,6 +295,12 @@ private struct KeroCommands: Commands {
             .keyboardShortcut(.return, modifiers: [.command, .shift])
             .disabled(manager?.hasSplitPanes != true)
 
+            Button("Rename Pane…") {
+                manager?.beginRenamingFocusedPane()
+            }
+            .keyboardShortcut("r", modifiers: [.command, .control])
+            .disabled(manager?.canRenameFocusedPane != true)
+
             Button("Equalize Panes") {
                 manager?.equalizePanes()
             }


### PR DESCRIPTION
_First public PR, bear with me_

Closes #29

## What this does

- Panes can be dragged to and from three destinations:
  - **Another pane** — splits it on the hovered edge
  - **The tab strip** — the pane becomes a tab of its own; dragging a tab back onto a pane folds it into that layout as a split
  - **A project row in the sidebar** — the tab moves into that project
- The pane's grab strip becomes a header showing the pane's name, which you can set from the header, the Info panel, or ⌃⌘R
- The command palette shows both the session title and the pane's name
- Nothing restarts: moving a pane or tab carries the same shell, pid and
  scrollback with it

## Why

Once a split has served its purpose there's no way to promote a pane to a tab, or fold a tab back into a layout, without closing a shell and starting another one somewhere else.

## Verification

Built and run against current `main`; exercised each drag direction, renaming from all three entry points, and a relaunch to confirm names and layouts restore.

Written with Claude Code; I directed the design, reviewed the changes, and tested them in the app. 

I noticed a `CHANGELOG.md` but I left out any edits to that since that file looks like yours to write.

<img width="967" height="176" alt="Kero Debug 2026-07-25 05 16 12" src="https://github.com/user-attachments/assets/8ed1609c-ac92-48ad-bbcd-e6e0adfe8011" />


<img width="968" height="199" alt="Kero Debug 2026-07-25 05 21 06" src="https://github.com/user-attachments/assets/99470b48-6e9d-428e-b1f2-c7953f144381" />
