### PR TITLE
feat(terminal): send Shift+Enter as newline for coding agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unrelease]
 
+- Shift+Enter now inserts a newline for coding agents running in the terminal, while Enter still submits. On by default; turn it off in Settings.
+
 ## [0.1.35]
 
 - Add per-pane live titles and split controls in split layouts

--- a/kero/Alacritty/AlacrittyKeyMap.swift
+++ b/kero/Alacritty/AlacrittyKeyMap.swift
@@ -36,7 +36,8 @@ enum AlacrittyKeyMap {
     static func bytes(
         for event: NSEvent,
         mode: AlacrittyTerminalMode,
-        optionAsAlt: Bool
+        optionAsAlt: Bool,
+        shiftEnterNewline: Bool
     ) -> [UInt8]? {
         let flags = event.modifierFlags
         if flags.contains(.command) {
@@ -56,7 +57,7 @@ enum AlacrittyKeyMap {
         let alt = optionAsAlt && flags.contains(.option)
         let shift = flags.contains(.shift)
 
-        if let special = specialKey(event, mode: mode, shift: shift, control: control, alt: alt) {
+        if let special = specialKey(event, mode: mode, shift: shift, control: control, alt: alt, shiftEnterNewline: shiftEnterNewline) {
             return special
         }
 
@@ -121,7 +122,8 @@ enum AlacrittyKeyMap {
         mode: AlacrittyTerminalMode,
         shift: Bool,
         control: Bool,
-        alt: Bool
+        alt: Bool,
+        shiftEnterNewline: Bool
     ) -> [UInt8]? {
         // The CSI parameter xterm uses to carry modifiers: 1 + a bitmask of
         // shift/alt/control. Only emitted when something is actually held.
@@ -156,7 +158,10 @@ enum AlacrittyKeyMap {
 
         switch Int(event.keyCode) {
         case 36, 76: // Return, keypad Enter
-            return [0x0d]
+            // Shift+Enter sends a line feed (LF) so coding agents running in
+            // the terminal insert a newline instead of submitting the prompt.
+            // They read LF as a literal newline and CR as submit.
+            return (shift && shiftEnterNewline) ? [0x0a] : [0x0d]
         case 48: // Tab
             return shift ? Array("\u{1b}[Z".utf8) : [0x09]
         case 51: // Delete (backspace)

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -1244,7 +1244,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         if let bytes = AlacrittyKeyMap.bytes(
             for: event,
             mode: terminalMode,
-            optionAsAlt: AppSettings.shared.macosOptionAsAlt
+            optionAsAlt: AppSettings.shared.macosOptionAsAlt,
+            shiftEnterNewline: AppSettings.shared.shiftEnterNewline
         ) {
             write(bytes)
             return

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -175,6 +175,15 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Send Shift+Enter as a line feed (LF) so coding agents running in the
+    /// terminal insert a newline instead of submitting the prompt. On by
+    /// default: Enter still submits, only Shift+Enter changes. These agents
+    /// read LF as a literal newline and CR as submit, so this needs no agent
+    /// changes. Persisted as `terminal.shift-enter-newline`.
+    @Published var shiftEnterNewline: Bool {
+        didSet { save() }
+    }
+
     /// Soft-wrap file editor lines to the viewport width. Off by default so
     /// long lines scroll horizontally.
     @Published var wrapLines: Bool {
@@ -226,6 +235,7 @@ final class AppSettings: nonisolated ObservableObject {
             ?? toml["font-thicken"]?.bool
             ?? false
         macosOptionAsAlt = toml["terminal.macos-option-as-alt"]?.bool ?? false
+        shiftEnterNewline = toml["terminal.shift-enter-newline"]?.bool ?? true
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
         terminalBackend = TerminalBackend(persisted: toml["terminal.backend"]?.string)
@@ -273,6 +283,7 @@ final class AppSettings: nonisolated ObservableObject {
         themeDark = Theme.defaultDarkThemeName
         themeLight = Theme.defaultLightThemeName
         macosOptionAsAlt = false
+        shiftEnterNewline = true
         wrapLines = false
         restoreTerminalHistory = false
         terminalBackend = .fallback
@@ -303,6 +314,9 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if macosOptionAsAlt {
             lines.append("terminal.macos-option-as-alt = true")
+        }
+        if !shiftEnterNewline {
+            lines.append("terminal.shift-enter-newline = false")
         }
         if wrapLines {
             lines.append("editor.wrap-lines = true")

--- a/kero/KeroTerminalView+Ghostty.swift
+++ b/kero/KeroTerminalView+Ghostty.swift
@@ -112,6 +112,22 @@ extension KeroTerminalView {
             ] {
                 builder.withCustom("keybind", keybind)
             }
+            // Shift+Enter sends a line feed (LF) so coding agents running in
+            // the terminal insert a newline instead of submitting the prompt.
+            // They read LF as a literal newline and CR as submit, so this
+            // needs no agent changes. Gated by `shiftEnterNewline` so a user
+            // who wants the default macOS behavior can turn it off.
+            //
+            // Both triggers are bound: `enter` is the main Return key and
+            // `numpad_enter` is the keypad Enter key. Ghostty (W3C key-code
+            // spec) treats them as distinct triggers, and in legacy/XTerm
+            // encoding both default to CR, so each needs its own binding for
+            // parity with the Alacritty backend, which handles macOS keyCodes
+            // 36 (Return) and 76 (keypad Enter).
+            if settings.shiftEnterNewline {
+                builder.withCustom("keybind", "shift+enter=text:\\x0a")
+                builder.withCustom("keybind", "shift+numpad_enter=text:\\x0a")
+            }
             builder.withCustom("command", "shell:\(command)")
             builder.withCustom("term", "xterm-256color")
             builder.withCustom("shell-integration", "none")

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -3245,6 +3245,22 @@
         }
       }
     },
+    "Lets coding agents insert a new line with Shift+Enter while Enter still submits the prompt." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shift+Enter でコーディングエージェントに改行を挿入します。Enter は引き続きプロンプトを送信します。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用 Shift+Enter 为编程智能体插入换行，而 Enter 仍用于提交提示。"
+          }
+        }
+      }
+    },
     "Light" : {
       "comment" : "Light app appearance.",
       "localizations" : {
@@ -5581,6 +5597,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共享"
+          }
+        }
+      }
+    },
+    "Shift+Enter inserts a newline" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shift+Enter で改行を挿入"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shift+Enter 插入换行"
           }
         }
       }

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -171,6 +171,14 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
 
                 Toggle(
+                    "Shift+Enter inserts a newline",
+                    isOn: $settings.shiftEnterNewline
+                )
+                Text("Lets coding agents insert a new line with Shift+Enter while Enter still submits the prompt.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                Toggle(
                     "Restore session history on relaunch",
                     isOn: $settings.restoreTerminalHistory
                 )
@@ -206,6 +214,7 @@ struct SettingsView: View {
                         && settings.sidebarFontSize == AppSettings.defaultSidebarFontSize
                         && !settings.fontThicken
                         && !settings.macosOptionAsAlt
+                        && settings.shiftEnterNewline
                         && settings.language == .system
                         && settings.theme == .system
                         && settings.themeDark == Theme.defaultDarkThemeName


### PR DESCRIPTION
## What

Adds Shift+Enter = newline to both terminal backends (Ghostty and Alacritty), gated by a new Settings toggle that is on by default.

## Why

Prompt-driven coding agents that run in the terminal read CR as submit and LF as a literal newline. macOS delivers the same CR for Enter and Shift+Enter, so without a distinct byte the agent cannot tell them apart and Shift+Enter submits the prompt instead of inserting a line. Today Kero has no setting or config path to change this on either backend; a user has no way to enable it.

## How

- Enter keeps sending CR on both backends. Shift+Enter now sends LF.
- Ghostty backend: binds `shift+enter` and `shift+numpad_enter` to `text:\x0a`. Both triggers are needed because Ghostty treats them as distinct keys (W3C key-code spec) and emits CR for each by default, so a single binding would miss the keypad.
- Alacritty backend: returns LF for Return and keypad Enter (macOS keyCodes 36 and 76) when Shift is held, in `AlacrittyKeyMap.specialKey`. Kero owns key encoding here and does not use Alacritty's config.
- New `AppSettings.shiftEnterNewline` (default on), persisted as `terminal.shift-enter-newline`, with a Settings toggle and ja + zh-Hans catalog entries.
- No agent changes are needed and no Kitty keyboard protocol is involved. Agents that read LF as a literal newline (the common convention) work as-is.

## Notes

- `text:\x0a` is Ghostty's Zig string-literal syntax for a single LF byte, confirmed against the keybind docs.
- The keypad-Enter trigger name was checked against `src/input/key.zig` on `main` (post #7320): main Enter is `enter`, keypad Enter is `numpad_enter`.
- CONTRIBUTING.md asks for an issue first on anything larger than a fix; happy to open a tracking issue if preferred.

## Testing

- [ ] Build the `kero` scheme in Xcode (arm64, Debug).
- [ ] Ghostty backend: Shift+Enter and Shift+KeypadEnter insert a newline in a coding agent; Enter submits.
- [ ] Alacritty backend: same two checks.
- [ ] Toggle off in Settings; Shift+Enter reverts to submitting on both backends.
- [ ] Relaunch; the toggle persists across restarts.
