### PR TITLE
Reduce Alacritty backend per-wakeup cost, and instrument what a frame waits on

### DIFF
--- a/Vendor/alacritty-bridge/include/kero_alacritty.h
+++ b/Vendor/alacritty-bridge/include/kero_alacritty.h
@@ -93,6 +93,15 @@ typedef struct {
   uint32_t cursor;
 } KeroTheme;
 
+/// The scrollbar's view of the grid, without any cell contents.
+typedef struct {
+  /// Rows scrolled back from the live prompt.
+  size_t display_offset;
+  /// Rows in the viewport plus the scrollback behind it.
+  size_t total_lines;
+  size_t screen_lines;
+} KeroScrollState;
+
 typedef struct {
   /// `columns * rows` cells in row-major order. Owned by the handle and valid
   /// only until the next call on it.
@@ -225,6 +234,10 @@ size_t kero_alacritty_find(KeroTerminal *handle, const char *needle);
 intptr_t kero_alacritty_find_step(KeroTerminal *handle, bool forward);
 
 void kero_alacritty_find_end(KeroTerminal *handle);
+
+/// Fills `out` with just the numbers the scrollbar needs. Runs on every wakeup,
+/// so it deliberately avoids exporting any cells.
+void kero_alacritty_scroll_state(KeroTerminal *handle, KeroScrollState *out);
 
 /// Whether the primary screen has rows above the viewport.
 bool kero_alacritty_has_scrollback(KeroTerminal *handle);

--- a/Vendor/alacritty-bridge/src/lib.rs
+++ b/Vendor/alacritty-bridge/src/lib.rs
@@ -133,6 +133,16 @@ pub struct KeroTheme {
     pub cursor: u32,
 }
 
+/// The scrollbar's view of the grid, without any cell contents.
+#[repr(C)]
+pub struct KeroScrollState {
+    /// Rows scrolled back from the live prompt.
+    pub display_offset: usize,
+    /// Rows in the viewport plus the scrollback behind it.
+    pub total_lines: usize,
+    pub screen_lines: usize,
+}
+
 #[repr(C)]
 pub struct KeroSnapshot {
     /// `columns * rows` cells in row-major order, owned by the handle and
@@ -1872,6 +1882,31 @@ pub unsafe extern "C" fn kero_alacritty_url_at(
     }
     std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer, bytes.len());
     bytes.len()
+}
+
+/// Fills `out` with just the numbers Kero's scrollbar needs.
+///
+/// Separate from `kero_alacritty_snapshot` because this runs on every wakeup: a
+/// program printing quickly wakes the host many times per second, and exporting
+/// the whole grid to read three integers is the most expensive thing a frame can
+/// do without drawing anything.
+///
+/// # Safety
+/// `handle` must be live and `out` must be a valid `KeroScrollState`.
+#[no_mangle]
+pub unsafe extern "C" fn kero_alacritty_scroll_state(
+    handle: *mut KeroTerminal,
+    out: *mut KeroScrollState,
+) {
+    if handle.is_null() || out.is_null() {
+        return;
+    }
+    let term = (*handle).term.lock();
+    *out = KeroScrollState {
+        display_offset: term.grid().display_offset(),
+        total_lines: term.total_lines(),
+        screen_lines: term.screen_lines(),
+    };
 }
 
 /// Whether the primary screen has rows above the viewport — Kero uses this to

--- a/kero/Alacritty/AlacrittyRenderStats.swift
+++ b/kero/Alacritty/AlacrittyRenderStats.swift
@@ -21,9 +21,14 @@ final class AlacrittyRenderStats: @unchecked Sendable {
     private var frames = 0
     private var skippedFrames = 0
     private var deferredFrames = 0
+    private var suppressedFrames = 0
+    private var wakeups = 0
     private var rebuiltRows = 0
     private var totalSeconds: Double = 0
     private var worstSeconds: Double = 0
+    private var snapshotSeconds: Double = 0
+    private var worstSnapshotSeconds: Double = 0
+    private var snapshots = 0
     private var lastReport = Date()
 
     func frame(seconds: Double) {
@@ -63,26 +68,71 @@ final class AlacrittyRenderStats: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Frames withheld because the program was mid-synchronized-update. Counted
+    /// because they are otherwise invisible: a screen that only refreshes a few
+    /// times a second looks like slow rendering, when the terminal is in fact
+    /// being told not to draw yet.
+    func suppressed() {
+        guard Self.isEnabled else { return }
+        lock.lock()
+        suppressedFrames += 1
+        lock.unlock()
+    }
+
+    /// Wakeups the emulator sent. Compared against `drawn`, this separates "the
+    /// program is not producing output" from "output is not reaching the screen".
+    func wakeup() {
+        guard Self.isEnabled else { return }
+        lock.lock()
+        wakeups += 1
+        lock.unlock()
+    }
+
+    /// Time inside `kero_alacritty_snapshot`, which both exports the grid and
+    /// waits for the terminal lock the PTY thread parses under. Tracked apart
+    /// from the frame total so contention is distinguishable from draw cost.
+    func snapshot(seconds: Double) {
+        guard Self.isEnabled else { return }
+        lock.lock()
+        snapshots += 1
+        snapshotSeconds += seconds
+        worstSnapshotSeconds = max(worstSnapshotSeconds, seconds)
+        lock.unlock()
+    }
+
     private func report() {
         lock.lock()
         let drawn = frames
         let skipped = skippedFrames
         let deferred = deferredFrames
+        let suppressed = suppressedFrames
+        let woke = wakeups
         let rows = rebuiltRows
         let mean = drawn > 0 ? totalSeconds / Double(drawn) * 1000 : 0
         let worst = worstSeconds * 1000
+        let snapshotMean = snapshots > 0 ? snapshotSeconds / Double(snapshots) * 1000 : 0
+        let snapshotWorst = worstSnapshotSeconds * 1000
         frames = 0
         skippedFrames = 0
         deferredFrames = 0
+        suppressedFrames = 0
+        wakeups = 0
         rebuiltRows = 0
         totalSeconds = 0
         worstSeconds = 0
+        snapshots = 0
+        snapshotSeconds = 0
+        worstSnapshotSeconds = 0
         lastReport = Date()
         lock.unlock()
 
         NSLog(String(
-            format: "kero-render drawn=%d skipped=%d deferred=%d rows=%d mean=%.3fms worst=%.3fms",
-            drawn, skipped, deferred, rows, mean, worst
+            format: """
+                kero-render woke=%d drawn=%d skipped=%d deferred=%d suppressed=%d rows=%d \
+                mean=%.3fms worst=%.3fms snapshot=%.3fms/%.3fms
+                """,
+            woke, drawn, skipped, deferred, suppressed, rows, mean, worst,
+            snapshotMean, snapshotWorst
         ))
     }
 }

--- a/kero/Alacritty/AlacrittyRenderStats.swift
+++ b/kero/Alacritty/AlacrittyRenderStats.swift
@@ -20,6 +20,7 @@ final class AlacrittyRenderStats: @unchecked Sendable {
     private let lock = NSLock()
     private var frames = 0
     private var skippedFrames = 0
+    private var deferredFrames = 0
     private var rebuiltRows = 0
     private var totalSeconds: Double = 0
     private var worstSeconds: Double = 0
@@ -52,15 +53,27 @@ final class AlacrittyRenderStats: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Frames dropped because the GPU had not caught up. Their damage is still
+    /// waiting in the emulator, so a high count means output arrived faster than
+    /// the display could show it, not that anything was lost.
+    func deferred() {
+        guard Self.isEnabled else { return }
+        lock.lock()
+        deferredFrames += 1
+        lock.unlock()
+    }
+
     private func report() {
         lock.lock()
         let drawn = frames
         let skipped = skippedFrames
+        let deferred = deferredFrames
         let rows = rebuiltRows
         let mean = drawn > 0 ? totalSeconds / Double(drawn) * 1000 : 0
         let worst = worstSeconds * 1000
         frames = 0
         skippedFrames = 0
+        deferredFrames = 0
         rebuiltRows = 0
         totalSeconds = 0
         worstSeconds = 0
@@ -68,8 +81,8 @@ final class AlacrittyRenderStats: @unchecked Sendable {
         lock.unlock()
 
         NSLog(String(
-            format: "kero-render drawn=%d skipped=%d rows=%d mean=%.3fms worst=%.3fms",
-            drawn, skipped, rows, mean, worst
+            format: "kero-render drawn=%d skipped=%d deferred=%d rows=%d mean=%.3fms worst=%.3fms",
+            drawn, skipped, deferred, rows, mean, worst
         ))
     }
 }

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -842,14 +842,17 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     /// AppKit abandon it part-way, leaving stale rows on screen.
     private func reportScroll() {
         guard let handle else { return }
-        var snapshot = KeroSnapshot()
-        kero_alacritty_snapshot(handle, &snapshot)
+        // Deliberately not `kero_alacritty_snapshot`: this runs on every wakeup,
+        // and exporting the whole grid to read three integers is the most
+        // expensive thing a frame can do without drawing anything.
+        var state = KeroScrollState()
+        kero_alacritty_scroll_state(handle, &state)
 
-        let total = UInt64(snapshot.total_lines)
-        let viewport = UInt64(snapshot.screen_lines)
+        let total = UInt64(state.total_lines)
+        let viewport = UInt64(state.screen_lines)
         // `display_offset` counts up as the viewport moves back through the
         // scrollback; Kero's scrollbar measures down from the oldest row.
-        let scrolledBack = UInt64(snapshot.display_offset)
+        let scrolledBack = UInt64(state.display_offset)
         let top = total > viewport
             ? (total - viewport) - min(scrolledBack, total - viewport) : 0
         let position = TerminalScrollPosition(
@@ -1015,10 +1018,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     func scroll(toFraction fraction: Double) {
         guard let handle else { return }
-        var snapshot = KeroSnapshot()
-        kero_alacritty_snapshot(handle, &snapshot)
-        let history = snapshot.total_lines > snapshot.screen_lines
-            ? snapshot.total_lines - snapshot.screen_lines : 0
+        var state = KeroScrollState()
+        kero_alacritty_scroll_state(handle, &state)
+        let history = state.total_lines > state.screen_lines
+            ? state.total_lines - state.screen_lines : 0
         // The scrollbar runs oldest-to-newest; display offset runs the other way.
         let fromTop = Int((Double(history) * fraction).rounded())
         kero_alacritty_scroll_to_offset(handle, history - min(fromTop, history))
@@ -1207,10 +1210,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         if event.modifierFlags.contains(.command), let handle {
             switch Int(event.keyCode) {
             case 115: // Command-Home
-                var snapshot = KeroSnapshot()
-                kero_alacritty_snapshot(handle, &snapshot)
-                let history = snapshot.total_lines > snapshot.screen_lines
-                    ? snapshot.total_lines - snapshot.screen_lines : 0
+                var state = KeroScrollState()
+                kero_alacritty_scroll_state(handle, &state)
+                let history = state.total_lines > state.screen_lines
+                    ? state.total_lines - state.screen_lines : 0
                 kero_alacritty_scroll_to_offset(handle, history)
                 scheduleRender(force: true)
                 reportScroll()

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -92,6 +92,16 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     /// the emulator knows nothing about — a resize, a new theme or font, a
     /// selection drag, focus — since those move pixels without touching a cell.
     private var needsUnconditionalRedraw = true
+    /// Frames handed to the GPU that have not completed yet.
+    ///
+    /// A program printing quickly wakes the host far more often than the display
+    /// refreshes. Submitting a frame per wakeup exhausts the drawable pool and
+    /// then blocks the main thread inside `nextDrawable()` — which is felt as
+    /// stutter, since that is the thread handling keystrokes. Damage accumulates
+    /// in the emulator either way, so intermediate frames are simply dropped.
+    private var framesInFlight = 0
+    private var renderDeferredUntilFrameCompletes = false
+    private static let maxFramesInFlight = 2
     private var metalRenderer: TerminalMetalRenderer?
     private var kittyPlacements: [AlacrittyKittyPlacement] = []
     private var kittyImageData: [AlacrittyKittyImageKey: Data] = [:]
@@ -251,7 +261,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         if !renderedInactive, !cursorWasVisible {
             addInactiveCursorOverlay(to: frozenLayer)
         }
-        metalRenderer = nil
+        discardMetalRenderer()
         replaceBackingLayer(with: frozenLayer)
     }
 
@@ -382,7 +392,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             updateHoveredURL(nil)
             // Drop the glyph atlas and row/instance buffers while parked,
             // matching Ghostty's occluded-surface GPU memory behavior.
-            metalRenderer = nil
+            discardMetalRenderer()
             // CAMetalLayer retains its current display drawable even after
             // `device` becomes nil. Replace the layer entirely so Core
             // Animation releases that drawable and its pool. A 1800×1600
@@ -564,6 +574,14 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         if !waitUntilCompleted, kero_alacritty_synchronized_update(handle) {
             return true
         }
+        // Before any per-frame work, and before damage is taken: taking damage is
+        // destructive, so a frame that is not going to be drawn must not consume
+        // it.
+        if !waitUntilCompleted, framesInFlight >= Self.maxFramesInFlight {
+            renderDeferredUntilFrameCompletes = true
+            AlacrittyRenderStats.shared.deferred()
+            return true
+        }
         revalidateURLHoverForRender()
         if metalRenderer == nil, let metalDevice {
             metalRenderer = TerminalMetalRenderer(device: metalDevice)
@@ -600,11 +618,20 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         metalLayer.device = metalDevice
         metalLayer.contentsScale = scale
         let size = bounds.size
-        guard size.width > 0, size.height > 0 else { return false }
+        // The damage above has already been consumed, so anything that gives up
+        // on this frame has to ask for a full rebuild rather than leave those
+        // rows stale until the program happens to touch them again.
+        guard size.width > 0, size.height > 0 else {
+            needsUnconditionalRedraw = true
+            return false
+        }
         metalLayer.drawableSize = CGSize(
             width: size.width * scale, height: size.height * scale
         )
-        guard let drawable = metalLayer.nextDrawable() else { return false }
+        guard let drawable = metalLayer.nextDrawable() else {
+            needsUnconditionalRedraw = true
+            return false
+        }
         // Keep the IOSurface before render schedules this drawable for
         // presentation. Accessing drawable.texture afterward is invalid.
         let drawableSurface = drawable.texture.iosurface
@@ -644,6 +671,20 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         } else {
             onPresented = nil
         }
+        // The synchronous path has nothing left in flight by the time it returns,
+        // so only asynchronous frames take a slot.
+        let countsInFlight = !waitUntilCompleted
+        let onCompleted: (@Sendable () -> Void)?
+        if countsInFlight {
+            onCompleted = {
+                DispatchQueue.main.async {
+                    AlacrittyRegistry.shared.view(for: presentationToken)?.didCompleteFrame()
+                }
+            }
+            framesInFlight += 1
+        } else {
+            onCompleted = nil
+        }
         let submitted = renderer.render(
             snapshot: snapshot,
             kittyPlacements: kittyPlacements,
@@ -654,10 +695,15 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             in: drawable,
             viewportSize: size,
             onPresented: onPresented,
+            onCompleted: onCompleted,
             waitUntilCompleted: waitUntilCompleted
         )
         if submitted {
             lastPresentedSurface = drawableSurface
+        } else {
+            // Nothing was committed, so no completion is coming.
+            if countsInFlight { framesInFlight = max(framesInFlight - 1, 0) }
+            needsUnconditionalRedraw = true
         }
         if submitted, waitUntilCompleted {
             lastPresentedSize = size
@@ -731,6 +777,24 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             return AlacrittyKittyPlacement(placement, png: png)
         }
         kittyImageData = kittyImageData.filter { activeImageKeys.contains($0.key) }
+    }
+
+    /// Frames submitted through the old renderer still complete, but their slots
+    /// belong to a layer that is gone. Clearing the count keeps a dropped
+    /// completion from wedging the gate shut.
+    private func discardMetalRenderer() {
+        metalRenderer = nil
+        framesInFlight = 0
+        renderDeferredUntilFrameCompletes = false
+    }
+
+    /// Releases the in-flight slot and draws the output that arrived while the
+    /// GPU was busy.
+    private func didCompleteFrame() {
+        framesInFlight = max(framesInFlight - 1, 0)
+        guard renderDeferredUntilFrameCompletes else { return }
+        renderDeferredUntilFrameCompletes = false
+        scheduleRender()
     }
 
     private func didPresentFrame(

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -572,6 +572,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         // Full-screen TUIs use DEC mode 2026 to replace a frame atomically.
         // A host cursor tick must not expose the cleared intermediate grid.
         if !waitUntilCompleted, kero_alacritty_synchronized_update(handle) {
+            AlacrittyRenderStats.shared.suppressed()
             return true
         }
         // Before any per-frame work, and before damage is taken: taking damage is
@@ -637,7 +638,11 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         let drawableSurface = drawable.texture.iosurface
 
         var snapshot = KeroSnapshot()
+        let snapshotStart = CFAbsoluteTimeGetCurrent()
         kero_alacritty_snapshot(handle, &snapshot)
+        AlacrittyRenderStats.shared.snapshot(
+            seconds: CFAbsoluteTimeGetCurrent() - snapshotStart
+        )
         applyHoveredURLUnderline(to: &snapshot)
         updateKittyGraphics(handle: handle)
         updateMarkedTextOverlay(snapshot: snapshot)
@@ -948,6 +953,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
         switch kind {
         case KERO_EVENT_WAKEUP:
+            AlacrittyRenderStats.shared.wakeup()
             updateFocusReport()
             if isPointerInside, isCommandPressed {
                 refreshURLHover(modifierFlags: NSEvent.modifierFlags)

--- a/kero/Alacritty/TerminalMetalRenderer.swift
+++ b/kero/Alacritty/TerminalMetalRenderer.swift
@@ -119,6 +119,7 @@ final class TerminalMetalRenderer {
         in drawable: CAMetalDrawable,
         viewportSize: CGSize,
         onPresented: (@Sendable () -> Void)? = nil,
+        onCompleted: (@Sendable () -> Void)? = nil,
         waitUntilCompleted: Bool = false
     ) -> Bool {
         if atlas == nil {
@@ -196,6 +197,12 @@ final class TerminalMetalRenderer {
         encoder.endEncoding()
         if let onPresented {
             drawable.addPresentedHandler { _ in onPresented() }
+        }
+        // On the command buffer rather than the drawable: this one is guaranteed
+        // to run, including when the frame errors, so a caller can use it to
+        // track how many frames the GPU still owes.
+        if let onCompleted {
+            commands.addCompletedHandler { _ in onCompleted() }
         }
         commands.present(drawable)
         commands.commit()


### PR DESCRIPTION
Reported against the Alacritty backend: noticeable stutter while a coding agent CLI streams output. Pre-existing, unrelated to the IME work.

**Status:** the first change below is a clear win. The second turns out not to fire in the reported workload (`deferred=0` throughout a capture), so it stands as a correctness fix and a safeguard rather than the cure. The third exists because the old counters could not distinguish the remaining suspects — see *Where the stutter is not*.

## 1. The scrollbar exported the whole grid on every wakeup

`reportScroll()` runs on every `KERO_EVENT_WAKEUP` — not coalesced with rendering — and read its three integers from `kero_alacritty_snapshot`, which clears, resizes and refills the entire visible cell buffer while holding the terminal lock:

```rust
terminal.cells.clear();
terminal.cell_text.clear();
terminal.cells.resize(columns * screen_lines, KeroCell { .. });
for item in content.display_iter { .. }   // every visible cell, damage-blind
```

A program printing quickly therefore paid for a **second** full-grid export per read batch, on top of the one its frame already does, and contended with the PTY parse loop for the same `FairMutex` while doing it.

New `kero_alacritty_scroll_state` returns just `display_offset` / `total_lines` / `screen_lines`. The two scroll commands that were exporting a grid for the same reason now use it too.

## 2. Frames could be submitted faster than the display shows them

`scheduleRender` coalesces to one frame per run-loop turn, but there is no vsync alignment and no cap on frames in flight. Once the drawable pool fills, `nextDrawable()` blocks on the main thread — the thread handling keystrokes.

There was a correctness problem behind it regardless of throughput: damage is taken *before* the drawable is acquired, so a `nextDrawable()` that timed out and returned nil silently dropped those rows until something happened to touch them again.

- Frames in flight are capped, tracked with the command buffer's completion handler (guaranteed to run, unlike a presented handler)
- The gate sits **ahead of `take_damage`**, so a dropped frame consumes nothing and the accumulated damage goes out with the next completed frame
- Paths that bail after taking damage now set `needsUnconditionalRedraw`
- Discarding the renderer (parked or frozen pane) clears the count, so a completion belonging to a dead layer cannot wedge the gate shut

## 3. The counters could not say what a frame was waiting on

Frames withheld for a DEC 2026 synchronized update returned early **without being recorded at all**, so a screen refreshing three times a second looked identical to one whose frames were expensive. `KERO_RENDER_STATS` now also reports:

- `woke` — wakeups received, which separates "the program produced nothing" from "output did not reach the screen"
- `suppressed` — frames withheld mid-synchronized-update
- `deferred` — frames dropped by the gate in 2
- `snapshot=mean/worst` — time inside `kero_alacritty_snapshot`, which both exports the grid and waits for the lock the PTY thread parses under, so contention shows up here rather than buried in the frame total

## Where the stutter is not

From a capture during normal agent output:

```
drawn=36 skipped=0 deferred=0 rows=60 mean=0.360ms worst=1.540ms
drawn=60 skipped=0 deferred=0 rows=217 mean=1.207ms worst=5.224ms
```

Frames cost well under a millisecond, row-level damage is working (~1.7 rows rebuilt per frame), nothing is deferred and nothing is skipped. The draw path is not the bottleneck in that window. Earlier in the same capture, `drawn=3` with `rows=99` — three frames a second, each rebuilding the full 33-row grid — which is the shape of a screen being withheld rather than one that is slow to draw. That is exactly what the new `suppressed` and `woke` counters were added to confirm or rule out.

## Test plan

- [x] `cargo test --lib`, `cargo clippy`, `cargo fmt --check`, `cargo build --release --locked` — `kero_alacritty_scroll_state` exported
- [ ] Re-capture `KERO_RENDER_STATS=1` while the stutter is actually visible and compare `woke` against `drawn` + `suppressed`
- [ ] Scrollbar still tracks while output streams; Command-Home / Command-End / dragging still jump correctly
- [ ] Resize and font changes still repaint fully (the bail-out paths now force a rebuild)
- [ ] Park a tab in the background and bring it back — no stalled rendering

## Follow-ups not in this PR

The snapshot is still damage-blind: every drawn frame exports the full viewport even when one row changed. Making it partial means keeping `cell_text` offsets stable across calls, which is a larger change worth doing separately — and the new `snapshot=` timing should say whether it is worth it.