### PR TITLE
Separate the two hidden-pane cases in the GPU memory entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ set in the Xcode project.
 - The Processes list no longer shows `<defunct>` entries: those are exited children waiting to be reaped, not something you can see output from or kill
 - Opening a large diff no longer freezes the window: diffs render only the rows on screen and highlight them off the main thread
 - The font setting now applies to the diff viewer too, so diffs match the terminal and the editor
-- Kero no longer draws sessions you are not looking at. Reopening a window full of sessions used to render every one of them straight away, holding a full-size GPU buffer for each whether or not you ever opened it — now only the panes you actually view take one, and each takes one buffer less than before. Hidden sessions keep running, and their titles, bells, and exits still arrive
+- Sessions you never open no longer cost any GPU memory. Reopening a window used to draw every restored session straight away, holding a full-size buffer for each whether you looked at it or not; now a pane claims one only when you first view it, and claims one buffer less than before. A pane you have already viewed keeps its buffer until you close it — switching away stops it drawing, but does not hand the memory back. Either way a hidden session keeps running, and its titles, bells, and exits still arrive
 
 ## [0.1.25]
 


### PR DESCRIPTION
Follow-up to #38. The entry still read as though hiding a pane returns its memory. Two different things are going on and they behave oppositely:

| | before #36 | after #36 |
|---|---|---|
| restored session you never open | renders on attach, full-size buffer | **nothing allocated** |
| session you viewed, then switched away from | keeps buffer, keeps drawing | keeps buffer, **stops drawing** |

The first case is where the win is: parked panes are attached, and `isDisplayVisible` defaulted to `true`, so `canRenderFrame` held for every restored session and each one allocated on attach.

The second case allocates on first view and holds until the pane closes. `ghostty_surface_set_occlusion` suppresses drawing without releasing the renderer's swap chain, and those surfaces are `PURGE=N`, so the kernel cannot reclaim them under pressure either. Measured by visiting panes one at a time: 2, 4, 6, 8, 10, 12, 14 surfaces, monotonic, unchanged on idle. Closing a viewed pane returns exactly its 2; closing a never-viewed one returns nothing.

Reworded to state both, including the second one's limitation rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)