### PR TITLE
Add Zed and Cursor actions to Info panel

### DIFF
--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -1845,6 +1845,19 @@ private struct GitEntryRow: View {
 /// Session dashboard: working directory (with reveal/open/copy actions),
 /// processes running under the shell, and ports they are listening on.
 private struct InfoPanel: View {
+    private struct ExternalEditor: Identifiable {
+        let name: String
+        let bundleIdentifier: String
+
+        var id: String { bundleIdentifier }
+
+        var applicationURL: URL? {
+            NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: bundleIdentifier
+            )
+        }
+    }
+
     @ObservedObject var model: SessionInfoModel
     @ObservedObject private var themeChanges = Theme.changes
     let session: TerminalSession?
@@ -1854,8 +1867,20 @@ private struct InfoPanel: View {
     @State private var processesCollapsed = false
     @State private var portsCollapsed = false
 
-    private static let vsCodeURL = NSWorkspace.shared
-        .urlForApplication(withBundleIdentifier: "com.microsoft.VSCode")
+    private static let externalEditors = [
+        ExternalEditor(
+            name: "VS Code",
+            bundleIdentifier: "com.microsoft.VSCode"
+        ),
+        ExternalEditor(
+            name: "Zed",
+            bundleIdentifier: "dev.zed.Zed"
+        ),
+        ExternalEditor(
+            name: "Cursor",
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        ),
+    ]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1938,7 +1963,7 @@ private struct InfoPanel: View {
         }
     }
 
-    /// Path line plus Finder / VS Code / Copy actions, shared by both
+    /// Path line plus Finder / editor / Copy actions, shared by both
     /// directory sections.
     private func directoryGroup(path: String) -> some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1953,19 +1978,27 @@ private struct InfoPanel: View {
                     Button("Copy Path") { copyPath(path) }
                 }
 
-            HStack(spacing: 4) {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 64), spacing: 4)],
+                spacing: 4
+            ) {
                 actionButton("Finder", systemImage: "arrow.up.forward.app") {
                     NSWorkspace.shared.activateFileViewerSelecting(
                         [URL(fileURLWithPath: path)]
                     )
                 }
-                if let vsCode = Self.vsCodeURL {
-                    actionButton("VS Code", systemImage: "chevron.left.forwardslash.chevron.right") {
-                        NSWorkspace.shared.open(
-                            [URL(fileURLWithPath: path)],
-                            withApplicationAt: vsCode,
-                            configuration: NSWorkspace.OpenConfiguration()
-                        )
+                ForEach(Self.externalEditors) { editor in
+                    if let applicationURL = editor.applicationURL {
+                        actionButton(
+                            editor.name,
+                            systemImage: "chevron.left.forwardslash.chevron.right"
+                        ) {
+                            NSWorkspace.shared.open(
+                                [URL(fileURLWithPath: path)],
+                                withApplicationAt: applicationURL,
+                                configuration: NSWorkspace.OpenConfiguration()
+                            )
+                        }
                     }
                 }
                 actionButton("Copy", systemImage: "doc.on.doc") {


### PR DESCRIPTION
## Summary

- add Info panel actions for Zed and Cursor alongside VS Code
- show each editor action only when its application is installed
- use an adaptive grid so the additional actions wrap at narrow sidebar widths

## Why

The Info panel currently provides a quick way to open a session directory in VS Code, but developers using Zed or Cursor need to leave Kero or open the directory manually.

Closes #66.

## Validation

- built the Debug configuration successfully with `xcodebuild`
- launched the built app and confirmed the Info panel exposes the installed VS Code and Zed actions
- opened the current Kero repository through the Zed action and confirmed Zed opened the `kero` project
- verified the Cursor path compiles; Cursor was not installed locally for a launch check
- ran `git diff --check`