### PR TITLE
Draw the Alacritty backend's IME composition the way Alacritty does

### DIFF
--- a/Vendor/alacritty-bridge/examples/dump.rs
+++ b/Vendor/alacritty-bridge/examples/dump.rs
@@ -104,6 +104,8 @@ fn main() {
         display_offset: 0,
         total_lines: 0,
         screen_lines: 0,
+        ime_line: -1,
+        ime_column: -1,
     };
     unsafe { kero_alacritty_snapshot(handle, &mut snapshot) };
 

--- a/Vendor/alacritty-bridge/include/kero_alacritty.h
+++ b/Vendor/alacritty-bridge/include/kero_alacritty.h
@@ -113,6 +113,12 @@ typedef struct {
   size_t display_offset;
   size_t total_lines;
   size_t screen_lines;
+  /// Viewport-relative cursor for IME anchoring, or -1 when scrolled out of the
+  /// viewport. Unlike `cursor_line`/`cursor_column` this ignores cursor
+  /// visibility, so an application that hides the cursor and draws its own
+  /// caret still composes at the grid cursor.
+  intptr_t ime_line;
+  intptr_t ime_column;
 } KeroSnapshot;
 
 typedef struct {

--- a/Vendor/alacritty-bridge/include/kero_alacritty.h
+++ b/Vendor/alacritty-bridge/include/kero_alacritty.h
@@ -260,6 +260,11 @@ void kero_alacritty_take_damage(KeroTerminal *handle, KeroDamage *out);
 /// Whether a DEC synchronized update is still being buffered.
 bool kero_alacritty_synchronized_update(KeroTerminal *handle);
 
+/// Sets the uncommitted IME composition drawn at the cursor, or clears it when
+/// `text` is NULL or empty. `caret` is a byte offset into `text` and decides
+/// where the candidate window is anchored.
+void kero_alacritty_set_preedit(KeroTerminal *handle, const char *text, size_t caret);
+
 /// Fills `out` with the visible grid.
 void kero_alacritty_snapshot(KeroTerminal *handle, KeroSnapshot *out);
 

--- a/Vendor/alacritty-bridge/src/lib.rs
+++ b/Vendor/alacritty-bridge/src/lib.rs
@@ -36,7 +36,7 @@ use alacritty_terminal::sync::FairMutex;
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::term::search::{Match, RegexIter, RegexSearch};
-use alacritty_terminal::term::{Config, Osc52, Term, TermDamage, TermMode};
+use alacritty_terminal::term::{point_to_viewport, Config, Osc52, Term, TermDamage, TermMode};
 use alacritty_terminal::tty::{self, EventedPty, EventedReadWrite};
 use alacritty_terminal::vte::ansi::{Color, CursorShape, CursorStyle, NamedColor, Rgb};
 use polling::{Event as PollingEvent, PollMode, Poller};
@@ -155,6 +155,12 @@ pub struct KeroSnapshot {
     pub display_offset: usize,
     pub total_lines: usize,
     pub screen_lines: usize,
+    /// Viewport-relative cursor for IME anchoring, or -1 when it is scrolled
+    /// out of the viewport. Unlike `cursor_line`/`cursor_column` this ignores
+    /// cursor visibility: a full-screen application that hides the cursor and
+    /// draws its own caret still composes at the grid cursor.
+    pub ime_line: isize,
+    pub ime_column: isize,
 }
 
 #[repr(C)]
@@ -2057,6 +2063,21 @@ mod tests {
     }
 
     #[test]
+    fn ime_anchor_follows_the_grid_cursor_into_the_viewport() {
+        assert_eq!(ime_anchor(0, 24, Point::new(Line(3), Column(5))), (3, 5));
+        // Scrolled back by five rows: the same cell is five rows further down.
+        assert_eq!(ime_anchor(5, 24, Point::new(Line(3), Column(5))), (8, 5));
+    }
+
+    #[test]
+    fn ime_anchor_is_dropped_once_the_cursor_leaves_the_viewport() {
+        // Scrolled far enough that the cursor sits below the visible rows.
+        assert_eq!(ime_anchor(24, 24, Point::new(Line(3), Column(5))), (-1, -1));
+        // Cursor still in scrollback while the viewport shows the live prompt.
+        assert_eq!(ime_anchor(0, 24, Point::new(Line(-2), Column(5))), (-1, -1));
+    }
+
+    #[test]
     fn osc8_url_lookup_returns_visible_cell_bounds() {
         let term = parse(b"x\x1b]8;;https://kero.sh\x1b\\Kero\x1b]8;;\x1b\\ y");
         let (url, bounds) = hyperlink_url_at(&term, Point::new(Line(0), Column(2))).unwrap();
@@ -2221,6 +2242,20 @@ pub unsafe extern "C" fn kero_alacritty_take_damage(
     };
 }
 
+/// Viewport-relative cursor an input method should compose at, or `(-1, -1)`
+/// once it scrolls out of view.
+///
+/// Mirrors Alacritty's `ime_position`: the grid cursor is mapped through the
+/// display offset and only dropped when it leaves the viewport. Cursor
+/// visibility deliberately plays no part — an application that hides the cursor
+/// and draws its own caret still composes at the grid cursor.
+fn ime_anchor(display_offset: usize, screen_lines: usize, cursor: Point) -> (isize, isize) {
+    match point_to_viewport(display_offset, cursor) {
+        Some(point) if point.line < screen_lines => (point.line as isize, point.column.0 as isize),
+        _ => (-1, -1),
+    }
+}
+
 /// Fills `out` with the visible grid.
 ///
 /// The cell array belongs to the handle and stays valid only until the next
@@ -2351,6 +2386,7 @@ pub unsafe extern "C" fn kero_alacritty_snapshot(
     } else {
         (cursor.point.line.0 as isize, cursor.point.column.0 as isize)
     };
+    let (ime_line, ime_column) = ime_anchor(content.display_offset, screen_lines, cursor.point);
 
     *out = KeroSnapshot {
         cells: terminal.cells.as_ptr(),
@@ -2375,6 +2411,8 @@ pub unsafe extern "C" fn kero_alacritty_snapshot(
         display_offset: content.display_offset,
         total_lines: term.total_lines(),
         screen_lines,
+        ime_line,
+        ime_column,
     };
 }
 

--- a/Vendor/alacritty-bridge/src/lib.rs
+++ b/Vendor/alacritty-bridge/src/lib.rs
@@ -40,6 +40,7 @@ use alacritty_terminal::term::{point_to_viewport, Config, Osc52, Term, TermDamag
 use alacritty_terminal::tty::{self, EventedPty, EventedReadWrite};
 use alacritty_terminal::vte::ansi::{Color, CursorShape, CursorStyle, NamedColor, Rgb};
 use polling::{Event as PollingEvent, PollMode, Poller};
+use unicode_width::UnicodeWidthChar;
 
 use graphics_event_loop::{
     GraphicsEventLoop, GraphicsEventLoopSender, GraphicsMsg, GraphicsNotifier,
@@ -876,9 +877,22 @@ pub struct KeroTerminal {
     /// Retains each placement's PNG while C pointers are visible to Swift.
     kitty_images: Vec<Arc<[u8]>>,
     last_kitty_damage_revision: u64,
+    /// Uncommitted IME composition, drawn into the grid at the cursor.
+    preedit: Option<Preedit>,
     /// Set once the shell has exited, so teardown does not wait on a loop that
     /// has already stopped.
     exited: bool,
+}
+
+/// Text an input method is still composing.
+///
+/// Kept here rather than in the host so it is drawn as grid cells, the way
+/// Alacritty's `draw_ime_preview` does: an overlay measured in points cannot
+/// line up with the cell grid, and its own clipping cuts the composition off.
+struct Preedit {
+    text: String,
+    /// Byte offset of the composition caret within `text`.
+    caret: usize,
 }
 
 fn pack(rgb: Rgb) -> u32 {
@@ -1075,6 +1089,7 @@ pub unsafe extern "C" fn kero_alacritty_new(
         kitty_placements: Vec::new(),
         kitty_images: Vec::new(),
         last_kitty_damage_revision: 0,
+        preedit: None,
         exited: false,
     }))
 }
@@ -2062,6 +2077,114 @@ mod tests {
         assert!(text.contains("\x1b]8;;\x1b\\"));
     }
 
+    fn preedit_row(columns: usize) -> Vec<KeroCell> {
+        vec![
+            KeroCell {
+                ch: u32::from(' '),
+                fg: 0,
+                bg: 0,
+                text_offset: 0,
+                text_len: 0,
+                flags: 0,
+            };
+            columns
+        ]
+    }
+
+    fn row_text(row: &[KeroCell]) -> String {
+        row.iter()
+            .filter(|cell| cell.flags & KERO_CELL_WIDE_SPACER == 0)
+            .map(|cell| char::from_u32(cell.ch).unwrap_or(' '))
+            .collect()
+    }
+
+    #[test]
+    fn preedit_is_drawn_underlined_at_the_cursor() {
+        let mut row = preedit_row(10);
+        let preedit = Preedit {
+            text: "ni".to_owned(),
+            caret: 2,
+        };
+
+        let anchor = overlay_preedit(&mut row, 3, &preedit, 0, 0);
+
+        assert_eq!(row_text(&row), "   ni     ");
+        assert!(row[3].flags & KERO_CELL_UNDERLINE != 0);
+        assert!(row[4].flags & KERO_CELL_UNDERLINE != 0);
+        // The caret sits just past the composition.
+        assert_eq!(anchor, 5);
+    }
+
+    #[test]
+    fn preedit_anchor_follows_the_caret_inside_the_composition() {
+        let mut row = preedit_row(10);
+        let preedit = Preedit {
+            text: "nihao".to_owned(),
+            caret: 2,
+        };
+
+        assert_eq!(overlay_preedit(&mut row, 0, &preedit, 0, 0), 2);
+    }
+
+    #[test]
+    fn preedit_reserves_two_cells_per_wide_character() {
+        let mut row = preedit_row(10);
+        let preedit = Preedit {
+            text: "你好".to_owned(),
+            caret: "你好".len(),
+        };
+
+        let anchor = overlay_preedit(&mut row, 0, &preedit, 0, 0);
+
+        assert!(row[0].flags & KERO_CELL_WIDE != 0);
+        assert!(row[1].flags & KERO_CELL_WIDE_SPACER != 0);
+        assert!(row[2].flags & KERO_CELL_WIDE != 0);
+        assert!(row[3].flags & KERO_CELL_WIDE_SPACER != 0);
+        assert_eq!(anchor, 4);
+    }
+
+    #[test]
+    fn preedit_slides_left_instead_of_running_off_the_row() {
+        let mut row = preedit_row(8);
+        let preedit = Preedit {
+            text: "nihao".to_owned(),
+            caret: 5,
+        };
+
+        // Anchored at column 6 the composition would need columns 6..11.
+        let anchor = overlay_preedit(&mut row, 6, &preedit, 0, 0);
+
+        assert_eq!(row_text(&row), "   nihao");
+        assert_eq!(anchor, 8);
+    }
+
+    #[test]
+    fn preedit_longer_than_the_row_keeps_its_tail() {
+        let mut row = preedit_row(4);
+        let preedit = Preedit {
+            text: "nihaoma".to_owned(),
+            caret: 7,
+        };
+
+        let anchor = overlay_preedit(&mut row, 0, &preedit, 0, 0);
+
+        assert_eq!(row_text(&row), "…oma");
+        assert_eq!(anchor, 4);
+    }
+
+    #[test]
+    fn preedit_with_the_caret_past_the_row_keeps_its_head() {
+        let mut row = preedit_row(4);
+        let preedit = Preedit {
+            text: "nihaoma".to_owned(),
+            caret: 0,
+        };
+
+        overlay_preedit(&mut row, 0, &preedit, 0, 0);
+
+        assert_eq!(row_text(&row), "nih…");
+    }
+
     #[test]
     fn ime_anchor_follows_the_grid_cursor_into_the_viewport() {
         assert_eq!(ime_anchor(0, 24, Point::new(Line(3), Column(5))), (3, 5));
@@ -2242,6 +2365,119 @@ pub unsafe extern "C" fn kero_alacritty_take_damage(
     };
 }
 
+/// The shortener Alacritty puts in place of the part of a composition that does
+/// not fit the row.
+const PREEDIT_SHORTENER: char = '…';
+
+fn char_cells(c: char) -> usize {
+    c.width().unwrap_or(1)
+}
+
+fn str_cells(text: &str) -> usize {
+    text.chars().map(char_cells).sum()
+}
+
+/// The part of `text` that fits in `columns` cells, shortened with `…`.
+///
+/// `from_start` keeps the beginning and marks the dropped tail, which is what
+/// Alacritty does once the caret itself is past the end of the row; otherwise
+/// the tail is kept so the caret stays visible.
+fn shorten_preedit(text: &str, columns: usize, from_start: bool) -> String {
+    if columns == 0 {
+        return String::new();
+    }
+    if str_cells(text) <= columns {
+        return text.to_owned();
+    }
+
+    let budget = columns - char_cells(PREEDIT_SHORTENER);
+    let mut kept: Vec<char> = Vec::new();
+    let mut cells = 0;
+    let source: Box<dyn Iterator<Item = char>> = if from_start {
+        Box::new(text.chars())
+    } else {
+        Box::new(text.chars().rev())
+    };
+    for c in source {
+        let width = char_cells(c);
+        if cells + width > budget {
+            break;
+        }
+        cells += width;
+        kept.push(c);
+    }
+
+    if from_start {
+        kept.push(PREEDIT_SHORTENER);
+        kept.into_iter().collect()
+    } else {
+        kept.push(PREEDIT_SHORTENER);
+        kept.into_iter().rev().collect()
+    }
+}
+
+/// Draws `preedit` into `row` and returns the column an input method should
+/// anchor its candidate window at.
+///
+/// Mirrors Alacritty's `draw_ime_preview`: the composition is underlined, it
+/// slides left so its tail never runs past the last column, and the anchor
+/// follows the composition caret rather than the start of the text.
+fn overlay_preedit(
+    row: &mut [KeroCell],
+    anchor_column: usize,
+    preedit: &Preedit,
+    foreground: u32,
+    background: u32,
+) -> usize {
+    let columns = row.len();
+    if columns == 0 {
+        return anchor_column;
+    }
+
+    let caret = preedit.caret.min(preedit.text.len());
+    let caret_to_end = str_cells(&preedit.text[caret..]);
+    let visible = if caret_to_end > columns {
+        shorten_preedit(&preedit.text[caret..], columns, true)
+    } else {
+        shorten_preedit(&preedit.text, columns, false)
+    };
+
+    let visible_cells = str_cells(&visible);
+    let end = (anchor_column + visible_cells).min(columns);
+    let mut column = end.saturating_sub(visible_cells);
+
+    for c in visible.chars() {
+        let width = char_cells(c);
+        if width == 0 || column >= columns {
+            continue;
+        }
+        row[column] = KeroCell {
+            ch: u32::from(c),
+            fg: foreground,
+            bg: background,
+            text_offset: 0,
+            text_len: 0,
+            flags: KERO_CELL_UNDERLINE | if width > 1 { KERO_CELL_WIDE } else { 0 },
+        };
+        for spacer in 1..width {
+            let Some(cell) = row.get_mut(column + spacer) else {
+                break;
+            };
+            *cell = KeroCell {
+                ch: 0,
+                fg: foreground,
+                bg: background,
+                text_offset: 0,
+                text_len: 0,
+                flags: KERO_CELL_UNDERLINE | KERO_CELL_WIDE_SPACER,
+            };
+        }
+        column += width;
+    }
+
+    end.saturating_sub(caret_to_end)
+}
+
 /// Viewport-relative cursor an input method should compose at, or `(-1, -1)`
 /// once it scrolls out of view.
 ///
@@ -2254,6 +2490,44 @@ fn ime_anchor(display_offset: usize, screen_lines: usize, cursor: Point) -> (isi
         Some(point) if point.line < screen_lines => (point.line as isize, point.column.0 as isize),
         _ => (-1, -1),
     }
+}
+
+/// Sets the uncommitted IME composition drawn at the cursor, or clears it when
+/// `text` is null or empty.
+///
+/// `caret` is a byte offset into `text` and decides where the candidate window
+/// is anchored.
+///
+/// # Safety
+/// `handle` must be live and `text`, when non-null, must be a NUL-terminated
+/// UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn kero_alacritty_set_preedit(
+    handle: *mut KeroTerminal,
+    text: *const c_char,
+    caret: usize,
+) {
+    if handle.is_null() {
+        return;
+    }
+    let terminal = &mut *handle;
+    let text = if text.is_null() {
+        String::new()
+    } else {
+        CStr::from_ptr(text).to_string_lossy().into_owned()
+    };
+
+    terminal.preedit = if text.is_empty() {
+        None
+    } else {
+        // A caret landing inside a multi-byte character would panic when the
+        // text is sliced, so snap it to a boundary.
+        let mut caret = caret.min(text.len());
+        while caret > 0 && !text.is_char_boundary(caret) {
+            caret -= 1;
+        }
+        Some(Preedit { text, caret })
+    };
 }
 
 /// Fills `out` with the visible grid.
@@ -2386,7 +2660,17 @@ pub unsafe extern "C" fn kero_alacritty_snapshot(
     } else {
         (cursor.point.line.0 as isize, cursor.point.column.0 as isize)
     };
-    let (ime_line, ime_column) = ime_anchor(content.display_offset, screen_lines, cursor.point);
+    let (ime_line, mut ime_column) = ime_anchor(content.display_offset, screen_lines, cursor.point);
+    if let (Some(preedit), true) = (terminal.preedit.as_ref(), ime_line >= 0) {
+        let row = ime_line as usize * columns..(ime_line as usize + 1) * columns;
+        ime_column = overlay_preedit(
+            &mut terminal.cells[row],
+            ime_column.max(0) as usize,
+            preedit,
+            theme.foreground,
+            background,
+        ) as isize;
+    }
 
     *out = KeroSnapshot {
         cells: terminal.cells.as_ptr(),

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -808,9 +808,12 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     }
 
     private func updateMarkedTextOverlay(snapshot: KeroSnapshot) {
+        // `ime_line`/`ime_column`, not the drawn cursor: a full-screen TUI hides
+        // the cursor and draws its own caret, and composition still belongs at
+        // the grid cursor.
         guard !markedText.isEmpty,
-              snapshot.cursor_line >= 0,
-              snapshot.cursor_column >= 0
+              snapshot.ime_line >= 0,
+              snapshot.ime_column >= 0
         else {
             markedTextField.isHidden = true
             reportedIMEAnchor = nil
@@ -828,9 +831,9 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         markedTextField.backgroundColor = Theme.terminal(
             dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ).backgroundNSColor
-        let geometry = preeditGeometry(cursorColumn: snapshot.cursor_column)
+        let geometry = preeditGeometry(cursorColumn: snapshot.ime_column)
         let originY = bounds.height - Self.padding.y
-            - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight
+            - CGFloat(snapshot.ime_line + 1) * metrics.cellHeight
         markedTextField.frame = NSRect(
             x: geometry.originX,
             y: originY,
@@ -1824,10 +1827,12 @@ extension AlacrittyTerminalView: NSTextInputClient {
         guard let handle, let window else { return .zero }
         var snapshot = KeroSnapshot()
         kero_alacritty_snapshot(handle, &snapshot)
-        let line = CGFloat(max(snapshot.cursor_line, 0))
+        // A hidden cursor still has a grid position, and anchoring at the
+        // pane's top-left corner instead pushes the panel into the screen edge.
+        let line = CGFloat(max(snapshot.ime_line, 0))
         let caretX: CGFloat = markedText.isEmpty
-            ? Self.padding.x + CGFloat(max(snapshot.cursor_column, 0)) * metrics.cellWidth
-            : preeditGeometry(cursorColumn: snapshot.cursor_column).caretX
+            ? Self.padding.x + CGFloat(max(snapshot.ime_column, 0)) * metrics.cellWidth
+            : preeditGeometry(cursorColumn: max(snapshot.ime_column, 0)).caretX
         // Exclude a full-width character so the panel neither covers the caret
         // nor gets pushed past the end of the row.
         let width = metrics.cellWidth * 2

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -39,6 +39,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     /// The candidate window is anchored at this caret, not at the start of the
     /// composition.
     private var markedTextSelectedRange = NSRange(location: 0, length: 0)
+    /// Anchor last handed to the input method. macOS caches whatever
+    /// `firstRect` returned and will not ask again on its own, so the anchor has
+    /// to be invalidated whenever it moves.
+    private var reportedIMEAnchor: CGPoint?
     private let markedTextField = NSTextField(labelWithString: "")
     private var isSurfaceVisible = false
     /// Covers Metal while a parked surface is moving back into a real pane.
@@ -809,6 +813,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
               snapshot.cursor_column >= 0
         else {
             markedTextField.isHidden = true
+            reportedIMEAnchor = nil
             return
         }
         let attributes: [NSAttributedString.Key: Any] = [
@@ -824,14 +829,31 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ).backgroundNSColor
         let geometry = preeditGeometry(cursorColumn: snapshot.cursor_column)
+        let originY = bounds.height - Self.padding.y
+            - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight
         markedTextField.frame = NSRect(
             x: geometry.originX,
-            y: bounds.height - Self.padding.y
-                - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight,
+            y: originY,
             width: geometry.width,
             height: metrics.cellHeight
         )
         markedTextField.isHidden = false
+        reportIMEAnchor(CGPoint(x: geometry.caretX, y: originY))
+    }
+
+    /// Alacritty re-reports the IME cursor area every frame, and winit's
+    /// `set_ime_cursor_area` invalidates the cached coordinates each time. Without
+    /// that the candidate window keeps the position it was first given, so it
+    /// drifts away from the caret and can end up clipped against a screen edge.
+    private func reportIMEAnchor(_ anchor: CGPoint) {
+        guard reportedIMEAnchor != anchor else { return }
+        reportedIMEAnchor = anchor
+        // The input method answers by calling `firstRect` synchronously, which
+        // takes another snapshot and rebuilds the buffers the in-flight frame
+        // still points at. Let this pass finish first.
+        DispatchQueue.main.async { [weak self] in
+            self?.inputContext?.invalidateCharacterCoordinates()
+        }
     }
 
     private func updateCursorBlinking(_ blinking: Bool) {

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -35,15 +35,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     private var metrics: AlacrittyMetrics
     private var gridSize = (columns: 0, rows: 0)
     private var markedText = ""
-    /// Selection within `markedText` (UTF-16) as the IME last reported it.
-    /// The candidate window is anchored at this caret, not at the start of the
-    /// composition.
-    private var markedTextSelectedRange = NSRange(location: 0, length: 0)
-    /// Anchor last handed to the input method. macOS caches whatever
+    /// Grid anchor last handed to the input method. macOS caches whatever
     /// `firstRect` returned and will not ask again on its own, so the anchor has
     /// to be invalidated whenever it moves.
     private var reportedIMEAnchor: CGPoint?
-    private let markedTextField = NSTextField(labelWithString: "")
     private var isSurfaceVisible = false
     /// Covers Metal while a parked surface is moving back into a real pane.
     /// The cover lives above the drawable so the GPU can acquire and present
@@ -114,13 +109,6 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         wantsLayer = true
         layerContentsRedrawPolicy = .onSetNeedsDisplay
         registerForDraggedTypes([.fileURL])
-        markedTextField.isHidden = true
-        markedTextField.isBezeled = false
-        markedTextField.drawsBackground = true
-        // The field is sized to the composition and slid left to fit, so this
-        // only kicks in when the composition is wider than a whole row.
-        markedTextField.lineBreakMode = .byTruncatingTail
-        addSubview(markedTextField)
         addSubview(progressBar)
         AlacrittyRegistry.shared.register(self, for: token)
         NotificationCenter.default.addObserver(
@@ -623,7 +611,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         kero_alacritty_snapshot(handle, &snapshot)
         applyHoveredURLUnderline(to: &snapshot)
         updateKittyGraphics(handle: handle)
-        updateMarkedTextOverlay(snapshot: snapshot)
+        reportIMEAnchor(snapshot: snapshot)
         updateCursorBlinking(snapshot.cursor_blinking)
         if cursorBlinking, !cursorVisible {
             snapshot.cursor_line = -1
@@ -773,82 +761,16 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         CATransaction.commit()
     }
 
-    /// Where the inline composition sits, following Alacritty's
-    /// `draw_ime_preview`: the preedit slides left so its tail stays inside the
-    /// row instead of running off the right edge, and the candidate window is
-    /// anchored at the composition caret rather than at the terminal cursor.
-    private struct PreeditGeometry {
-        var originX: CGFloat
-        var caretX: CGFloat
-        var width: CGFloat
-    }
-
-    private func preeditGeometry(cursorColumn: Int) -> PreeditGeometry {
-        let rowStart = Self.padding.x
-        let rowEnd = max(bounds.width - Self.padding.x, rowStart + metrics.cellWidth)
-        let cursorX = rowStart + CGFloat(max(cursorColumn, 0)) * metrics.cellWidth
-        // The extra couple of points keep the trailing glyph off the field edge.
-        let width = min(
-            max(measuredPreeditWidth(markedText) + 2, metrics.cellWidth),
-            rowEnd - rowStart
-        )
-        let originX = min(max(cursorX, rowStart), rowEnd - width)
-        let caretPrefix = (markedText as NSString)
-            .substring(to: min(markedTextSelectedRange.location, markedText.utf16.count))
-        let caretX = originX + min(measuredPreeditWidth(caretPrefix), width)
-        return PreeditGeometry(originX: originX, caretX: caretX, width: width)
-    }
-
-    private func measuredPreeditWidth(_ text: String) -> CGFloat {
-        guard !text.isEmpty else { return 0 }
-        return (text as NSString)
-            .size(withAttributes: [.font: metrics.regular])
-            .width
-            .rounded(.up)
-    }
-
-    private func updateMarkedTextOverlay(snapshot: KeroSnapshot) {
-        // `ime_line`/`ime_column`, not the drawn cursor: a full-screen TUI hides
-        // the cursor and draws its own caret, and composition still belongs at
-        // the grid cursor.
-        guard !markedText.isEmpty,
-              snapshot.ime_line >= 0,
-              snapshot.ime_column >= 0
-        else {
-            markedTextField.isHidden = true
-            reportedIMEAnchor = nil
-            return
-        }
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: metrics.regular,
-            .foregroundColor: Theme.terminal(
-                dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ).foregroundNSColor,
-            .underlineStyle: NSUnderlineStyle.single.rawValue,
-        ]
-        let attributed = NSAttributedString(string: markedText, attributes: attributes)
-        markedTextField.attributedStringValue = attributed
-        markedTextField.backgroundColor = Theme.terminal(
-            dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        ).backgroundNSColor
-        let geometry = preeditGeometry(cursorColumn: snapshot.ime_column)
-        let originY = bounds.height - Self.padding.y
-            - CGFloat(snapshot.ime_line + 1) * metrics.cellHeight
-        markedTextField.frame = NSRect(
-            x: geometry.originX,
-            y: originY,
-            width: geometry.width,
-            height: metrics.cellHeight
-        )
-        markedTextField.isHidden = false
-        reportIMEAnchor(CGPoint(x: geometry.caretX, y: originY))
-    }
-
     /// Alacritty re-reports the IME cursor area every frame, and winit's
     /// `set_ime_cursor_area` invalidates the cached coordinates each time. Without
     /// that the candidate window keeps the position it was first given, so it
     /// drifts away from the caret and can end up clipped against a screen edge.
-    private func reportIMEAnchor(_ anchor: CGPoint) {
+    private func reportIMEAnchor(snapshot: KeroSnapshot) {
+        guard !markedText.isEmpty, snapshot.ime_line >= 0, snapshot.ime_column >= 0 else {
+            reportedIMEAnchor = nil
+            return
+        }
+        let anchor = CGPoint(x: snapshot.ime_column, y: snapshot.ime_line)
         guard reportedIMEAnchor != anchor else { return }
         reportedIMEAnchor = anchor
         // The input method answers by calling `firstRect` synchronously, which
@@ -1770,8 +1692,9 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
 // MARK: - Text input
 
-/// Enough of `NSTextInputClient` for IME: composition is shown inline at the
-/// cursor and only committed text reaches the PTY.
+/// Enough of `NSTextInputClient` for IME: only committed text reaches the PTY,
+/// and the composition is handed to the terminal to be drawn as grid cells the
+/// way Alacritty's `draw_ime_preview` does.
 ///
 /// Mark-rect geometry follows Alacritty's `Window::update_ime_position`: the
 /// rect covers a fixed two cells at the composition caret. Reporting the whole
@@ -1780,8 +1703,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 /// off — the same trap Alacritty documents for other platforms' popups.
 extension AlacrittyTerminalView: NSTextInputClient {
     func insertText(_ string: Any, replacementRange: NSRange) {
-        markedText = ""
-        markedTextSelectedRange = NSRange(location: 0, length: 0)
+        setPreedit("", caret: 0)
         let text = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
         guard !text.isEmpty else { return }
         write(Array(text.utf8))
@@ -1790,15 +1712,32 @@ extension AlacrittyTerminalView: NSTextInputClient {
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         let text = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
-        markedText = text
-        markedTextSelectedRange = Self.clampedIMERange(selectedRange, in: text)
+        let clamped = Self.clampedIMERange(selectedRange, in: text)
+        setPreedit(text, caret: Self.utf8Offset(ofUTF16: clamped.location, in: text))
         scheduleRender(force: true)
     }
 
     func unmarkText() {
-        markedText = ""
-        markedTextSelectedRange = NSRange(location: 0, length: 0)
+        setPreedit("", caret: 0)
         scheduleRender(force: true)
+    }
+
+    /// Hands the composition to the terminal so it is drawn as grid cells, the
+    /// way Alacritty draws its preedit. Nothing about it is rendered here.
+    private func setPreedit(_ text: String, caret: Int) {
+        markedText = text
+        guard let handle else { return }
+        if text.isEmpty {
+            kero_alacritty_set_preedit(handle, nil, 0)
+        } else {
+            text.withCString { kero_alacritty_set_preedit(handle, $0, caret) }
+        }
+    }
+
+    private static func utf8Offset(ofUTF16 offset: Int, in text: String) -> Int {
+        let index = String.Index(utf16Offset: offset, in: text)
+        guard let utf8Index = index.samePosition(in: text.utf8) else { return text.utf8.count }
+        return text.utf8.distance(from: text.utf8.startIndex, to: utf8Index)
     }
 
     func selectedRange() -> NSRange {
@@ -1827,12 +1766,12 @@ extension AlacrittyTerminalView: NSTextInputClient {
         guard let handle, let window else { return .zero }
         var snapshot = KeroSnapshot()
         kero_alacritty_snapshot(handle, &snapshot)
-        // A hidden cursor still has a grid position, and anchoring at the
-        // pane's top-left corner instead pushes the panel into the screen edge.
+        // `ime_*`, not the drawn cursor: a full-screen application that hides the
+        // cursor still composes at the grid cursor, and anchoring at the pane's
+        // top-left corner instead pushes the panel into the screen edge. While
+        // composing this column is the caret inside the preedit.
         let line = CGFloat(max(snapshot.ime_line, 0))
-        let caretX: CGFloat = markedText.isEmpty
-            ? Self.padding.x + CGFloat(max(snapshot.ime_column, 0)) * metrics.cellWidth
-            : preeditGeometry(cursorColumn: max(snapshot.ime_column, 0)).caretX
+        let caretX = Self.padding.x + CGFloat(max(snapshot.ime_column, 0)) * metrics.cellWidth
         // Exclude a full-width character so the panel neither covers the caret
         // nor gets pushed past the end of the row.
         let width = metrics.cellWidth * 2

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -35,6 +35,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     private var metrics: AlacrittyMetrics
     private var gridSize = (columns: 0, rows: 0)
     private var markedText = ""
+    /// Selection within `markedText` (UTF-16), matching what the IME last
+    /// passed to `setMarkedText`. Needed so `selectedRange` / substring
+    /// queries stay consistent while composing.
+    private var markedTextSelectedRange = NSRange(location: 0, length: 0)
     private let markedTextField = NSTextField(labelWithString: "")
     private var isSurfaceVisible = false
     /// Covers Metal while a parked surface is moving back into a real pane.
@@ -109,7 +113,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         markedTextField.isHidden = true
         markedTextField.isBezeled = false
         markedTextField.drawsBackground = true
-        markedTextField.lineBreakMode = .byClipping
+        // Prefer fitting the field to the text; if the pane edge forces a
+        // clamp, show a tail ellipsis instead of a hard clip that looks like
+        // a broken IME candidate.
+        markedTextField.lineBreakMode = .byTruncatingTail
         addSubview(markedTextField)
         addSubview(progressBar)
         AlacrittyRegistry.shared.register(self, for: token)
@@ -783,12 +790,14 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         markedTextField.backgroundColor = Theme.terminal(
             dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ).backgroundNSColor
-        let width = max(
-            attributed.size().width.rounded(.up) + 2,
-            metrics.cellWidth
+        let x = Self.padding.x + CGFloat(snapshot.cursor_column) * metrics.cellWidth
+        let maxWidth = max(bounds.width - Self.padding.x - x, metrics.cellWidth)
+        let width = min(
+            max(attributed.size().width.rounded(.up) + 2, metrics.cellWidth),
+            maxWidth
         )
         markedTextField.frame = NSRect(
-            x: Self.padding.x + CGFloat(snapshot.cursor_column) * metrics.cellWidth,
+            x: x,
             y: bounds.height - Self.padding.y
                 - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight,
             width: width,
@@ -1709,10 +1718,13 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 // MARK: - Text input
 
 /// Enough of `NSTextInputClient` for IME: composition is shown inline at the
-/// cursor and only committed text reaches the PTY.
+/// cursor and only committed text reaches the PTY. Mark-rect geometry mirrors
+/// Ghostty's `imePoint` so the system candidate window anchors under the full
+/// preedit, not a single cell.
 extension AlacrittyTerminalView: NSTextInputClient {
     func insertText(_ string: Any, replacementRange: NSRange) {
         markedText = ""
+        markedTextSelectedRange = NSRange(location: 0, length: 0)
         let text = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
         guard !text.isEmpty else { return }
         write(Array(text.utf8))
@@ -1720,19 +1732,25 @@ extension AlacrittyTerminalView: NSTextInputClient {
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
-        markedText = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
+        let text = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
+        markedText = text
+        markedTextSelectedRange = Self.clampedIMERange(selectedRange, in: text)
         scheduleRender(force: true)
     }
 
     func unmarkText() {
         markedText = ""
+        markedTextSelectedRange = NSRange(location: 0, length: 0)
         scheduleRender(force: true)
     }
 
     func selectedRange() -> NSRange {
+        if !markedText.isEmpty {
+            return markedTextSelectedRange
+        }
         // Insertion point with no selection. `NSNotFound` makes some IMEs
         // refuse to begin composition against this client.
-        NSRange(location: 0, length: 0)
+        return NSRange(location: 0, length: 0)
     }
 
     func markedRange() -> NSRange {
@@ -1745,21 +1763,44 @@ extension AlacrittyTerminalView: NSTextInputClient {
 
     func attributedSubstring(
         forProposedRange range: NSRange, actualRange: NSRangePointer?
-    ) -> NSAttributedString? { nil }
+    ) -> NSAttributedString? {
+        guard !markedText.isEmpty else { return nil }
+        let clamped = Self.clampedIMERange(range, in: markedText)
+        actualRange?.pointee = clamped
+        let nsText = markedText as NSString
+        return NSAttributedString(string: nsText.substring(with: clamped))
+    }
 
     func validAttributesForMarkedText() -> [NSAttributedString.Key] { [] }
 
-    /// Places the IME candidate window under the cursor.
+    /// Places the IME candidate window under the preedit, matching Ghostty's
+    /// mark rect (preedit-aware width, clamped to the remaining row).
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
         guard let handle, let window else { return .zero }
         var snapshot = KeroSnapshot()
         kero_alacritty_snapshot(handle, &snapshot)
         let column = CGFloat(max(snapshot.cursor_column, 0))
         let line = CGFloat(max(snapshot.cursor_line, 0))
+        let x = Self.padding.x + column * metrics.cellWidth
+        let y = bounds.maxY - Self.padding.y - (line + 1) * metrics.cellHeight
+        let remainingWidth = max(bounds.width - Self.padding.x - x, metrics.cellWidth)
+        let preeditWidth: CGFloat = {
+            guard !markedText.isEmpty else { return metrics.cellWidth }
+            let measured = (markedText as NSString)
+                .size(withAttributes: [.font: metrics.regular])
+                .width
+                .rounded(.up)
+            return min(max(measured, metrics.cellWidth), remainingWidth)
+        }()
+        if let actualRange {
+            actualRange.pointee = markedText.isEmpty
+                ? range
+                : Self.clampedIMERange(range, in: markedText)
+        }
         let local = NSRect(
-            x: Self.padding.x + column * metrics.cellWidth,
-            y: bounds.maxY - Self.padding.y - (line + 1) * metrics.cellHeight,
-            width: metrics.cellWidth,
+            x: x,
+            y: y,
+            width: preeditWidth,
             height: metrics.cellHeight
         )
         return window.convertToScreen(convert(local, to: nil))
@@ -1770,6 +1811,13 @@ extension AlacrittyTerminalView: NSTextInputClient {
     override func doCommand(by selector: Selector) {
         // Key encoding is handled in `keyDown`; anything reaching here would
         // otherwise beep.
+    }
+
+    private static func clampedIMERange(_ range: NSRange, in text: String) -> NSRange {
+        let length = text.utf16.count
+        let location = min(max(range.location, 0), length)
+        let end = min(max(range.location + range.length, location), length)
+        return NSRange(location: location, length: end - location)
     }
 }
 

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -35,9 +35,9 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     private var metrics: AlacrittyMetrics
     private var gridSize = (columns: 0, rows: 0)
     private var markedText = ""
-    /// Selection within `markedText` (UTF-16), matching what the IME last
-    /// passed to `setMarkedText`. Needed so `selectedRange` / substring
-    /// queries stay consistent while composing.
+    /// Selection within `markedText` (UTF-16) as the IME last reported it.
+    /// The candidate window is anchored at this caret, not at the start of the
+    /// composition.
     private var markedTextSelectedRange = NSRange(location: 0, length: 0)
     private let markedTextField = NSTextField(labelWithString: "")
     private var isSurfaceVisible = false
@@ -113,9 +113,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         markedTextField.isHidden = true
         markedTextField.isBezeled = false
         markedTextField.drawsBackground = true
-        // Prefer fitting the field to the text; if the pane edge forces a
-        // clamp, show a tail ellipsis instead of a hard clip that looks like
-        // a broken IME candidate.
+        // The field is sized to the composition and slid left to fit, so this
+        // only kicks in when the composition is wider than a whole row.
         markedTextField.lineBreakMode = .byTruncatingTail
         addSubview(markedTextField)
         addSubview(progressBar)
@@ -770,6 +769,40 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         CATransaction.commit()
     }
 
+    /// Where the inline composition sits, following Alacritty's
+    /// `draw_ime_preview`: the preedit slides left so its tail stays inside the
+    /// row instead of running off the right edge, and the candidate window is
+    /// anchored at the composition caret rather than at the terminal cursor.
+    private struct PreeditGeometry {
+        var originX: CGFloat
+        var caretX: CGFloat
+        var width: CGFloat
+    }
+
+    private func preeditGeometry(cursorColumn: Int) -> PreeditGeometry {
+        let rowStart = Self.padding.x
+        let rowEnd = max(bounds.width - Self.padding.x, rowStart + metrics.cellWidth)
+        let cursorX = rowStart + CGFloat(max(cursorColumn, 0)) * metrics.cellWidth
+        // The extra couple of points keep the trailing glyph off the field edge.
+        let width = min(
+            max(measuredPreeditWidth(markedText) + 2, metrics.cellWidth),
+            rowEnd - rowStart
+        )
+        let originX = min(max(cursorX, rowStart), rowEnd - width)
+        let caretPrefix = (markedText as NSString)
+            .substring(to: min(markedTextSelectedRange.location, markedText.utf16.count))
+        let caretX = originX + min(measuredPreeditWidth(caretPrefix), width)
+        return PreeditGeometry(originX: originX, caretX: caretX, width: width)
+    }
+
+    private func measuredPreeditWidth(_ text: String) -> CGFloat {
+        guard !text.isEmpty else { return 0 }
+        return (text as NSString)
+            .size(withAttributes: [.font: metrics.regular])
+            .width
+            .rounded(.up)
+    }
+
     private func updateMarkedTextOverlay(snapshot: KeroSnapshot) {
         guard !markedText.isEmpty,
               snapshot.cursor_line >= 0,
@@ -790,17 +823,12 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         markedTextField.backgroundColor = Theme.terminal(
             dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ).backgroundNSColor
-        let x = Self.padding.x + CGFloat(snapshot.cursor_column) * metrics.cellWidth
-        let maxWidth = max(bounds.width - Self.padding.x - x, metrics.cellWidth)
-        let width = min(
-            max(attributed.size().width.rounded(.up) + 2, metrics.cellWidth),
-            maxWidth
-        )
+        let geometry = preeditGeometry(cursorColumn: snapshot.cursor_column)
         markedTextField.frame = NSRect(
-            x: x,
+            x: geometry.originX,
             y: bounds.height - Self.padding.y
                 - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight,
-            width: width,
+            width: geometry.width,
             height: metrics.cellHeight
         )
         markedTextField.isHidden = false
@@ -1718,9 +1746,13 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 // MARK: - Text input
 
 /// Enough of `NSTextInputClient` for IME: composition is shown inline at the
-/// cursor and only committed text reaches the PTY. Mark-rect geometry mirrors
-/// Ghostty's `imePoint` so the system candidate window anchors under the full
-/// preedit, not a single cell.
+/// cursor and only committed text reaches the PTY.
+///
+/// Mark-rect geometry follows Alacritty's `Window::update_ime_position`: the
+/// rect covers a fixed two cells at the composition caret. Reporting the whole
+/// preedit width instead makes macOS place the candidate panel at the far end
+/// of the excluded area, where it collides with the screen edge and appears cut
+/// off — the same trap Alacritty documents for other platforms' popups.
 extension AlacrittyTerminalView: NSTextInputClient {
     func insertText(_ string: Any, replacementRange: NSRange) {
         markedText = ""
@@ -1745,12 +1777,9 @@ extension AlacrittyTerminalView: NSTextInputClient {
     }
 
     func selectedRange() -> NSRange {
-        if !markedText.isEmpty {
-            return markedTextSelectedRange
-        }
         // Insertion point with no selection. `NSNotFound` makes some IMEs
         // refuse to begin composition against this client.
-        return NSRange(location: 0, length: 0)
+        NSRange(location: 0, length: 0)
     }
 
     func markedRange() -> NSRange {
@@ -1763,44 +1792,28 @@ extension AlacrittyTerminalView: NSTextInputClient {
 
     func attributedSubstring(
         forProposedRange range: NSRange, actualRange: NSRangePointer?
-    ) -> NSAttributedString? {
-        guard !markedText.isEmpty else { return nil }
-        let clamped = Self.clampedIMERange(range, in: markedText)
-        actualRange?.pointee = clamped
-        let nsText = markedText as NSString
-        return NSAttributedString(string: nsText.substring(with: clamped))
-    }
+    ) -> NSAttributedString? { nil }
 
     func validAttributesForMarkedText() -> [NSAttributedString.Key] { [] }
 
-    /// Places the IME candidate window under the preedit, matching Ghostty's
-    /// mark rect (preedit-aware width, clamped to the remaining row).
+    /// Anchors the IME candidate window at the composition caret, excluding
+    /// only two cells the way Alacritty does.
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
         guard let handle, let window else { return .zero }
         var snapshot = KeroSnapshot()
         kero_alacritty_snapshot(handle, &snapshot)
-        let column = CGFloat(max(snapshot.cursor_column, 0))
         let line = CGFloat(max(snapshot.cursor_line, 0))
-        let x = Self.padding.x + column * metrics.cellWidth
-        let y = bounds.maxY - Self.padding.y - (line + 1) * metrics.cellHeight
-        let remainingWidth = max(bounds.width - Self.padding.x - x, metrics.cellWidth)
-        let preeditWidth: CGFloat = {
-            guard !markedText.isEmpty else { return metrics.cellWidth }
-            let measured = (markedText as NSString)
-                .size(withAttributes: [.font: metrics.regular])
-                .width
-                .rounded(.up)
-            return min(max(measured, metrics.cellWidth), remainingWidth)
-        }()
-        if let actualRange {
-            actualRange.pointee = markedText.isEmpty
-                ? range
-                : Self.clampedIMERange(range, in: markedText)
-        }
+        let caretX: CGFloat = markedText.isEmpty
+            ? Self.padding.x + CGFloat(max(snapshot.cursor_column, 0)) * metrics.cellWidth
+            : preeditGeometry(cursorColumn: snapshot.cursor_column).caretX
+        // Exclude a full-width character so the panel neither covers the caret
+        // nor gets pushed past the end of the row.
+        let width = metrics.cellWidth * 2
+        let maxX = max(bounds.width - Self.padding.x - width, Self.padding.x)
         let local = NSRect(
-            x: x,
-            y: y,
-            width: preeditWidth,
+            x: min(caretX, maxX),
+            y: bounds.maxY - Self.padding.y - (line + 1) * metrics.cellHeight,
+            width: width,
             height: metrics.cellHeight
         )
         return window.convertToScreen(convert(local, to: nil))


### PR DESCRIPTION
> **Heads up — this is a structural change, not a tweak.** IME composition moves out of the Swift view and into the terminal: the `NSTextField` overlay is deleted, `KeroSnapshot` gains two fields, and there is a new FFI entry point. Xcode rebuilds the Rust automatically (`src/lib.rs` is a declared input of the *Build Alacritty bridge* phase), so no extra step is needed, but the bridge does have to compile — a Rust toolchain is required exactly as before.

## Summary

Composing CJK in the Alacritty backend misplaced and cut off the system IME candidate window. Official Alacritty is fine, so this walks through its macOS path and adopts it. Four things differed, and the first is the reason geometry-only fixes could not work.

### 1. The composition was an overlay, not grid cells

Kero drew the preedit into an `NSTextField` laid over the Metal view: measured in points with a proportional-fallback font against a cell grid, clipped by its own bounds, and hidden entirely whenever the snapshot reported no drawable cursor.

Alacritty draws it into the grid (`Display::draw_ime_preview`) — cell-aligned, underlined, two cells per wide character, shortened with `…` when it exceeds the row, and slid left so the tail never runs past the last column:

```rust
let end = cmp::min(point.column.0 + visible_len, num_cols);
let start = end.saturating_sub(visible_len);
```

The composition now lives in the terminal (`kero_alacritty_set_preedit`) and is written into the snapshot's cells, so the existing row rebuild renders it and the caret column comes from the grid rather than from a point measurement.

### 2. The IME anchor was discarded whenever the cursor was hidden

The snapshot collapsed "cursor hidden" and "scrolled back" into a cursor position of `-1`, and the IME path clamped that to zero. Composing inside a full-screen TUI — which hides the real cursor and draws its own caret — therefore anchored the candidate window at the **pane's top-left corner**.

Alacritty derives `ime_position` from the grid cursor mapped through the display offset, and visibility never enters into it:

```rust
term::point_to_viewport(display_offset, cursor_point)
    .filter(|point| point.line < num_lines)
```

### 3. The cached mark rect was never invalidated

macOS caches whatever `firstRect(forCharacterRange:)` returned and does not ask again on its own. Alacritty re-reports the IME cursor area every frame, and winit's `set_ime_cursor_area` calls `invalidateCharacterCoordinates()` each time. Nothing in Kero did, so the panel kept the geometry from the first query.

### 4. The excluded rect was the wrong shape

Alacritty deliberately excludes only **two cells** at the composition caret:

> some compositors don't like excluding too much and try to render popup at the bottom right corner of the provided area, so exclude just the full-width char to not obscure the cursor and not render popup at the end of the window

Kero reported a single cell at the terminal cursor.

## What changed

**Rust bridge** (`Vendor/alacritty-bridge`, in-tree — not a submodule)

- New `kero_alacritty_set_preedit(handle, text, caret)` takes the composition and a byte offset for its caret, and clears on NULL/empty
- `kero_alacritty_snapshot` draws the composition into the cursor's row: `unicode-width` cell widths, `KERO_CELL_WIDE` + spacer for wide characters, underline, ellipsis shortening, and Alacritty's slide-left placement
- `KeroSnapshot` gains `ime_line` / `ime_column`, **appended at the end** so no existing field offset moves. They are derived with `point_to_viewport` and are independent of cursor visibility; while composing, `ime_column` is the caret inside the preedit
- Header and `examples/dump.rs` updated in step (the header is hand-maintained)

**Swift** (`AlacrittyTerminalView`)

- `markedTextField` and every bit of its geometry — measurement, slide, clipping mode, the `PreeditGeometry` helper — deleted
- `setMarkedText` / `unmarkText` / `insertText` forward to the terminal; the view keeps only what `NSTextInputClient` has to answer
- `firstRect` returns a two-cell rect at the reported caret, clamped to the row
- The anchor is re-reported and the cached coordinates invalidated whenever it moves, deferred past the render pass — the requery calls `firstRect`, which takes another snapshot and would otherwise rebuild the buffers the in-flight frame still points at

Behaviour outside IME composition is untouched: with no composition the new overlay is skipped entirely, and `cursor_line` / `cursor_column` keep their existing meaning for cursor drawing.

## Test plan

- [x] `cargo test --lib` — 27 pass, including new cases for the underlined composition, the caret anchor, two cells per wide character, sliding left at the row edge, and both ellipsis directions
- [x] `cargo clippy` / `cargo fmt --check` clean apart from a pre-existing `type_complexity` warning
- [x] `cargo build --release --locked` succeeds and exports `kero_alacritty_set_preedit`
- [x] Verified locally on macOS: composing Chinese in a full-screen TUI now behaves like official Alacritty — the composition renders cell-aligned at the caret and the candidate window is no longer cut off

## Unrelated: stutter under fast agent output

Noticed while testing this branch, and worth writing down even though it is a separate problem: with the Alacritty backend, output from a coding agent CLI that redraws quickly stutters noticeably. It reproduces without this change, and nothing here plausibly contributes — the grid overlay only runs while `preedit` is set, and the per-frame anchor check returns immediately when nothing is being composed.

An attempt at it (#94, since closed) did **not** fix the stutter. What it did establish is that the draw path is not the bottleneck. A capture with `KERO_RENDER_STATS=1` during agent output:

```
drawn=36 skipped=0 deferred=0 rows=60  mean=0.360ms worst=1.540ms
drawn=60 skipped=0 deferred=0 rows=217 mean=1.207ms worst=5.224ms
```

Frames cost well under a millisecond, row-level damage is working (~1.7 rows rebuilt per frame), and a frame-in-flight cap never fired, so `nextDrawable()` was never blocking.

The suspicious part of the same capture is earlier, while the agent was redrawing: `drawn=3` with `rows=99`, i.e. three frames a second, each rebuilding the whole 33-row grid. Three frames a second at 4ms per frame is not a slow renderer — it is a screen being withheld. The likely candidate is DEC 2026 synchronized updates, which Kero honours by returning early without drawing, and that path records no counter at all, so it stays invisible in the current stats. Two other things found while looking, unfixed and unrelated to this PR:

- `reportScroll()` runs on every wakeup and reads its three integers from `kero_alacritty_snapshot`, which clears, resizes and refills the entire visible cell buffer under the terminal lock — a second full-grid export per read batch, contending with the PTY parse loop
- damage is taken before the drawable is acquired, so a `nextDrawable()` that times out and returns nil drops those rows until something happens to touch them again
