### PR TITLE
Keep the launch shim's umask out of the user's shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unrelease]
 
+- Files created in a terminal now use your system's default permissions instead of being made private to your user
+
 ## [0.1.33]
 
 - Fix: never set `LANG` env for the terminal session

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -333,9 +333,17 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         pidFileURL: URL?,
         replayFileURL: URL?
     ) -> String {
-        var commands = ["umask 077"]
+        var commands: [String] = []
         if let pidFileURL {
-            commands.append("printf '%s\\n' \"$$\" > \(shellQuote(pidFileURL.path))")
+            // The PID file is the only thing this script creates, so the
+            // tightened mask stays inside a subshell: `umask` outlives the
+            // `exec` below, and a terminal that leaves the user's shell at 077
+            // silently makes every file they create private. `$$` keeps
+            // expanding to this shell's PID inside the subshell — the same PID
+            // `exec` hands to the shell itself.
+            commands.append(
+                "(umask 077; printf '%s\\n' \"$$\" > \(shellQuote(pidFileURL.path)))"
+            )
         }
         if let replayFileURL {
             let path = shellQuote(replayFileURL.path)
@@ -364,7 +372,7 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         }
         // Ghostty's macOS launcher prepends `exec -l` to a shell command.
         // Keeping the setup as one compound command means `exec -l` does not
-        // stop after the first shell builtin (`umask`).
+        // stop after the first shell builtin.
         return commands.joined(separator: "; ")
     }
 


### PR DESCRIPTION
Fixes #63

## The bug

Every pane starts through an `sh` shim (`TerminalSession.makeLaunchScript`) that
sets `umask 077` and then `exec`s the user's login shell. `umask` is process
state that `exec` preserves, so the mask outlives the shim and stays with the
shell for the rest of the session: files created in a Kero terminal come out
`rw-------` and directories `rwx------`. Anything expecting the system default
is surprised by it — a checkout a web server has to read, an artifact another
account picks up, files copied into an image.

## The fix

The mask was there for the one file the shim writes itself, `shell.pid`, so it
moves into a subshell around that write. `$$` still expands to the invoking
shell's PID inside a subshell, so the recorded PID is the one `exec` hands to
the user's shell. `shell.pid` also lives in a per-session directory created with
`0o700`, so the subshell mask stays defense in depth rather than the only thing
protecting it.

## Verification

Debug build, a fresh pane per run. Observed by pointing the app at a throwaway
`ZDOTDIR` whose `.zshrc` records `umask` and `$$` and creates a file:

|        | login shell `umask` | file created in the pane | `shell.pid`                     |
| ------ | ------------------- | ------------------------ | ------------------------------- |
| before | `077`               | `-rw-------`             | `-rw-------`, matches shell PID |
| after  | `022` (inherited)   | `-rw-r--r--`             | `-rw-------`, matches shell PID |

Both backends launch from the same `makeLaunchScript` output, so the Alacritty
path is covered as well.

The changelog line is under `## [unrelease]` — drop it if you'd rather word it
yourself.
