### PR TITLE
Fix sidebar project title alignment

### DIFF
--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -294,39 +294,41 @@ private struct SidebarProjectRow: View {
 
     private var rowContent: some View {
         HStack(spacing: 8) {
-            Image(systemName: "folder")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(isSelected ? Color(nsColor: Theme.accent) : .secondary)
-
-            VStack(alignment: .leading, spacing: 1) {
-                // Activity glyph is separate and fixed-width so Braille
-                // spinner frames do not reflow the project name (or shift
-                // neighboring rows) while an agent is working.
-                HStack(spacing: 3) {
-                    Text(project.activityIndicator ?? "")
+            // Activity replaces the folder inside one fixed slot. This keeps
+            // both text lines aligned without reflowing the row as an agent
+            // starts, stops, or asks for approval.
+            ZStack {
+                if let activity = project.activityIndicator {
+                    Text(activity)
                         .font(.system(size: fontSize, design: .monospaced))
-                        // Fits Braille frames and Grok's ⚠ approval glyph.
-                        .frame(width: max(14, fontSize), alignment: .center)
                         .foregroundStyle(isSelected ? .primary : .secondary)
                         .accessibilityHidden(true)
-                    if isRenaming {
-                        TextField("", text: $renameDraft)
-                            .textFieldStyle(.plain)
-                            .font(.system(size: fontSize, weight: .medium))
-                            .focused($renameFocused)
-                            .onSubmit(commitRename)
-                            .onExitCommand { isRenaming = false }
-                            .onChange(of: renameFocused) {
-                                if !renameFocused, isRenaming {
-                                    commitRename()
-                                }
+                } else {
+                    Image(systemName: "folder")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(isSelected ? Color(nsColor: Theme.accent) : .secondary)
+                }
+            }
+            .frame(width: max(14, fontSize), alignment: .center)
+
+            VStack(alignment: .leading, spacing: 1) {
+                if isRenaming {
+                    TextField("", text: $renameDraft)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: fontSize, weight: .medium))
+                        .focused($renameFocused)
+                        .onSubmit(commitRename)
+                        .onExitCommand { isRenaming = false }
+                        .onChange(of: renameFocused) {
+                            if !renameFocused, isRenaming {
+                                commitRename()
                             }
-                    } else {
-                        Text(project.name)
-                            .font(.system(size: fontSize))
-                            .foregroundStyle(isSelected ? .primary : .secondary)
-                            .lineLimit(1)
-                    }
+                        }
+                } else {
+                    Text(project.name)
+                        .font(.system(size: fontSize))
+                        .foregroundStyle(isSelected ? .primary : .secondary)
+                        .lineLimit(1)
                 }
                 subtitle
             }


### PR DESCRIPTION
## What changed

- Move the agent activity glyph into the existing leading icon slot.
- Show the folder while idle and replace it with the spinner or approval warning while active.
- Keep the project title, rename field, and directory subtitle on one shared leading edge.

## Why

PR #21 reserved a separate activity slot inside the title row to prevent spinner jitter. That fixed reflow, but permanently indented the title relative to its subtitle whenever no activity glyph was visible.

The leading icon is already a fixed-size slot, so using it for activity preserves the no-jitter behavior without misaligning the text.

## Verification

- Full Debug build with Xcode beta: passed.
- Live Alacritty UI: verified idle title/subtitle alignment.
- Injected a Braille Grok activity title: the spinner replaced the folder without moving either text line.
- Injected an action-required Grok title: the warning fit the same slot without reflow.
- Stopped both foreground jobs and confirmed the folder returned with unchanged text geometry.