### PR TITLE
Note the restore-time win in the GPU memory entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ set in the Xcode project.
 - The Processes list no longer shows `<defunct>` entries: those are exited children waiting to be reaped, not something you can see output from or kill
 - Opening a large diff no longer freezes the window: diffs render only the rows on screen and highlight them off the main thread
 - The font setting now applies to the diff viewer too, so diffs match the terminal and the editor
-- Terminal panes each hold one less full-size render buffer, so a window you have opened a lot of sessions in uses about a third less GPU memory. Background panes also stop drawing altogether: a hidden session keeps running and its titles, bells, and exits still arrive, it just no longer spends GPU time on frames nobody can see
+- Kero no longer draws sessions you are not looking at. Reopening a window full of sessions used to render every one of them straight away, holding a full-size GPU buffer for each whether or not you ever opened it — now only the panes you actually view take one, and each takes one buffer less than before. Hidden sessions keep running, and their titles, bells, and exits still arrive
 
 ## [0.1.25]
 


### PR DESCRIPTION
#37 removed a false claim but replaced it with an understated one. There are two distinct effects in #36, and the previous two passes each described the wrong one.

## The effect that was missed

Before #36, **every parked session rendered on attach**. Parked panes are attached to the window, and `isDisplayVisible` defaulted to `true`, so `canRenderFrame` held for all of them. Reopening a window allocated a full-size render buffer for every restored session — viewed or not. That is the dominant cost, and #36 removes it.

A/B on an identical 5-session restore:

| | occlusion disabled (pre-fix behaviour) | with fix |
|---|---|---|
| panes restored | 5 | 5 |
| pane-sized surfaces | 10 | **2** |
| IOSurface | 149 MB | **61 MB** |
| footprint | 304 MB | 217 MB |

The disabled build still carried `maximumDrawableCount = 2`, so the true original would have been 15 surfaces (~224 MB) for those 5 panes.

## Corrected model

- **before:** memory ∝ *total sessions* × 3 buffers
- **after:** memory ∝ *sessions actually viewed* × 2 buffers

The saving is everything you never open. #37's finding still stands — a pane you *have* viewed keeps its surfaces until it is closed, since `setOcclusion` stops drawing without releasing the renderer's swap chain — but that is the smaller half of the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)