### PR TITLE
Order the Ctrl-Tab switcher by recent use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the original feature bullet instead of adding separate entries for them.
 
 - Add per-pane live titles and split controls in split layouts
 - Splitting a pane now divides only the focused pane, preserving the size of neighboring panes in nested layouts
+- The Ctrl-Tab switcher now lists tabs in the order you last used them and opens already pointing at the previous tab, so a quick Ctrl-Tab flips between the two tabs you're working in
 
 ## [0.1.34]
 

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -26,7 +26,18 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     /// moves (see `panelRoot(followingSessionAt:)`).
     @Published var customDirectory: String?
     @Published var tabs: [PaneTab] = []
-    @Published var selectedTabID: UUID?
+    @Published var selectedTabID: UUID? {
+        didSet {
+            guard selectedTabID != oldValue, let selectedTabID else { return }
+            recentTabIDs.removeAll { $0 == selectedTabID }
+            recentTabIDs.insert(selectedTabID, at: 0)
+        }
+    }
+
+    /// Tab IDs newest-used first. Kept here rather than in the switcher
+    /// because every way of reaching a tab — strip click, Ctrl-number,
+    /// opening a file — counts as a use.
+    private var recentTabIDs: [UUID] = []
 
     private let fallbackName: String
     /// Sessions publish their own changes (title, directory); re-publish them
@@ -76,6 +87,32 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
 
     var selectedTab: PaneTab? {
         tabs.first { $0.id == selectedTabID }
+    }
+
+    /// Tabs by recency of use, selected first. Tabs not yet selected this
+    /// session trail in strip order, so the sequence covers every tab even
+    /// before any switching has happened.
+    var tabsByRecency: [PaneTab] {
+        var seen = Set<UUID>()
+        var ordered: [PaneTab] = []
+        func add(_ tab: PaneTab) {
+            guard seen.insert(tab.id).inserted else { return }
+            ordered.append(tab)
+        }
+        if let selectedTab { add(selectedTab) }
+        for id in recentTabIDs {
+            guard let tab = tabs.first(where: { $0.id == id }) else { continue }
+            add(tab)
+        }
+        tabs.forEach(add)
+        return ordered
+    }
+
+    /// Drops recorded recency, leaving strip order behind the selected tab.
+    /// Restoring a window selects each tab as it is rebuilt; without this the
+    /// order would just mirror the rebuild.
+    func resetRecency() {
+        recentTabIDs = selectedTabID.map { [$0] } ?? []
     }
 
     /// Content of the focused pane in the selected tab.
@@ -725,6 +762,7 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
             browserObservations[browser.id] = nil
         }
         tabObservations[tabID] = nil
+        recentTabIDs.removeAll { $0 == tabID }
         tabs.remove(at: index)
         if selectedTabID == tabID {
             let neighbor = min(index, tabs.count - 1)

--- a/kero/TabSwitcherView.swift
+++ b/kero/TabSwitcherView.swift
@@ -15,6 +15,9 @@ final class TabSwitcherController: ObservableObject {
     @Published private(set) var isPresented = false
     @Published private(set) var highlightedTabID: UUID?
     @Published private(set) var terminalPreviews: [UUID: String] = [:]
+    /// Recency order captured when the switcher opened, frozen for the whole
+    /// gesture so cards never reshuffle under the highlight.
+    @Published private(set) var orderedTabIDs: [UUID] = []
 
     private weak var activeProject: Project?
     private var originalTabID: UUID?
@@ -125,6 +128,14 @@ final class TabSwitcherController: ObservableObject {
         highlightedTabID = tabID
     }
 
+    /// The tabs the overlay draws, in the order this gesture walks them.
+    func orderedTabs(in project: Project) -> [PaneTab] {
+        let ordered = orderedTabIDs.compactMap { id in
+            project.tabs.first { $0.id == id }
+        }
+        return ordered.isEmpty ? project.tabs : ordered
+    }
+
     private func cycle(in manager: TerminalManager, reverse: Bool) -> Bool {
         guard let project = manager.selectedProject,
               project.tabs.count > 1,
@@ -135,7 +146,10 @@ final class TabSwitcherController: ObservableObject {
             previewTask?.cancel()
             activeProject = project
             originalTabID = selectedID
-            highlightedTabID = selectedID
+            orderedTabIDs = project.tabsByRecency.map(\.id)
+            // Open already pointing at the previously used tab, so one
+            // Ctrl-Tab toggles between the last two tabs like Cmd-Tab does.
+            highlightedTabID = orderedTabIDs[reverse ? orderedTabIDs.count - 1 : 1]
             acceptsPointerHighlight = false
             let validContentIDs = Set(project.tabs.flatMap(\.allContents).map(\.id))
             terminalPreviews = terminalPreviews.filter {
@@ -148,18 +162,15 @@ final class TabSwitcherController: ObservableObject {
             return true
         }
 
+        let order = orderedTabs(in: project).map(\.id)
         guard let currentHighlightedTabID = highlightedTabID,
-              let currentIndex = project.tabs.firstIndex(
-                where: { $0.id == currentHighlightedTabID }
-              )
+              let currentIndex = order.firstIndex(of: currentHighlightedTabID)
         else {
             cancel()
             return false
         }
         let offset = reverse ? -1 : 1
-        let nextIndex = (currentIndex + offset + project.tabs.count) % project.tabs.count
-        let nextTab = project.tabs[nextIndex]
-        highlightedTabID = nextTab.id
+        highlightedTabID = order[(currentIndex + offset + order.count) % order.count]
         return true
     }
 
@@ -324,7 +335,8 @@ struct TabSwitcherOverlay: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let columnCount = columnsPerRow(available: geometry.size.width)
+            let tabs = controller.orderedTabs(in: project)
+            let columnCount = columnsPerRow(count: tabs.count, available: geometry.size.width)
 
             ZStack {
                 Color.clear
@@ -338,11 +350,10 @@ struct TabSwitcherOverlay: View {
                             alignment: .leading,
                             spacing: TabSwitcherLayout.gridSpacing
                         ) {
-                            ForEach(Array(project.tabs.enumerated()), id: \.element.id) {
-                                index, tab in
+                            ForEach(tabs, id: \.id) { tab in
                                 TabSwitcherCard(
                                     tab: tab,
-                                    index: index,
+                                    index: project.tabs.firstIndex { $0.id == tab.id } ?? 0,
                                     isHighlighted: tab.id == controller.highlightedTabID,
                                     terminalPreviews: controller.terminalPreviews,
                                     highlight: {
@@ -360,6 +371,7 @@ struct TabSwitcherOverlay: View {
                     .frame(
                         width: overlayWidth(columns: columnCount),
                         height: gridHeight(
+                            count: tabs.count,
                             columns: columnCount,
                             available: geometry.size.height
                         )
@@ -423,14 +435,14 @@ struct TabSwitcherOverlay: View {
             : .primary.opacity(0.18)
     }
 
-    private func columnsPerRow(available: CGFloat) -> Int {
+    private func columnsPerRow(count: Int, available: CGFloat) -> Int {
         let horizontalInsets = 44 + TabSwitcherLayout.gridInset * 2
         let usable = max(
             TabSwitcherLayout.cardWidth,
             available - horizontalInsets
         )
         let fitting = Int(usable / TabSwitcherLayout.cardWidth)
-        return min(5, max(1, min(project.tabs.count, fitting)))
+        return min(5, max(1, min(count, fitting)))
     }
 
     private func gridColumns(count: Int) -> [GridItem] {
@@ -448,8 +460,8 @@ struct TabSwitcherOverlay: View {
             + TabSwitcherLayout.gridInset * 2
     }
 
-    private func gridHeight(columns: Int, available: CGFloat) -> CGFloat {
-        let rows = (project.tabs.count + columns - 1) / columns
+    private func gridHeight(count: Int, columns: Int, available: CGFloat) -> CGFloat {
+        let rows = (count + columns - 1) / columns
         let contentHeight = CGFloat(rows) * TabSwitcherLayout.cardHeight
             + TabSwitcherLayout.gridInset * 2
         return min(

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -878,6 +878,7 @@ final class TerminalManager: nonisolated ObservableObject {
             if let index = saved.selectedTabIndex, project.tabs.indices.contains(index) {
                 project.selectedTabID = project.tabs[index].id
             }
+            project.resetRecency()
             projects.append(project)
         }
         guard !projects.isEmpty else { return false }


### PR DESCRIPTION
The Ctrl-Tab switcher walked tabs in strip order and opened with the current tab highlighted, so the first Ctrl-Tab landed on whatever tab happens to sit next in the strip.

Now the switcher lists tabs most-recently-used first and opens on the second card, so a quick Ctrl-Tab flips back to the tab you came from, like Cmd-Tab. Shift-Ctrl-Tab starts from the other end.

Recency is recorded on `Project` when `selectedTabID` changes, so every way of reaching a tab counts — strip clicks, Ctrl-number, opening a file — not just the switcher. The order is snapshotted when the overlay opens so cards don't reshuffle mid-gesture, and it's reset after a window restore, where tabs get selected once each as they're rebuilt.

Built and tested locally: switching, hold-and-cycle, Escape, click-to-select, closing tabs while the overlay is open.
