### PR TITLE
Preserve the user's umask in terminal sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unrelease]
 
+- Preserve the user's file-creation permissions in terminal sessions instead of forcing private-only files and directories
+
 ## [0.1.32]
 
 - Add native English, Simplified Chinese, and Japanese localization throughout the app, with a language picker in Settings

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -334,9 +334,13 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         pidFileURL: URL?,
         replayFileURL: URL?
     ) -> String {
-        var commands = ["umask 077"]
+        var commands: [String] = []
         if let pidFileURL {
-            commands.append("printf '%s\\n' \"$$\" > \(shellQuote(pidFileURL.path))")
+            // Keep the launch artifact private without leaking a restrictive
+            // umask into the user's login shell and every process it starts.
+            commands.append(
+                "(umask 077; printf '%s\\n' \"$$\" > \(shellQuote(pidFileURL.path)))"
+            )
         }
         if let replayFileURL {
             let path = shellQuote(replayFileURL.path)


### PR DESCRIPTION
## Summary

- Scope `umask 077` to the private PID-file write instead of the whole terminal session.
- Preserve the user's inherited umask for login shells and commands.
- Document the behavior change.

## Why

Every pane previously ran `umask 077` before execing the login shell. Descendant processes then defaulted to `0600` files and `0700` directories, which can break shared projects, make build artifacts inaccessible to collaborators or cooperating processes, and surprise development tools that expect normal permission semantics. A subshell keeps the PID file at `0600` without changing shell policy.

## Verification

- Shell regression: inherited `0022`, PID file `0600`, ordinary file `0644`.
- Debug and Release arm64 builds succeeded.
- Runtime Kero terminal: `022`, file `0644`, directory `0755`.