### PR TITLE
Settings Preview reflects Thicken font strokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ the original feature bullet instead of adding separate entries for them.
 ## [unrelease]
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
+- Settings font preview now reflects “Thicken font strokes”: it draws through AppKit with CoreText font smoothing, matching what Ghostty does in the terminal
 
 ## [0.1.26]
 

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -165,6 +165,81 @@ struct SettingsView: View {
     private static let lightThemeNames = Theme.commonLightThemes.map(\.name)
 }
 
+/// Settings font preview that honors `font-thicken`. Ghostty thickens by
+/// enabling CoreText font smoothing when rasterizing glyphs; SwiftUI `Text`
+/// does not, so toggling the setting left this preview unchanged.
+private struct FontThickenPreview: NSViewRepresentable {
+    var font: NSFont
+    var thicken: Bool
+
+    func makeNSView(context: Context) -> FontThickenPreviewView {
+        FontThickenPreviewView()
+    }
+
+    func updateNSView(_ view: FontThickenPreviewView, context: Context) {
+        view.previewFont = font
+        view.thicken = thicken
+        view.needsDisplay = true
+        view.invalidateIntrinsicContentSize()
+    }
+}
+
+private final class FontThickenPreviewView: NSView {
+    var previewFont: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
+    var thicken = false
+
+    /// Regular / CJK / icon / bold — same idea as the old SwiftUI preview,
+    /// plus a Chinese line so stroke weight is obvious on CJK glyphs too.
+    private let lines: [(text: String, bold: Bool)] = [
+        ("kero ❯ echo \"the quick brown fox\" 0O 1lI", false),
+        ("中文预览 — 你好，世界", false),
+        ("\u{E0A0} main \u{E0B0} ~/dev/kero \u{E711} \u{F024B} \u{F0A7D}", false),
+        ("bold — 加粗中文 permission denied", true),
+    ]
+
+    private let lineSpacing: CGFloat = 6
+    private let verticalPadding: CGFloat = 4
+
+    override var isFlipped: Bool { true }
+
+    override var intrinsicContentSize: NSSize {
+        let lineHeight = ceil(previewFont.boundingRectForFont.height)
+        let height = verticalPadding * 2
+            + CGFloat(lines.count) * lineHeight
+            + CGFloat(max(0, lines.count - 1)) * lineSpacing
+        return NSSize(width: NSView.noIntrinsicMetric, height: height)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        // Mirror Ghostty's CoreText glyph path (face/coretext.zig):
+        // font-thicken == shouldSmoothFonts.
+        ctx.setAllowsFontSmoothing(true)
+        ctx.setShouldSmoothFonts(thicken)
+        ctx.setAllowsFontSubpixelPositioning(true)
+        ctx.setShouldSubpixelPositionFonts(true)
+        ctx.setAllowsFontSubpixelQuantization(false)
+        ctx.setShouldSubpixelQuantizeFonts(false)
+        ctx.setAllowsAntialiasing(true)
+        ctx.setShouldAntialias(true)
+
+        let color = NSColor.labelColor
+        var y = verticalPadding
+        let lineHeight = ceil(previewFont.boundingRectForFont.height)
+        for (text, bold) in lines {
+            let font = bold
+                ? (NSFontManager.shared.convert(previewFont, toHaveTrait: .boldFontMask) ?? previewFont)
+                : previewFont
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: color,
+            ]
+            (text as NSString).draw(at: NSPoint(x: 0, y: y), withAttributes: attrs)
+            y += lineHeight + lineSpacing
+        }
+    }
+}
+
 /// Sizes its sole child to the child's ideal height, capped at `maxHeight`.
 /// A `maxHeight` frame plus `fixedSize` can't express this: the grouped Form
 /// is a List, which only scrolls when *proposed* the capped height, yet still

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -188,13 +188,11 @@ private final class FontThickenPreviewView: NSView {
     var previewFont: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
     var thicken = false
 
-    /// Regular / CJK / icon / bold — same idea as the old SwiftUI preview,
-    /// plus a Chinese line so stroke weight is obvious on CJK glyphs too.
+    /// Regular / icon / bold lines — same samples as the old SwiftUI preview.
     private let lines: [(text: String, bold: Bool)] = [
         ("kero ❯ echo \"the quick brown fox\" 0O 1lI", false),
-        ("中文预览 — 你好，世界", false),
         ("\u{E0A0} main \u{E0B0} ~/dev/kero \u{E711} \u{F024B} \u{F0A7D}", false),
-        ("bold — 加粗中文 permission denied", true),
+        ("bold — permission denied (os error 13)", true),
     ]
 
     private let lineSpacing: CGFloat = 6

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -79,15 +79,11 @@ struct SettingsView: View {
             }
 
             Section("Preview") {
-                // Exercises regular/bold plus Nerd Font icon fallback.
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("kero ❯ echo \"the quick brown fox\" 0O 1lI")
-                    Text("\u{E0A0} main \u{E0B0} ~/dev/kero \u{E711} \u{F024B} \u{F0A7D}")
-                    Text("bold — permission denied (os error 13)")
-                        .bold()
-                }
-                .font(Font(previewFont))
-                .padding(.vertical, 4)
+                // SwiftUI Text cannot show Ghostty's font-thicken — that flag
+                // only affects CoreText glyph rasterization — so draw through
+                // AppKit with shouldSmoothFonts matching the toggle.
+                FontThickenPreview(font: previewFont, thicken: settings.fontThicken)
+                    .padding(.vertical, 4)
             }
 
             Section("Terminal") {


### PR DESCRIPTION
## Summary

Settings → Preview used SwiftUI `Text`, which does not expose the Core Graphics font-smoothing switch used by Ghostty’s CoreText rasterizer. As a result, toggling **Thicken font strokes** updated the terminal but left Preview visually unchanged.

The Preview now draws its existing samples through an AppKit view and maps the setting to `CGContext.setShouldSmoothFonts`. This mirrors the relevant smoothing control for immediate feedback; it does not embed a full Ghostty Metal surface or claim pixel-identical rendering.

## Test plan

- [x] Open Settings → Terminal and toggle **Thicken font strokes**
- [x] Confirm Preview text weight changes immediately
- [x] Confirm the live terminal still hot-updates with the same toggle
- [x] Change Font Family / Size and confirm Preview follows those settings