### PR TITLE
Open highlighted terminal file paths with default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ the original feature bullet instead of adding separate entries for them.
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
 - Configure the left and right sidebar font size in Settings
+- Clicking a highlighted file path in the terminal now opens it with its default macOS app, including absolute, relative, tilde, and compiler-style `path:line:column` links
 
 ## [0.1.26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the original feature bullet instead of adding separate entries for them.
 - Settings font preview now reflects “Thicken font strokes”
 - Prevent terminal tabs from crashing after switching sessions or resizing during a partial redraw
 - Files created in a terminal now use your system's default permissions instead of being made private to your user
+- Clicking a highlighted file path in the terminal now opens it with its default macOS app (absolute, relative, and `~/…` paths)
 
 ## [0.1.33]
 
@@ -56,7 +57,6 @@ the original feature bullet instead of adding separate entries for them.
 
 - Choose which terminal emulator drives new panes in Settings → Terminal → Backend. Ghostty remains the default, with a new Alacritty backend
 - Configure the left and right sidebar font size in Settings
-- Clicking a highlighted file path in the terminal now opens it with its default macOS app, including absolute, relative, tilde, and compiler-style `path:line:column` links
 
 ## [0.1.26]
 

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -475,59 +475,19 @@ extension TerminalSession: TerminalBackendEvents {
     }
 
     func terminalDidRequestOpenURL(_ url: String) {
-        let fileTarget = Self.fileLinkURL(url, relativeTo: currentDirectoryPath)
+        // Ghostty sends detected filesystem links as plain paths, not
+        // `file://` URLs. A schemeless `URL(string:)` is not a file URL and
+        // Launch Services rejects it, so convert paths explicitly — same fix
+        // as ghostty-org/ghostty#8764.
         let target: URL
-        if let parsed = URL(string: url), parsed.isFileURL {
-            // Resolve from `path` so percent escapes are decoded and a
-            // compiler-style line/column suffix can still be removed.
-            target = Self.fileLinkURL(parsed.path, relativeTo: currentDirectoryPath)
-        } else if let parsed = URL(string: url), parsed.scheme != nil,
-                  !FileManager.default.fileExists(atPath: fileTarget.path) {
+        if let parsed = URL(string: url), parsed.scheme != nil {
             target = parsed
         } else {
-            target = fileTarget
+            target = URL(filePath: (url as NSString).standardizingPath)
         }
         if !NSWorkspace.shared.open(target) {
             NSLog("kero: failed to open terminal link %@", target.absoluteString)
         }
-    }
-
-    /// Ghostty sends detected filesystem links as plain paths, not `file://`
-    /// URLs. A schemeless `URL(string:)` is not a file URL and Launch Services
-    /// rejects it, so resolve paths against this session's working directory.
-    /// Compiler-style `path:line[:column]` suffixes are removed only when the
-    /// resulting path names an existing file.
-    private static func fileLinkURL(_ value: String, relativeTo directory: String) -> URL {
-        let direct = resolvedFileURL(value, relativeTo: directory)
-        if FileManager.default.fileExists(atPath: direct.path) {
-            return direct
-        }
-
-        if let range = value.range(
-            of: #":\d+(?::\d+)?$"#,
-            options: .regularExpression
-        ) {
-            let withoutLocation = String(value[..<range.lowerBound])
-            let file = resolvedFileURL(withoutLocation, relativeTo: directory)
-            if FileManager.default.fileExists(atPath: file.path) {
-                return file
-            }
-        }
-        return direct
-    }
-
-    private static func resolvedFileURL(
-        _ value: String, relativeTo directory: String
-    ) -> URL {
-        let path = (value as NSString).expandingTildeInPath
-        if path.hasPrefix("/") {
-            return URL(fileURLWithPath: path).standardizedFileURL
-        }
-        let base = URL(
-            fileURLWithPath: directory,
-            isDirectory: true
-        )
-        return URL(fileURLWithPath: path, relativeTo: base).standardizedFileURL
     }
 
     func terminalDidScroll(_ position: TerminalScrollPosition) {

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -475,8 +475,59 @@ extension TerminalSession: TerminalBackendEvents {
     }
 
     func terminalDidRequestOpenURL(_ url: String) {
-        guard let target = URL(string: url) else { return }
-        NSWorkspace.shared.open(target)
+        let fileTarget = Self.fileLinkURL(url, relativeTo: currentDirectoryPath)
+        let target: URL
+        if let parsed = URL(string: url), parsed.isFileURL {
+            // Resolve from `path` so percent escapes are decoded and a
+            // compiler-style line/column suffix can still be removed.
+            target = Self.fileLinkURL(parsed.path, relativeTo: currentDirectoryPath)
+        } else if let parsed = URL(string: url), parsed.scheme != nil,
+                  !FileManager.default.fileExists(atPath: fileTarget.path) {
+            target = parsed
+        } else {
+            target = fileTarget
+        }
+        if !NSWorkspace.shared.open(target) {
+            NSLog("kero: failed to open terminal link %@", target.absoluteString)
+        }
+    }
+
+    /// Ghostty sends detected filesystem links as plain paths, not `file://`
+    /// URLs. A schemeless `URL(string:)` is not a file URL and Launch Services
+    /// rejects it, so resolve paths against this session's working directory.
+    /// Compiler-style `path:line[:column]` suffixes are removed only when the
+    /// resulting path names an existing file.
+    private static func fileLinkURL(_ value: String, relativeTo directory: String) -> URL {
+        let direct = resolvedFileURL(value, relativeTo: directory)
+        if FileManager.default.fileExists(atPath: direct.path) {
+            return direct
+        }
+
+        if let range = value.range(
+            of: #":\d+(?::\d+)?$"#,
+            options: .regularExpression
+        ) {
+            let withoutLocation = String(value[..<range.lowerBound])
+            let file = resolvedFileURL(withoutLocation, relativeTo: directory)
+            if FileManager.default.fileExists(atPath: file.path) {
+                return file
+            }
+        }
+        return direct
+    }
+
+    private static func resolvedFileURL(
+        _ value: String, relativeTo directory: String
+    ) -> URL {
+        let path = (value as NSString).expandingTildeInPath
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path).standardizedFileURL
+        }
+        let base = URL(
+            fileURLWithPath: directory,
+            isDirectory: true
+        )
+        return URL(fileURLWithPath: path, relativeTo: base).standardizedFileURL
     }
 
     func terminalDidScroll(_ position: TerminalScrollPosition) {


### PR DESCRIPTION
## Summary

Highlighted file paths reached Kero’s open-link callback, but the callback passed plain paths through `URL(string:)`. That creates a schemeless URL (or fails for paths with spaces), which Launch Services cannot hand to a macOS application — the same root cause as [ghostty-org/ghostty#8763](https://github.com/ghostty-org/ghostty/issues/8763), fixed upstream by [ghostty-org/ghostty#8764](https://github.com/ghostty-org/ghostty/pull/8764).

This mirrors Ghostty’s fix: strings with a URL scheme are opened as URLs; anything else is treated as a filesystem path (`~` expanded) and converted to a real file URL. Relative paths are already resolved against the terminal's working directory by the Ghostty core (`resolvePathForOpening`) before reaching the app layer.

## Test plan

- [ ] Cmd-click an absolute highlighted path → opens in its default app
- [ ] Cmd-click a relative path (resolved by the core against the session pwd)
- [ ] Cmd-click a `~/…` path and a path containing spaces
- [ ] Cmd-click `https://…` and `file://…` links → existing behavior still works