### PR TITLE
Double-click rename and middle-click close for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ the original feature bullet instead of adding separate entries for them.
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
 - Configure the left and right sidebar font size in Settings
-- Double-click a project in the left sidebar or a session tab to rename it
+- Double-click a project in the left sidebar or a session tab to rename it. Leaving the name unchanged (or clearing it) keeps the automatic title, so terminal / tool title updates still flow to the tab
 - Middle-click a project or session tab to close it
 
 ## [0.1.26]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ the original feature bullet instead of adding separate entries for them.
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
 - Configure the left and right sidebar font size in Settings
+- Double-click a project in the left sidebar to rename it
+- Middle-click a project or session tab to close it
 
 ## [0.1.26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ the original feature bullet instead of adding separate entries for them.
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
 - Configure the left and right sidebar font size in Settings
-- Double-click a project in the left sidebar to rename it
+- Double-click a project in the left sidebar or a session tab to rename it
 - Middle-click a project or session tab to close it
 
 ## [0.1.26]

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -256,6 +256,7 @@ private struct SessionTabsView: View {
                             isSelected: tab.id == project.selectedTabID,
                             select: { project.selectedTabID = tab.id },
                             close: { project.close(tab) },
+                            initialRenameWidth: tabFrames[tab.id]?.width,
                             renamingTabID: $renamingTabID
                         )
                         .contextMenu { tabContextMenu(for: tab) }
@@ -440,6 +441,9 @@ private struct PaneTabItem: View {
     let isSelected: Bool
     let select: () -> Void
     let close: () -> Void
+    /// Width of the rendered tab before editing starts. The rename field
+    /// captures this so long tabs do not collapse to its intrinsic width.
+    let initialRenameWidth: CGFloat?
     @Binding var renamingTabID: UUID?
 
     var body: some View {
@@ -449,6 +453,7 @@ private struct PaneTabItem: View {
                 systemImage: tab.focusedContent?.systemImage ?? "terminal",
                 browserIcon: focusedBrowser,
                 initialValue: tab.displayTitle ?? "",
+                initialWidth: initialRenameWidth,
                 commit: { name, changed in
                     // An untouched field is not a rename. In particular, do
                     // not pin the title if OSC updates it while this editor is
@@ -505,6 +510,8 @@ private struct PaneTabItem: View {
 /// cancels on Escape. An untouched field leaves the current automatic/custom
 /// mode alone; an empty edited field returns the tab to its automatic title.
 private struct TabRenameChrome: View {
+    private static let minimumWidth: CGFloat = 140
+
     @ObservedObject private var themeChanges = Theme.changes
     let systemImage: String
     let browserIcon: BrowserTab?
@@ -516,6 +523,9 @@ private struct TabRenameChrome: View {
     /// the field is open, but that must not turn an untouched draft into a
     /// user rename.
     @State private var initialValue: String
+    /// Lower bound captured from the non-editing tab. Short tabs may grow to
+    /// fit the 110 pt field, while long tabs retain their previous width.
+    @State private var initialWidth: CGFloat
     /// Set by the first commit/cancel so the focus-loss handler that fires
     /// while the field is being torn down doesn't commit a second time.
     @State private var finished = false
@@ -525,6 +535,7 @@ private struct TabRenameChrome: View {
         systemImage: String,
         browserIcon: BrowserTab?,
         initialValue: String,
+        initialWidth: CGFloat?,
         commit: @escaping (String, Bool) -> Void,
         end: @escaping () -> Void
     ) {
@@ -534,6 +545,7 @@ private struct TabRenameChrome: View {
         self.end = end
         _draft = State(initialValue: initialValue)
         _initialValue = State(initialValue: initialValue)
+        _initialWidth = State(initialValue: initialWidth ?? 0)
     }
 
     var body: some View {
@@ -550,7 +562,7 @@ private struct TabRenameChrome: View {
             TextField("", text: $draft)
                 .textFieldStyle(.plain)
                 .font(.system(size: 11.5))
-                .frame(width: 110)
+                .frame(minWidth: 110, maxWidth: .infinity)
                 .focused($focused)
                 .onSubmit { finish(apply: true) }
                 .onExitCommand { finish(apply: false) }
@@ -561,6 +573,7 @@ private struct TabRenameChrome: View {
         .padding(.leading, 9)
         .padding(.trailing, 5)
         .padding(.vertical, 4)
+        .frame(width: max(initialWidth, Self.minimumWidth))
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(Color.primary.opacity(0.09))

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -456,26 +456,33 @@ private struct PaneTabItem: View {
                 end: { renamingTabID = nil }
             )
         } else {
-            switch tab.focusedContent {
-            case .session(let session):
-                SessionTabLabel(session: session, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
-            case .file(let file):
-                FileTabLabel(file: file, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
-            case .browser(let browser):
-                BrowserTabLabel(browser: browser, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
-            case .diff(let diff):
-                TabItemChrome(
-                    systemImage: "plus.forwardslash.minus",
-                    title: tab.customName ?? diff.title,
-                    paneCount: paneCount,
-                    isSelected: isSelected,
-                    select: select,
-                    close: close
-                )
-                .help(diff.path)
-            case nil:
-                EmptyView()
+            Group {
+                switch tab.focusedContent {
+                case .session(let session):
+                    SessionTabLabel(session: session, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                case .file(let file):
+                    FileTabLabel(file: file, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                case .browser(let browser):
+                    BrowserTabLabel(browser: browser, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                case .diff(let diff):
+                    TabItemChrome(
+                        systemImage: "plus.forwardslash.minus",
+                        title: tab.customName ?? diff.title,
+                        paneCount: paneCount,
+                        isSelected: isSelected,
+                        select: select,
+                        close: close
+                    )
+                    .help(diff.path)
+                case nil:
+                    EmptyView()
+                }
             }
+            // Double-click renames in place — same affordance as the left
+            // sidebar and the context-menu Rename… item.
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded { renamingTabID = tab.id }
+            )
         }
     }
 

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -450,8 +450,12 @@ private struct PaneTabItem: View {
                 browserIcon: focusedBrowser,
                 initialValue: tab.displayTitle ?? "",
                 commit: { name in
+                    // Empty or unchanged vs the live pane title → stay
+                    // automatic so OSC / tool title updates keep flowing.
                     let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    tab.customName = trimmed.isEmpty ? nil : trimmed
+                    let automatic = tab.focusedContent?.title
+                    tab.customName =
+                        (trimmed.isEmpty || trimmed == automatic) ? nil : trimmed
                 },
                 end: { renamingTabID = nil }
             )
@@ -497,7 +501,8 @@ private struct PaneTabItem: View {
 
 /// Inline editor shown in place of a tab while it's renamed — the same
 /// affordance as the project row's rename. Commits on Return or focus loss,
-/// cancels on Escape; an empty name returns the tab to its automatic title.
+/// cancels on Escape. An empty name, or one that matches the live pane
+/// title, clears the override so the tab keeps following terminal updates.
 private struct TabRenameChrome: View {
     @ObservedObject private var themeChanges = Theme.changes
     let systemImage: String

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -449,13 +449,14 @@ private struct PaneTabItem: View {
                 systemImage: tab.focusedContent?.systemImage ?? "terminal",
                 browserIcon: focusedBrowser,
                 initialValue: tab.displayTitle ?? "",
-                commit: { name in
-                    // Empty or unchanged vs the live pane title → stay
-                    // automatic so OSC / tool title updates keep flowing.
+                commit: { name, changed in
+                    // An untouched field is not a rename. In particular, do
+                    // not pin the title if OSC updates it while this editor is
+                    // open; TabRenameChrome compares against its captured
+                    // initial value rather than the latest live title.
+                    guard changed else { return }
                     let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let automatic = tab.focusedContent?.title
-                    tab.customName =
-                        (trimmed.isEmpty || trimmed == automatic) ? nil : trimmed
+                    tab.customName = trimmed.isEmpty ? nil : trimmed
                 },
                 end: { renamingTabID = nil }
             )
@@ -501,16 +502,20 @@ private struct PaneTabItem: View {
 
 /// Inline editor shown in place of a tab while it's renamed — the same
 /// affordance as the project row's rename. Commits on Return or focus loss,
-/// cancels on Escape. An empty name, or one that matches the live pane
-/// title, clears the override so the tab keeps following terminal updates.
+/// cancels on Escape. An untouched field leaves the current automatic/custom
+/// mode alone; an empty edited field returns the tab to its automatic title.
 private struct TabRenameChrome: View {
     @ObservedObject private var themeChanges = Theme.changes
     let systemImage: String
     let browserIcon: BrowserTab?
-    let commit: (String) -> Void
+    let commit: (String, Bool) -> Void
     let end: () -> Void
 
     @State private var draft: String
+    /// Frozen when editing starts. The live terminal title may change while
+    /// the field is open, but that must not turn an untouched draft into a
+    /// user rename.
+    @State private var initialValue: String
     /// Set by the first commit/cancel so the focus-loss handler that fires
     /// while the field is being torn down doesn't commit a second time.
     @State private var finished = false
@@ -520,7 +525,7 @@ private struct TabRenameChrome: View {
         systemImage: String,
         browserIcon: BrowserTab?,
         initialValue: String,
-        commit: @escaping (String) -> Void,
+        commit: @escaping (String, Bool) -> Void,
         end: @escaping () -> Void
     ) {
         self.systemImage = systemImage
@@ -528,6 +533,7 @@ private struct TabRenameChrome: View {
         self.commit = commit
         self.end = end
         _draft = State(initialValue: initialValue)
+        _initialValue = State(initialValue: initialValue)
     }
 
     var body: some View {
@@ -567,7 +573,11 @@ private struct TabRenameChrome: View {
     private func finish(apply: Bool) {
         guard !finished else { return }
         finished = true
-        if apply { commit(draft) }
+        if apply {
+            let normalizedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedInitial = initialValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            commit(draft, normalizedDraft != normalizedInitial)
+        }
         end()
     }
 }

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -706,6 +706,7 @@ private struct TabItemChrome: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(isSelected ? Color.primary.opacity(0.09) : (isHovering ? Color.primary.opacity(0.04) : .clear))
         )
+        .overlay { MiddleClickCatcher(action: close) }
         .onHover { isHovering = $0 }
     }
 }

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -578,6 +578,11 @@ private struct TabRenameChrome: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(Color.primary.opacity(0.09))
         )
+        .background {
+            OutsideClickMonitor {
+                finish(apply: true)
+            }
+        }
         .onAppear {
             DispatchQueue.main.async { focused = true }
         }

--- a/kero/MiddleClickCatcher.swift
+++ b/kero/MiddleClickCatcher.swift
@@ -1,0 +1,55 @@
+//
+//  MiddleClickCatcher.swift
+//  kero
+//
+
+import AppKit
+import SwiftUI
+
+/// Invisible overlay that fires on middle-mouse click. Left-button hits pass
+/// through (`hitTest` returns nil) so SwiftUI buttons underneath still select
+/// and drag; only `.otherMouse*` events land here — the browser-tab close
+/// convention without stealing the primary click.
+struct MiddleClickCatcher: NSViewRepresentable {
+    var action: () -> Void
+
+    func makeNSView(context: Context) -> MiddleClickNSView {
+        let view = MiddleClickNSView()
+        view.onMiddleClick = action
+        return view
+    }
+
+    func updateNSView(_ view: MiddleClickNSView, context: Context) {
+        view.onMiddleClick = action
+    }
+}
+
+final class MiddleClickNSView: NSView {
+    var onMiddleClick: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        // Transparent to layout; we only participate in hit-testing for
+        // middle-button events (see hitTest).
+        wantsLayer = true
+        layer?.backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let event = NSApp.currentEvent else { return nil }
+        switch event.type {
+        case .otherMouseDown, .otherMouseUp, .otherMouseDragged:
+            return self
+        default:
+            return nil
+        }
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2 else { return }
+        onMiddleClick?()
+    }
+}

--- a/kero/MiddleClickCatcher.swift
+++ b/kero/MiddleClickCatcher.swift
@@ -154,7 +154,14 @@ final class OutsideClickMonitorNSView: NSView {
     }
 
     deinit {
-        stopMonitoring()
+        // `deinit` is nonisolated, so it cannot call the @MainActor helper.
+        // Mirror TabSwitcherMonitorView and release the AppKit tokens here.
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
+        for observer in focusObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 }
 

--- a/kero/MiddleClickCatcher.swift
+++ b/kero/MiddleClickCatcher.swift
@@ -53,3 +53,92 @@ final class MiddleClickNSView: NSView {
         onMiddleClick?()
     }
 }
+
+/// Invisible background that reports mouse-downs outside its bounds, plus
+/// application deactivation. macOS buttons generally do not become first
+/// responder, so `@FocusState` alone cannot tell an inline text field that a
+/// user clicked another tab/sidebar row or the desktop.
+struct OutsideClickMonitor: NSViewRepresentable {
+    var action: () -> Void
+
+    func makeNSView(context: Context) -> OutsideClickMonitorNSView {
+        let view = OutsideClickMonitorNSView()
+        view.onOutsideClick = action
+        return view
+    }
+
+    func updateNSView(_ view: OutsideClickMonitorNSView, context: Context) {
+        view.onOutsideClick = action
+    }
+
+    static func dismantleNSView(_ view: OutsideClickMonitorNSView, coordinator: ()) {
+        view.stopMonitoring()
+    }
+}
+
+final class OutsideClickMonitorNSView: NSView {
+    var onOutsideClick: (() -> Void)?
+
+    private var eventMonitor: Any?
+    private var resignActiveObserver: NSObjectProtocol?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        stopMonitoring()
+        guard window != nil else { return }
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] event in
+            guard let self else { return event }
+            let isInside: Bool
+            if event.window === self.window {
+                isInside = self.bounds.contains(
+                    self.convert(event.locationInWindow, from: nil)
+                )
+            } else {
+                isInside = false
+            }
+            if !isInside {
+                self.reportOutsideClick()
+            }
+            return event
+        }
+
+        resignActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.reportOutsideClick()
+        }
+    }
+
+    /// This view observes events globally within the app; it never takes a hit
+    /// away from the SwiftUI control layered above it.
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    func stopMonitoring() {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+        if let resignActiveObserver {
+            NotificationCenter.default.removeObserver(resignActiveObserver)
+            self.resignActiveObserver = nil
+        }
+    }
+
+    private func reportOutsideClick() {
+        // Leave the current event free to reach its intended target. Capture
+        // the closure now because SwiftUI may dismantle this view first.
+        let action = onOutsideClick
+        DispatchQueue.main.async {
+            action?()
+        }
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+}

--- a/kero/MiddleClickCatcher.swift
+++ b/kero/MiddleClickCatcher.swift
@@ -76,11 +76,12 @@ struct OutsideClickMonitor: NSViewRepresentable {
     }
 }
 
+@MainActor
 final class OutsideClickMonitorNSView: NSView {
     var onOutsideClick: (() -> Void)?
 
     private var eventMonitor: Any?
-    private var resignActiveObserver: NSObjectProtocol?
+    private var focusObservers: [NSObjectProtocol] = []
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -90,27 +91,41 @@ final class OutsideClickMonitorNSView: NSView {
         eventMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
         ) { [weak self] event in
-            guard let self else { return event }
-            let isInside: Bool
-            if event.window === self.window {
-                isInside = self.bounds.contains(
-                    self.convert(event.locationInWindow, from: nil)
-                )
-            } else {
-                isInside = false
+            // Local monitors run synchronously on AppKit's main event thread.
+            // Keep non-Sendable NSEvent inside an unchecked wrapper while
+            // crossing `assumeIsolated`'s generic boundary.
+            let input = MainThreadMouseEvent(event)
+            let output: MainThreadMouseEvent = MainActor.assumeIsolated {
+                guard let self, let event = input.value else { return input }
+                let isInside: Bool
+                if event.window === self.window {
+                    isInside = self.bounds.contains(
+                        self.convert(event.locationInWindow, from: nil)
+                    )
+                } else {
+                    isInside = false
+                }
+                if !isInside {
+                    self.reportOutsideClick()
+                }
+                return input
             }
-            if !isInside {
-                self.reportOutsideClick()
-            }
-            return event
+            return output.value
         }
 
-        resignActiveObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didResignActiveNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.reportOutsideClick()
+        for name in [
+            NSWindow.didResignKeyNotification,
+            NSApplication.didResignActiveNotification,
+        ] {
+            focusObservers.append(NotificationCenter.default.addObserver(
+                forName: name,
+                object: name == NSWindow.didResignKeyNotification ? window : nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.reportOutsideClick()
+                }
+            })
         }
     }
 
@@ -123,10 +138,10 @@ final class OutsideClickMonitorNSView: NSView {
             NSEvent.removeMonitor(eventMonitor)
             self.eventMonitor = nil
         }
-        if let resignActiveObserver {
-            NotificationCenter.default.removeObserver(resignActiveObserver)
-            self.resignActiveObserver = nil
+        for observer in focusObservers {
+            NotificationCenter.default.removeObserver(observer)
         }
+        focusObservers.removeAll()
     }
 
     private func reportOutsideClick() {
@@ -140,5 +155,13 @@ final class OutsideClickMonitorNSView: NSView {
 
     deinit {
         stopMonitoring()
+    }
+}
+
+private struct MainThreadMouseEvent: @unchecked Sendable {
+    let value: NSEvent?
+
+    init(_ value: NSEvent?) {
+        self.value = value
     }
 }

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -74,6 +74,7 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
 
+
     }
 
     /// Every terminal session across every pane in every tab.

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -53,6 +53,12 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         if let customName = Self.normalizedCustomName(customName) {
             return customName
         }
+        return automaticName
+    }
+
+    /// Sidebar title ignoring any user override: the selected session's
+    /// title verbatim, else the fallback.
+    var automaticName: String {
         guard let title = selectedSession?.title,
               !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
@@ -67,6 +73,7 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         guard let name else { return nil }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+
     }
 
     /// Every terminal session across every pane in every tab.

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -216,6 +216,7 @@ private struct SidebarProjectRow: View {
     @State private var isHovering = false
     @State private var isRenaming = false
     @State private var renameDraft = ""
+    @State private var renameInitialValue = ""
     @FocusState private var renameFocused: Bool
 
     var body: some View {
@@ -362,7 +363,9 @@ private struct SidebarProjectRow: View {
     }
 
     private func beginRename() {
-        renameDraft = project.name
+        let initialValue = project.name
+        renameDraft = initialValue
+        renameInitialValue = initialValue
         isRenaming = true
         DispatchQueue.main.async {
             renameFocused = true
@@ -370,13 +373,12 @@ private struct SidebarProjectRow: View {
     }
 
     private func commitRename() {
-        // Empty or unchanged vs the live automatic name → stay automatic so
-        // the row keeps following the selected session's terminal title.
         let trimmed = renameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty || trimmed == project.automaticName {
-            project.customName = nil
-        } else {
-            project.customName = Project.normalizedCustomName(renameDraft)
+        let initial = renameInitialValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        // If the selected session changes its title while the field is open,
+        // an untouched draft must not freeze the old value as a custom name.
+        if trimmed != initial {
+            project.customName = trimmed.isEmpty ? nil : Project.normalizedCustomName(renameDraft)
         }
         isRenaming = false
     }

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -370,7 +370,14 @@ private struct SidebarProjectRow: View {
     }
 
     private func commitRename() {
-        project.customName = Project.normalizedCustomName(renameDraft)
+        // Empty or unchanged vs the live automatic name → stay automatic so
+        // the row keeps following the selected session's terminal title.
+        let trimmed = renameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed == project.automaticName {
+            project.customName = nil
+        } else {
+            project.customName = Project.normalizedCustomName(renameDraft)
+        }
         isRenaming = false
     }
 

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -227,6 +227,11 @@ private struct SidebarProjectRow: View {
                     rowContent
                 }
                 .buttonStyle(.plain)
+                // Double-click renames in place — same affordance as Finder
+                // list rows and browser tabs; the context-menu Rename… stays.
+                .simultaneousGesture(
+                    TapGesture(count: 2).onEnded { beginRename() }
+                )
                 .highPriorityGesture(
                     DragGesture(minimumDistance: 4, coordinateSpace: .global)
                         .onChanged { onDrag($0.location) }
@@ -239,6 +244,12 @@ private struct SidebarProjectRow: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(isSelected ? Color.primary.opacity(0.09) : (isHovering ? Color.primary.opacity(0.04) : .clear))
         )
+        // Middle-click closes, matching browser tabs and the session strip.
+        .overlay {
+            if !isRenaming {
+                MiddleClickCatcher(action: close)
+            }
+        }
         .onHover { isHovering = $0 }
         .contextMenu {
             Button("Rename…") {

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -360,6 +360,13 @@ private struct SidebarProjectRow: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .contentShape(RoundedRectangle(cornerRadius: 6))
+        .background {
+            if isRenaming {
+                OutsideClickMonitor {
+                    commitRename()
+                }
+            }
+        }
     }
 
     private func beginRename() {
@@ -373,6 +380,7 @@ private struct SidebarProjectRow: View {
     }
 
     private func commitRename() {
+        guard isRenaming else { return }
         let trimmed = renameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         let initial = renameInitialValue.trimmingCharacters(in: .whitespacesAndNewlines)
         // If the selected session changes its title while the field is open,


### PR DESCRIPTION
## Summary
- Double-click a left-sidebar project or a session tab to rename it in place (the same editor as the existing Rename… menu)
- Middle-click a project or session tab to close it
- An untouched rename stays automatic, even if OSC/tool updates change the live title while the editor is open
- Long tabs keep their width while editing; clicking elsewhere, switching windows, or leaving the app commits the rename

Fixes #25.

## Notes
- Double-click is an additional shortcut for Kero’s existing inline rename; it is not meant to claim that browser tabs universally use this gesture.
- Middle-click close follows Terminal.app/browser tab behavior requested in #25.
- Session-tab rename via the context menu was already added for #12.
- Hover layout/jitter (close vs ⌘N reflow, spinner titles) remains scoped to #21.

## Test plan
Manually verified on macOS (Kero Debug build):

- [x] Double-click a left-sidebar project → inline rename; Enter commits, Esc cancels
- [x] Double-click a session tab → same rename field as Rename…
- [x] Middle-click a session tab → closes that tab
- [x] Middle-click a left-sidebar project → closes that project
- [x] Left-click / drag-reorder still work
- [x] Open rename, let the terminal OSC title change, then Enter without editing → the tab follows the new title
- [x] Rename to a different string → title stays pinned; Use Automatic Title restores live updates
- [x] Click another tab/sidebar row or the desktop while editing → rename commits and the click still reaches its target
- [x] A long tab does not shrink when its inline editor opens