### PR TITLE
Release background panes' GPU memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ set in the Xcode project.
 - The Processes list no longer shows `<defunct>` entries: those are exited children waiting to be reaped, not something you can see output from or kill
 - Opening a large diff no longer freezes the window: diffs render only the rows on screen and highlight them off the main thread
 - The font setting now applies to the diff viewer too, so diffs match the terminal and the editor
+- Background panes no longer hold on to their GPU memory: a window with a dozen sessions used to keep a full-size render buffer for every one of them, whether or not it was on screen. Those buffers are now released when a pane is parked and rebuilt when you switch back to it — sessions keep running, and titles, bells, and exits still land while a pane is hidden
 
 ## [0.1.25]
 

--- a/kero/TerminalHostView.swift
+++ b/kero/TerminalHostView.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import GhosttyTerminal
 import SwiftUI
 
 /// Hosts a session's long-lived Ghostty terminal view in SwiftUI,
@@ -26,6 +27,8 @@ struct TerminalHostView: NSViewRepresentable {
         container.terminal = session.terminalView
         container.focusOnAppear = isFocused
         let terminal = session.terminalView
+        // Coming out of parking: let the renderer draw again.
+        terminal.setSurfaceVisible(true)
         terminal.onBecomeFirstResponder = onFocused
         terminal.splitTarget.onSplit = onSplit
         let scrollbar = session.overlayScrollbar
@@ -55,6 +58,7 @@ struct TerminalHostView: NSViewRepresentable {
     }
 
     func updateNSView(_ view: NSView, context: Context) {
+        session.terminalView.setSurfaceVisible(true)
         session.terminalView.onBecomeFirstResponder = onFocused
         session.terminalView.splitTarget.onSplit = onSplit
         let container = view as? TerminalContainerView
@@ -118,6 +122,12 @@ final class TerminalParkingContainerView: NSView {
 
         for session in sessions {
             let terminal = session.terminalView
+            // Parked panes stay attached at full size so the grid survives
+            // unparking, but nothing composites them. Marking them occluded
+            // lets libghostty drop the renderer's pane-sized IOSurfaces
+            // (~20 MB each) while `shouldProcessWakeup` — gated on attachment,
+            // not visibility — keeps title/bell/exit events draining.
+            terminal.setSurfaceVisible(false)
             guard terminal.superview !== self else { continue }
             let parkedSize = terminal.frame.size
             if terminal.window?.firstResponder === terminal {


### PR DESCRIPTION
## Problem

A window with a dozen sessions held a full-size render buffer for every one of them, whether or not it was on screen.

`TerminalParkingContainerView` deliberately keeps off-screen terminals attached at their last frame size, so the grid survives unparking and libghostty keeps draining process/title/bell events. But nothing ever told libghostty those panes were not visible, so each kept its pane-sized IOSurfaces pinned and non-purgeable.

Profiling the running app after 25 hours (13 panes, 9 live shells):

| | |
|---|---|
| phys_footprint | 868 MB (peak 1013 MB) |
| **IOSurface** | **499 MB — 57%** |
| pane-sized buffers | 31, triple-buffered at ~20 MB each |
| non-purgeable | 68 of 72 surfaces `PURGE=N` |

`ps` RSS reports 293 MB and hides all of this; IOSurface is shared memory counted in `phys_footprint`, which is what Activity Monitor shows.

## Change

Drive occlusion from the park/host transition in `TerminalHostView` — parked panes drop their render surfaces, hosting one brings it back.

That needs a paired change in libghostty-spm (egoist-labs/libghostty-spm#1, already merged and pointed to here). `shouldProcessWakeup` was gated on `canRenderFrame`, so occluding a surface *also* stopped its `ghostty_app_tick` — a parked pane would have gone silent, which is precisely what parking exists to prevent. It is now gated on attachment: occluded-but-attached surfaces still drain events, only drawing stops.

## Result

12 sessions, one visible:

| | before | after |
|---|---|---|
| pane-sized IOSurfaces | 31 | **2** |
| IOSurface total | 499 MB | **61 MB** |

## Verification

Built, run, and exercised against the real app:

- terminals render when visible; switching tabs unparks and repaints from ghostty's own grid — no blank or stale frame, and no `SIGWINCH`, since parked panes keep their size
- killing a parked session's shell still closes its pane (12 → 11 views) — child-exit drains while occluded
- `OSC 0` sent to parked ttys retitled four parked projects in the sidebar
- ~1 MB written into each of four parked panes' ttys drained in under 4s with no write blocking, and the app still held only 2 pane-sized surfaces afterward

The tty test is the one that matters for background agents: if a parked pane stopped reading, the ~64 KB pipe buffer would fill and a long-running process in a hidden tab would block on write. It doesn't — an agent in a background tab keeps running, it just stops being drawn.

Version left alone per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)