### PR TITLE
feat[panes]: add focus ring toggle and opacity setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ set in the Xcode project.
 
 ## [unrelease]
 
+- Add Settings → Panes controls for the split-pane focus ring: toggle it off, or dial opacity (`panes.show-focus-ring`, `panes.focus-ring-opacity` in config.toml)
 - The Processes list no longer shows `<defunct>` entries: those are exited children waiting to be reaped, not something you can see output from or kill
 - Opening a large diff no longer freezes the window: diffs render only the rows on screen and highlight them off the main thread
 - The font setting now applies to the diff viewer too, so diffs match the terminal and the editor

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -32,6 +32,10 @@ final class AppSettings: nonisolated ObservableObject {
     static let defaultFontSize: Double = 13
     static let fontSizeRange: ClosedRange<Double> = 8...32
 
+    /// Default matches the pre-setting focus ring (accent @ 85% opacity).
+    static let defaultPaneFocusRingOpacity: Double = 0.85
+    static let paneFocusRingOpacityRange: ClosedRange<Double> = 0.05...1
+
     /// Light/dark appearance override; `system` follows macOS.
     @Published var theme: AppTheme {
         didSet {
@@ -87,6 +91,19 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Draw an accent focus ring around the active pane in a split layout.
+    /// On by default so multi-pane focus stays obvious; turn off for a
+    /// quieter look when the caret/cursor is enough.
+    @Published var showPaneFocusRing: Bool {
+        didSet { save() }
+    }
+
+    /// Opacity of the focused pane's accent ring (unfocused hairlines stay
+    /// faint). Only used while `showPaneFocusRing` is on.
+    @Published var paneFocusRingOpacity: Double {
+        didSet { save() }
+    }
+
     private init() {
         let existing = TOML.parse(at: Self.configURL)
         let toml = existing ?? Self.legacyDefaults()
@@ -103,9 +120,22 @@ final class AppSettings: nonisolated ObservableObject {
         fontThicken = toml["font-thicken"]?.bool ?? false
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
+        showPaneFocusRing = toml["panes.show-focus-ring"]?.bool ?? true
+        let opacity = toml["panes.focus-ring-opacity"]?.double
+            ?? Self.defaultPaneFocusRingOpacity
+        paneFocusRingOpacity = Self.paneFocusRingOpacityRange.contains(opacity)
+            ? opacity
+            : Self.defaultPaneFocusRingOpacity
         applyAppearance()
         reloadThemeSelection()
         if existing == nil { save() }
+    }
+
+    /// Slider steps are not always bit-exact with the default; compare as
+    /// whole-percent so Reset / sparse save treat 85% as the default.
+    static func paneFocusRingOpacityMatchesDefault(_ value: Double) -> Bool {
+        Int((value * 100).rounded())
+            == Int((defaultPaneFocusRingOpacity * 100).rounded())
     }
 
     /// Pushes the current names into `Theme`, which resolves and caches the
@@ -144,6 +174,8 @@ final class AppSettings: nonisolated ObservableObject {
         themeLight = Theme.defaultLightThemeName
         wrapLines = false
         restoreTerminalHistory = false
+        showPaneFocusRing = true
+        paneFocusRingOpacity = Self.defaultPaneFocusRingOpacity
     }
 
     private func save() {
@@ -171,6 +203,15 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if restoreTerminalHistory {
             lines.append("terminal.restore-history = true")
+        }
+        // Default is on; only persist the opt-out.
+        if !showPaneFocusRing {
+            lines.append("panes.show-focus-ring = false")
+        }
+        if !Self.paneFocusRingOpacityMatchesDefault(paneFocusRingOpacity) {
+            lines.append(
+                "panes.focus-ring-opacity = \(TOML.number(paneFocusRingOpacity))"
+            )
         }
         let dir = Self.configURL.deletingLastPathComponent()
         do {

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -98,8 +98,10 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
-    /// Opacity of the focused pane's accent ring (unfocused hairlines stay
-    /// faint). Only used while `showPaneFocusRing` is on.
+    /// Opacity of the focused pane's accent ring. Unfocused hairlines stay
+    /// faint whether the accent ring is on or off — they're the pane delimiter
+    /// when a TUI background fills the gap. Only used while
+    /// `showPaneFocusRing` is on.
     @Published var paneFocusRingOpacity: Double {
         didSet { save() }
     }

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -492,21 +492,19 @@ private struct PaneView: View {
         }
     }
 
-    @ViewBuilder
     private var focusRing: some View {
-        // Settings can hide the ring or dial its opacity; move handle and drop
-        // highlight still work so split chrome stays usable without a loud
-        // accent outline.
-        if settings.showPaneFocusRing {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .strokeBorder(
-                    isFocused
-                        ? Color(nsColor: Theme.accent)
-                            .opacity(settings.paneFocusRingOpacity)
-                        : Color.primary.opacity(0.06),
-                    lineWidth: isFocused ? 1.5 : 1
-                )
-        }
+        // Settings can hide the accent ring or dial its opacity; the faint
+        // unfocused hairline stays either way — it's the only thing delimiting
+        // adjacent panes once a TUI's background bleeds into the gap.
+        let ringed = isFocused && settings.showPaneFocusRing
+        return RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .strokeBorder(
+                ringed
+                    ? Color(nsColor: Theme.accent)
+                        .opacity(settings.paneFocusRingOpacity)
+                    : Color.primary.opacity(0.06),
+                lineWidth: ringed ? 1.5 : 1
+            )
     }
 
     /// Thin strip pinned to the pane's top edge — an absolutely-positioned grab

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -65,12 +65,13 @@ struct PaneLayoutView: View {
             if tab.isZoomed, tab.hasMultiplePanes, let pane = tab.focusedPane {
                 // Zoom: the focused pane alone, filling the tab. The grid — and
                 // with it the dividers and the other panes — unmounts, exactly
-                // like an unselected tab's layout; the focus ring stays as the
-                // hint that a split layout is hiding underneath.
+                // like an unselected tab's layout; the focus ring (when enabled
+                // in Settings) stays as the hint that a split layout is hiding
+                // underneath. The header zoom control remains either way.
                 PaneView(
                     tab: tab,
                     pane: pane,
-                    showFocusRing: true,
+                    showSplitChrome: true,
                     allowsMove: false,
                     isMoveSource: false,
                     dropEdge: nil,
@@ -157,7 +158,7 @@ struct PaneLayoutView: View {
                 PaneView(
                     tab: tab,
                     pane: pane,
-                    showFocusRing: tab.hasMultiplePanes,
+                    showSplitChrome: tab.hasMultiplePanes,
                     allowsMove: true,
                     isMoveSource: paneDrag?.sourceID == pane.id,
                     dropEdge: paneDrag?.targetID == pane.id ? paneDrag?.edge : nil,
@@ -402,14 +403,17 @@ private struct ResizableDivider: View {
 }
 
 /// One tile: hosts its content and, when the tab holds more than one pane,
-/// draws a focus ring (accent for the focused pane, faint otherwise), a thin
-/// top strip you can grab to move the pane onto another, and a highlight while
-/// it's the drop target.
+/// draws optional focus chrome (accent for the focused pane, faint otherwise),
+/// a thin top strip you can grab to move the pane onto another, and a
+/// highlight while it's the drop target.
 private struct PaneView: View {
     @ObservedObject var tab: PaneTab
     @ObservedObject private var themeChanges = Theme.changes
+    @ObservedObject private var settings = AppSettings.shared
     let pane: Pane
-    let showFocusRing: Bool
+    /// Multi-pane chrome (move handle, drop target, optional focus ring).
+    /// Single-pane tabs leave this off so they stay full-bleed.
+    let showSplitChrome: Bool
     /// Whether the top grab strip is offered at all — false while zoomed,
     /// where there is no other pane on screen to drop onto.
     let allowsMove: Bool
@@ -444,7 +448,7 @@ private struct PaneView: View {
     var body: some View {
         // Single-pane tabs render exactly as before splits existed — no ring,
         // no handle — so nothing about the common case changes.
-        if showFocusRing {
+        if showSplitChrome {
             content
                 // Deliberately no clip: masking an AppKit view forces an
                 // offscreen recomposite that flickers on live resize. The
@@ -488,14 +492,21 @@ private struct PaneView: View {
         }
     }
 
+    @ViewBuilder
     private var focusRing: some View {
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
-            .strokeBorder(
-                isFocused
-                    ? Color(nsColor: Theme.accent).opacity(0.85)
-                    : Color.primary.opacity(0.06),
-                lineWidth: isFocused ? 1.5 : 1
-            )
+        // Settings can hide the ring or dial its opacity; move handle and drop
+        // highlight still work so split chrome stays usable without a loud
+        // accent outline.
+        if settings.showPaneFocusRing {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(
+                    isFocused
+                        ? Color(nsColor: Theme.accent)
+                            .opacity(settings.paneFocusRingOpacity)
+                        : Color.primary.opacity(0.06),
+                    lineWidth: isFocused ? 1.5 : 1
+                )
+        }
     }
 
     /// Thin strip pinned to the pane's top edge — an absolutely-positioned grab

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -105,6 +105,31 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Panes") {
+                Toggle(
+                    "Show focus ring on active pane",
+                    isOn: $settings.showPaneFocusRing
+                )
+                Text("Draws an accent outline around the focused pane when a tab is split.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Text("Focus ring opacity")
+                    Slider(
+                        value: $settings.paneFocusRingOpacity,
+                        in: AppSettings.paneFocusRingOpacityRange,
+                        step: 0.05
+                    )
+                    .disabled(!settings.showPaneFocusRing)
+                    Text("\(Int((settings.paneFocusRingOpacity * 100).rounded()))%")
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(width: 40, alignment: .trailing)
+                }
+                .foregroundStyle(settings.showPaneFocusRing ? .primary : .secondary)
+            }
+
             Section("Text Editing") {
                 Toggle("Wrap lines to editor width", isOn: $settings.wrapLines)
             }
@@ -134,7 +159,11 @@ struct SettingsView: View {
                         && settings.themeDark == Theme.defaultDarkThemeName
                         && settings.themeLight == Theme.defaultLightThemeName
                         && !settings.wrapLines
-                        && !settings.restoreTerminalHistory)
+                        && !settings.restoreTerminalHistory
+                        && settings.showPaneFocusRing
+                        && AppSettings.paneFocusRingOpacityMatchesDefault(
+                            settings.paneFocusRingOpacity
+                        ))
                 }
             }
         }


### PR DESCRIPTION
## What

Settings → **Panes** controls the accent outline on the focused pane in a split:

- **Show focus ring on active pane** — off removes the ring (move handle / drop chrome stay)
- **Focus ring opacity** — 5%–100%, default 85% (previous hardcoded value)

## Why

With multiple panes the accent ring can feel loud on some themes; turning it fully off loses the focus cue. Opacity lets you keep a quieter indicator.

## Config (`~/.config/kero/config.toml`)

```toml
panes.show-focus-ring = false
panes.focus-ring-opacity = 0.4
```

Defaults match prior behavior when unset.

## How

- `AppSettings`: load/save/reset for both keys (sparse TOML)
- `PaneLayoutView`: observes settings; renames `showFocusRing` → `showSplitChrome` so multi-pane chrome is not confused with the optional ring
- CHANGELOG under `[unrelease]`

## Testing

- Split (`⌘D`): ring at 85%
- Opacity slider updates the ring live
- Toggle off → no ring; drag-to-move still works
- Reset to Defaults restores on + 85%