### PR TITLE
Correct the background-pane GPU memory claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ set in the Xcode project.
 - The Processes list no longer shows `<defunct>` entries: those are exited children waiting to be reaped, not something you can see output from or kill
 - Opening a large diff no longer freezes the window: diffs render only the rows on screen and highlight them off the main thread
 - The font setting now applies to the diff viewer too, so diffs match the terminal and the editor
-- Background panes no longer hold on to their GPU memory: a window with a dozen sessions used to keep a full-size render buffer for every one of them, whether or not it was on screen. Those buffers are now released when a pane is parked and rebuilt when you switch back to it — sessions keep running, and titles, bells, and exits still land while a pane is hidden
+- Terminal panes each hold one less full-size render buffer, so a window you have opened a lot of sessions in uses about a third less GPU memory. Background panes also stop drawing altogether: a hidden session keeps running and its titles, bells, and exits still arrive, it just no longer spends GPU time on frames nobody can see
 
 ## [0.1.25]
 


### PR DESCRIPTION
Follow-up to #36, which overstated what it did in the release notes.

## What was wrong

The note claimed parked panes' render buffers "are now released when a pane is parked and rebuilt when you switch back to it". They are not. `ghostty_surface_set_occlusion` stops the renderer from drawing; it does not free its IOSurfaces.

Measured after the change, visiting projects one at a time:

| panes visited | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|---|---|---|---|---|---|---|
| pane-sized surfaces | 2 | 4 | 6 | 8 | 10 | 12 | 14 |

Monotonic, +2 per pane, unchanged after idling. All 14 are `PURGE=N` and fully resident, so the kernel cannot reclaim them under pressure either. Pane GPU memory scales with panes **visited**, not panes **visible**.

The 31 → 2 figure in #36 came from comparing a 25-hour-old session against a cold start, where most panes had never rendered — those cost nothing before the change either.

## What #36 actually delivers

Still worth having, just smaller:

- `maximumDrawableCount = 2` — verified as +2 per pane rather than +3, so about a third less pane GPU memory, permanently
- hidden panes stop drawing entirely — a CPU/GPU/battery win

The correctness work in #36 is unaffected: parked panes still drain their PTY without blocking, and still deliver titles, bells, and child-exit. Those were tested directly against a running app.

## Not fixed here

Actually reclaiming a parked pane's surfaces needs libghostty's renderer to release on occlusion, which is Zig-side inside the prebuilt xcframework. The only wrapper-side lever is shrinking a parked pane's `setSize`, which forces a grid resize and `SIGWINCH` on both park and unpark — the TUI reflow parking exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)