### PR TITLE
Add opt-in terminal background opacity + behind-window blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Make the terminal background translucent, with an optional frosted blur behind it, while text and other panels stay opaque
+
 ## [0.1.44]
 
 - Prevent a rare crash while using the Ctrl-Tab switcher

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -240,8 +240,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
         presentationCoverLayer.removeFromSuperlayer()
         let frozenLayer = CALayer()
-        frozenLayer.isOpaque = true
-        frozenLayer.backgroundColor = Theme.background.cgColor
+        frozenLayer.isOpaque = Self.backdropLayerIsOpaque
+        frozenLayer.backgroundColor = Self.backdropLayerColor
         frozenLayer.contents = lastPresentedSurface
         frozenLayer.contentsScale = lastPresentedScale
             ?? window?.backingScaleFactor
@@ -390,8 +390,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             // multi-tab memory.
             presentationCoverLayer.removeFromSuperlayer()
             let parkedLayer = CALayer()
-            parkedLayer.isOpaque = true
-            parkedLayer.backgroundColor = Theme.background.cgColor
+            parkedLayer.isOpaque = Self.backdropLayerIsOpaque
+            parkedLayer.backgroundColor = Self.backdropLayerColor
             parkedLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
             replaceBackingLayer(with: parkedLayer)
             lastPresentedSize = nil
@@ -413,7 +413,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             size: CGFloat(AppSettings.shared.fontSize),
             fontThicken: AppSettings.shared.fontThicken
         )
-        presentationCoverLayer.backgroundColor = Theme.background.cgColor
+        // Opacity may have just changed; re-assert the view/layer opacity so a
+        // live toggle reaches the placeholder layers too.
+        layer?.isOpaque = Self.backdropLayerIsOpaque
+        presentationCoverLayer.backgroundColor = Self.backdropLayerColor
         var theme = AlacrittyTheme.current()
         if let handle {
             withUnsafePointer(to: &theme) { kero_alacritty_set_theme(handle, $0) }
@@ -482,7 +485,20 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     override var isFlipped: Bool { false }
 
-    override var isOpaque: Bool { true }
+    override var isOpaque: Bool { !AppSettings.shared.terminalBackgroundIsTranslucent }
+
+    /// Fill colour for the placeholder layers (cover before the first frame,
+    /// frozen while inactive, parked while off-screen). Tracks the configured
+    /// background opacity so those transitions match the live surface instead
+    /// of flashing an opaque fill.
+    private static var backdropLayerColor: CGColor {
+        let opacity = AppSettings.shared.resolvedTerminalBackgroundOpacity
+        return Theme.background.withAlphaComponent(opacity).cgColor
+    }
+
+    private static var backdropLayerIsOpaque: Bool {
+        !AppSettings.shared.terminalBackgroundIsTranslucent
+    }
 
     // MARK: - Drawing
 
@@ -495,7 +511,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         layer.device = metalDevice
         layer.pixelFormat = .bgra8Unorm
         layer.framebufferOnly = true
-        layer.isOpaque = true
+        layer.isOpaque = Self.backdropLayerIsOpaque
         // Terminal frames are cheap enough to keep up with the display link;
         // a third full-window drawable only adds one pane-sized IOSurface
         // (~15 MiB on a large Retina window) without improving throughput.
@@ -507,7 +523,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         layer.contentsGravity = .topLeft
         layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         layer.needsDisplayOnBoundsChange = true
-        presentationCoverLayer.backgroundColor = Theme.background.cgColor
+        layer.isOpaque = Self.backdropLayerIsOpaque
+        presentationCoverLayer.backgroundColor = Self.backdropLayerColor
         presentationCoverLayer.frame = layer.bounds
         presentationCoverLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         presentationCoverLayer.isHidden = false
@@ -651,6 +668,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             padding: Self.padding,
             scale: scale,
             dirtyRows: dirtyRows,
+            backgroundOpacity: AppSettings.shared.resolvedTerminalBackgroundOpacity,
             in: drawable,
             viewportSize: size,
             onPresented: onPresented,

--- a/kero/Alacritty/TerminalMetalRenderer.swift
+++ b/kero/Alacritty/TerminalMetalRenderer.swift
@@ -116,6 +116,7 @@ final class TerminalMetalRenderer {
         padding: CGPoint,
         scale: CGFloat,
         dirtyRows: [Int]?,
+        backgroundOpacity: Double = 1,
         in drawable: CAMetalDrawable,
         viewportSize: CGSize,
         onPresented: (@Sendable () -> Void)? = nil,
@@ -151,11 +152,17 @@ final class TerminalMetalRenderer {
         pass.colorAttachments[0].loadAction = .clear
         pass.colorAttachments[0].storeAction = .store
         let background = Self.color(snapshot.background)
+        // Only the default-background region is painted by this clear; cells
+        // with an explicit background emit opaque quads. Fading the clear
+        // alpha therefore translucates exactly the terminal's "empty"
+        // background — matching ghostty's background-opacity — while text and
+        // coloured backgrounds stay solid. Premultiply so the blended output
+        // keeps straight-alpha colour.
         pass.colorAttachments[0].clearColor = MTLClearColor(
-            red: Double(background.x),
-            green: Double(background.y),
-            blue: Double(background.z),
-            alpha: 1
+            red: Double(background.x) * backgroundOpacity,
+            green: Double(background.y) * backgroundOpacity,
+            blue: Double(background.z) * backgroundOpacity,
+            alpha: backgroundOpacity
         )
 
         guard let commands = queue.makeCommandBuffer(),

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -116,6 +116,10 @@ final class AppSettings: nonisolated ObservableObject {
     static let defaultSidebarFontSize: Double = 14
     static let sidebarFontSizeRange: ClosedRange<Double> = 9...18
     static let defaultToolbarVisibility: ToolbarVisibility = .hide
+    static let defaultBackgroundOpacity: Double = 1
+    /// Floored above zero so the terminal never becomes fully invisible; the
+    /// opaque text and chrome stay readable across the whole range.
+    static let backgroundOpacityRange: ClosedRange<Double> = 0.2...1
 
     /// The language this process launched with, kept separate from the pending
     /// selection so Settings can explain when a relaunch is required.
@@ -204,6 +208,49 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Opacity of the terminal's background fill, `0.2...1`. Below `1` the
+    /// pane's background becomes translucent so the window backdrop (desktop,
+    /// or the blur below) shows through, while text, cursor, and every other
+    /// surface stay fully opaque. `1` (the default) keeps Kero's original
+    /// fully opaque look with no window-level compositing changes.
+    @Published var terminalBackgroundOpacity: Double {
+        didSet { save() }
+    }
+
+    /// Frost the area behind translucent terminal panes with a native
+    /// behind-window blur (`NSVisualEffectView`). Off by default; only has a
+    /// visible effect while `terminalBackgroundOpacity` is below `1`.
+    @Published var terminalBackgroundBlur: Bool {
+        didSet { save() }
+    }
+
+    /// macOS "Reduce Transparency" accessibility switch. When on, Kero keeps
+    /// the terminal fully opaque regardless of the opacity/blur settings, the
+    /// standard contract for translucency features.
+    var reduceTransparency: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+    }
+
+    /// Background opacity actually applied, after honoring Reduce Transparency.
+    /// The terminal backend and the pane backdrops all read this rather than
+    /// the raw stored value.
+    var resolvedTerminalBackgroundOpacity: Double {
+        reduceTransparency ? 1 : terminalBackgroundOpacity
+    }
+
+    /// Whether terminal panes should paint themselves translucent. Drives the
+    /// window-level opacity and the backdrop behind terminal panes; when this
+    /// is off nothing about the window's compositing changes.
+    var terminalBackgroundIsTranslucent: Bool {
+        resolvedTerminalBackgroundOpacity < 1
+    }
+
+    /// Whether the behind-window blur should be drawn: opted in, translucent,
+    /// and not suppressed by Reduce Transparency.
+    var terminalBackgroundBlurActive: Bool {
+        terminalBackgroundIsTranslucent && terminalBackgroundBlur
+    }
+
     /// Which emulator drives terminal panes. Only ever holds a backend this
     /// build ships a surface for — see `TerminalBackend` — and a session binds
     /// its backend at creation, so a change here reaches terminals opened
@@ -245,6 +292,12 @@ final class AppSettings: nonisolated ObservableObject {
             ?? toml["font-thicken"]?.bool
             ?? false
         macosOptionAsAlt = toml["terminal.macos-option-as-alt"]?.bool ?? false
+        let opacity = toml["terminal.background-opacity"]?.double
+            ?? Self.defaultBackgroundOpacity
+        terminalBackgroundOpacity = Self.backgroundOpacityRange.contains(opacity)
+            ? opacity
+            : Self.defaultBackgroundOpacity
+        terminalBackgroundBlur = toml["terminal.background-blur"]?.bool ?? false
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
         terminalBackend = TerminalBackend(persisted: toml["terminal.backend"]?.string)
@@ -293,6 +346,8 @@ final class AppSettings: nonisolated ObservableObject {
         themeLight = Theme.defaultLightThemeName
         toolbarVisibility = Self.defaultToolbarVisibility
         macosOptionAsAlt = false
+        terminalBackgroundOpacity = Self.defaultBackgroundOpacity
+        terminalBackgroundBlur = false
         wrapLines = false
         restoreTerminalHistory = false
         terminalBackend = .fallback
@@ -326,6 +381,14 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if macosOptionAsAlt {
             lines.append("terminal.macos-option-as-alt = true")
+        }
+        if terminalBackgroundOpacity != Self.defaultBackgroundOpacity {
+            lines.append(
+                "terminal.background-opacity = \(TOML.number(terminalBackgroundOpacity))"
+            )
+        }
+        if terminalBackgroundBlur {
+            lines.append("terminal.background-blur = true")
         }
         if wrapLines {
             lines.append("editor.wrap-lines = true")

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @ObservedObject var manager: TerminalManager
     @ObservedObject private var settings = AppSettings.shared
     @ObservedObject private var themeChanges = Theme.changes
+    @ObservedObject private var settings = AppSettings.shared
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var tabSwitcher = TabSwitcherController()
     @StateObject private var git = GitStatusModel()
@@ -54,6 +55,7 @@ struct ContentView: View {
                 // Above the pane stack so header tooltips, which hang down
                 // into the terminal area, aren't covered by it.
                 MainHeaderView(manager: manager)
+                    .background(Color(nsColor: Theme.background))
                     .zIndex(1)
 
                 ZStack {
@@ -93,12 +95,17 @@ struct ContentView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     // Opaque so the pane gaps hide the unselected diffs behind,
-                    // except while a diff tab is up — then stay clear so its
-                    // web view shows through from the stack below.
-                    .background(paneLayerIsOpaque ? AnyShapeStyle(Color(nsColor: Theme.background)) : AnyShapeStyle(Color.clear))
+                    // except while a diff tab is up (then stay clear so its web
+                    // view shows through) or while the terminal is translucent
+                    // (then the frosted/desktop backdrop below shows through).
+                    .background(paneLayerIsTranslucent ? AnyShapeStyle(Color.clear) : AnyShapeStyle(Color(nsColor: Theme.background)))
                     .zIndex(2)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Backdrop for the whole pane region (below the header): the
+                // frosted blur or bare desktop that translucent terminal panes
+                // composite against, or the plain opaque fill by default.
+                .background(terminalBackdrop)
 
                 if manager.selectedProject != nil
                     && settings.toolbarVisibility != .hide
@@ -111,7 +118,12 @@ struct ContentView: View {
                     )
                 }
             }
-            .background(Color(nsColor: Theme.background))
+            // The header stays opaque even when terminals are translucent, so
+            // it keeps its own fill; the pane region's fill moves to the
+            // ZStack backdrop above.
+            .background(settings.terminalBackgroundIsTranslucent
+                ? AnyShapeStyle(Color.clear)
+                : AnyShapeStyle(Color(nsColor: Theme.background)))
 
             // Dropping the hidden sidebar also drops its expanded file tree
             // and process snapshot. Git stays window-owned because the toolbar
@@ -143,6 +155,12 @@ struct ContentView: View {
                 .frame(width: 0, height: 0)
         }
         .background(WindowChromeAccessor { manager.attach(to: $0) })
+        .background(
+            WindowTranslucencyController(
+                isTranslucent: settings.terminalBackgroundIsTranslucent
+            )
+            .frame(width: 0, height: 0)
+        )
         .onAppear { syncGit() }
         .onReceive(NotificationCenter.default.publisher(
             for: NSApplication.didBecomeActiveNotification
@@ -158,6 +176,27 @@ struct ContentView: View {
         .onChange(of: colorScheme) {
             manager.refreshAppearance()
         }
+    }
+
+    /// Backdrop painted behind the whole pane region (below the header):
+    /// frosted behind-window blur when opted in, the bare desktop when merely
+    /// translucent, otherwise the plain opaque theme fill.
+    @ViewBuilder
+    private var terminalBackdrop: some View {
+        if settings.terminalBackgroundBlurActive {
+            VisualEffectView(material: .underWindowBackground, state: .active)
+        } else if settings.terminalBackgroundIsTranslucent {
+            Color.clear
+        } else {
+            Color(nsColor: Theme.background)
+        }
+    }
+
+    /// The pane layer drops its opaque fill either for a diff tab (its web view
+    /// shows through) or while the terminal is translucent (the backdrop shows
+    /// through).
+    private var paneLayerIsTranslucent: Bool {
+        !paneLayerIsOpaque || settings.terminalBackgroundIsTranslucent
     }
 
     /// Sessions in the visible tab are owned by `TerminalHostView`; every

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -172,126 +172,12 @@ struct ContentView: View {
         BottomToolbarLayout.height(for: manager.selectedSession)
     }
 
+    // The window's layers are split into explicitly typed sub-views. As one
+    // expression this body exceeds the type checker's time budget on the
+    // release toolchain, and the failure only reappears once it is large
+    // enough again — keep new layers in their own properties.
     var body: some View {
-        HStack(spacing: 0) {
-            if manager.isLeftSidebarVisible {
-                SidebarView(
-                    manager: manager,
-                    bottomBarHeight: bottomToolbarHeight
-                )
-            }
-
-            VStack(spacing: 0) {
-                // Above the pane stack so header tooltips, which hang down
-                // into the terminal area, aren't covered by it.
-                MainHeaderView(manager: manager, tabSplitDrag: tabSplitDrag)
-                    .background(Color(nsColor: Theme.background))
-                    .zIndex(1)
-
-                ZStack {
-                    // Diff panes stay mounted after their project has been
-                    // visited: removing a project's stack pulls every
-                    // NSHostingView out of the window at once, making project
-                    // switching block while WebKit tears down and reattaches
-                    // the rendered diffs. Unvisited restored projects remain
-                    // lazy; inactive stacks sit beneath the active opaque pane.
-                    ForEach(manager.projectsWithMountedDiffs) { project in
-                        ForEach(project.diffPlacements, id: \.diff.id) { placement in
-                            let isSelected = manager.selectedProjectID == project.id
-                                && project.selectedTabID == placement.tabID
-                            DiffViewerView(
-                                diff: placement.diff,
-                                isSelected: isSelected
-                            )
-                            .background(Color(nsColor: Theme.background))
-                            .allowsHitTesting(isSelected)
-                            .zIndex(isSelected ? 1 : 0)
-                        }
-                    }
-                    Group {
-                        if let tab = manager.selectedProject?.selectedTab {
-                            PaneLayoutView(
-                                tab: tab,
-                                tabSplitDrag: tabSplitDrag,
-                                onSplit: { manager.split(toward: $0) },
-                                onNewBrowserTab: {
-                                    manager.newBrowserTab(initialURL: $0)
-                                },
-                                onNewBrowserPane: {
-                                    manager.newBrowserPane(initialURL: $0)
-                                },
-                                onNewFileTab: {
-                                    manager.openFile($0)
-                                },
-                                onNewFilePane: {
-                                    manager.openFileToSide($0)
-                                }
-                            )
-                        } else {
-                            emptyState
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    // Opaque so the pane gaps hide the unselected diffs behind,
-                    // except while a diff tab is up (then stay clear so its web
-                    // view shows through) or while the terminal is translucent
-                    // (then the frosted/desktop backdrop below shows through).
-                    .background(paneLayerIsTranslucent ? AnyShapeStyle(Color.clear) : AnyShapeStyle(Color(nsColor: Theme.background)))
-                    .zIndex(2)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // Backdrop for the whole pane region (below the header): the
-                // frosted blur or bare desktop that translucent terminal panes
-                // composite against, or the plain opaque fill by default.
-                .background(terminalBackdrop)
-
-                if manager.selectedProject != nil
-                    && settings.toolbarVisibility != .hide
-                    && (git.isRepo || settings.toolbarVisibility == .always) {
-                    BottomToolbarView(
-                        model: git,
-                        height: bottomToolbarHeight,
-                        toggleGitPanel: { manager.togglePanel(.git) },
-                        hideToolbar: { settings.toolbarVisibility = .hide }
-                    )
-                }
-            }
-            // The header stays opaque even when terminals are translucent, so
-            // it keeps its own fill; the pane region's fill moves to the
-            // ZStack backdrop above.
-            .background(settings.terminalBackgroundIsTranslucent
-                ? AnyShapeStyle(Color.clear)
-                : AnyShapeStyle(Color(nsColor: Theme.background)))
-
-            // Dropping the hidden sidebar also drops its expanded file tree
-            // and process snapshot. Git stays window-owned because the toolbar
-            // remains visible while this panel is closed.
-            if manager.isPanelVisible {
-                RightSidebarView(manager: manager, git: git)
-            }
-        }
-        .ignoresSafeArea()
-        .overlay(alignment: .topLeading) {
-            TerminalParkingView(sessions: parkedTerminalSessions)
-                .frame(width: 1, height: 1)
-                .allowsHitTesting(false)
-                .accessibilityHidden(true)
-        }
-        .overlay {
-            if manager.isCommandPaletteVisible {
-                CommandPaletteView(manager: manager)
-            }
-        }
-        .overlay {
-            if tabSwitcher.isPresented, let project = manager.selectedProject {
-                TabSwitcherOverlay(project: project, controller: tabSwitcher)
-                    .zIndex(10)
-            }
-        }
-        .background {
-            TabSwitcherEventMonitor(manager: manager, controller: tabSwitcher)
-                .frame(width: 0, height: 0)
-        }
+        overlaidContent
         .background(WindowChromeAccessor { manager.attach(to: $0) })
         .background(
             WindowTranslucencyController(
@@ -317,6 +203,139 @@ struct ContentView: View {
         .onChange(of: colorScheme) {
             manager.refreshAppearance()
         }
+    }
+
+    private var windowColumns: some View {
+        HStack(spacing: 0) {
+            if manager.isLeftSidebarVisible {
+                SidebarView(
+                    manager: manager,
+                    bottomBarHeight: bottomToolbarHeight
+                )
+            }
+
+            mainColumn
+
+            // Dropping the hidden sidebar also drops its expanded file tree
+            // and process snapshot. Git stays window-owned because the toolbar
+            // remains visible while this panel is closed.
+            if manager.isPanelVisible {
+                RightSidebarView(manager: manager, git: git)
+            }
+        }
+    }
+
+    private var overlaidContent: some View {
+        windowColumns
+            .ignoresSafeArea()
+            .overlay(alignment: .topLeading) {
+                TerminalParkingView(sessions: parkedTerminalSessions)
+                    .frame(width: 1, height: 1)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
+            .overlay {
+                if manager.isCommandPaletteVisible {
+                    CommandPaletteView(manager: manager)
+                }
+            }
+            .overlay {
+                if tabSwitcher.isPresented, let project = manager.selectedProject {
+                    TabSwitcherOverlay(project: project, controller: tabSwitcher)
+                        .zIndex(10)
+                }
+            }
+            .background {
+                TabSwitcherEventMonitor(manager: manager, controller: tabSwitcher)
+                    .frame(width: 0, height: 0)
+            }
+    }
+
+    /// The window's centre column. Split out of `body` because the whole
+    /// window as a single expression exceeds the type checker's time
+    /// budget on the release toolchain.
+    private var mainColumn: some View {
+        VStack(spacing: 0) {
+            // Above the pane stack so header tooltips, which hang down
+            // into the terminal area, aren't covered by it.
+            MainHeaderView(manager: manager, tabSplitDrag: tabSplitDrag)
+                .background(Color(nsColor: Theme.background))
+                .zIndex(1)
+
+            ZStack {
+                // Diff panes stay mounted after their project has been
+                // visited: removing a project's stack pulls every
+                // NSHostingView out of the window at once, making project
+                // switching block while WebKit tears down and reattaches
+                // the rendered diffs. Unvisited restored projects remain
+                // lazy; inactive stacks sit beneath the active opaque pane.
+                ForEach(manager.projectsWithMountedDiffs) { project in
+                    ForEach(project.diffPlacements, id: \.diff.id) { placement in
+                        let isSelected = manager.selectedProjectID == project.id
+                            && project.selectedTabID == placement.tabID
+                        DiffViewerView(
+                            diff: placement.diff,
+                            isSelected: isSelected
+                        )
+                        .background(Color(nsColor: Theme.background))
+                        .allowsHitTesting(isSelected)
+                        .zIndex(isSelected ? 1 : 0)
+                    }
+                }
+                Group {
+                    if let tab = manager.selectedProject?.selectedTab {
+                        PaneLayoutView(
+                            tab: tab,
+                            tabSplitDrag: tabSplitDrag,
+                            onSplit: { manager.split(toward: $0) },
+                            onNewBrowserTab: {
+                                manager.newBrowserTab(initialURL: $0)
+                            },
+                            onNewBrowserPane: {
+                                manager.newBrowserPane(initialURL: $0)
+                            },
+                            onNewFileTab: {
+                                manager.openFile($0)
+                            },
+                            onNewFilePane: {
+                                manager.openFileToSide($0)
+                            }
+                        )
+                    } else {
+                        emptyState
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Opaque so the pane gaps hide the unselected diffs behind,
+                // except while a diff tab is up (then stay clear so its web
+                // view shows through) or while the terminal is translucent
+                // (then the frosted/desktop backdrop below shows through).
+                .background(paneLayerIsTranslucent ? AnyShapeStyle(Color.clear) : AnyShapeStyle(Color(nsColor: Theme.background)))
+                .zIndex(2)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Backdrop for the whole pane region (below the header): the
+            // frosted blur or bare desktop that translucent terminal panes
+            // composite against, or the plain opaque fill by default.
+            .background(terminalBackdrop)
+
+            if manager.selectedProject != nil
+                && settings.toolbarVisibility != .hide
+                && (git.isRepo || settings.toolbarVisibility == .always) {
+                BottomToolbarView(
+                    model: git,
+                    height: bottomToolbarHeight,
+                    toggleGitPanel: { manager.togglePanel(.git) },
+                    hideToolbar: { settings.toolbarVisibility = .hide }
+                )
+            }
+        }
+        // The header stays opaque even when terminals are translucent, so
+        // it keeps its own fill; the pane region's fill moves to the
+        // ZStack backdrop above.
+        .background(settings.terminalBackgroundIsTranslucent
+            ? AnyShapeStyle(Color.clear)
+            : AnyShapeStyle(Color(nsColor: Theme.background)))
     }
 
     /// Backdrop painted behind the whole pane region (below the header):

--- a/kero/KeroTerminalView+Ghostty.swift
+++ b/kero/KeroTerminalView+Ghostty.swift
@@ -73,6 +73,13 @@ extension KeroTerminalView {
             // config injects the package default `font-thicken = true`, and
             // only a later entry in the rendered config overrides it.
             builder.withFontThicken(settings.fontThicken)
+            // Libghostty's Metal surface is already non-opaque (see
+            // AppTerminalView); Kero paints the opaque pane background behind
+            // it. Passing an opacity below 1 makes ghostty render its own
+            // background fill translucent, and TerminalHostView drops the
+            // opaque backdrop so the window's blur/desktop shows through.
+            // Text, cursor, and selection keep their own full alpha.
+            builder.withBackgroundOpacity(settings.resolvedTerminalBackgroundOpacity)
             builder.withCursorStyle(.block)
             builder.withCursorStyleBlink(true)
             // Kero's insets around the grid live inside ghostty as

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -340,6 +340,7 @@ private struct ResizableDivider: View {
 private struct PaneView: View {
     @ObservedObject var tab: PaneTab
     @ObservedObject private var themeChanges = Theme.changes
+    @ObservedObject private var settings = AppSettings.shared
     let pane: Pane
     let showFocusRing: Bool
     /// Whether the header can be grabbed — false while zoomed, where there is
@@ -432,7 +433,13 @@ private struct PaneView: View {
                 onNewBrowserTab: newBrowserTabFromMenu,
                 onNewBrowserPane: newBrowserPaneFromMenu
             )
-                .background(Color(nsColor: Theme.background))
+                // Terminal panes drop their opaque fill when translucency is
+                // on so the window backdrop shows through; the emulator paints
+                // its own background at the configured opacity. Text, cursor,
+                // and selection keep full alpha inside the surface.
+                .background(settings.terminalBackgroundIsTranslucent
+                    ? AnyShapeStyle(Color.clear)
+                    : AnyShapeStyle(Color(nsColor: Theme.background)))
                 .overlay(alignment: .topTrailing) {
                     TerminalFindOverlay(find: session.find)
                 }

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -206,6 +206,37 @@ struct SettingsView: View {
                     )
                     .labelsHidden()
                 }
+
+                HStack {
+                    Text("Background opacity")
+                    Slider(
+                        value: $settings.terminalBackgroundOpacity,
+                        in: AppSettings.backgroundOpacityRange
+                    )
+                    .accessibilityLabel("Terminal background opacity")
+                    Text("\(Int((settings.terminalBackgroundOpacity * 100).rounded()))%")
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(width: 40, alignment: .trailing)
+                }
+                Text("Makes the terminal background translucent so the desktop shows through. Text and other panels stay opaque.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                Toggle(
+                    "Blur behind translucent background",
+                    isOn: $settings.terminalBackgroundBlur
+                )
+                .disabled(!settings.terminalBackgroundIsTranslucent)
+                Text("Frosts the desktop behind the terminal, like frosted glass. Needs background opacity below 100%.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                if settings.reduceTransparency, settings.terminalBackgroundIsTranslucent {
+                    Text("Reduce Transparency is on in System Settings, so the terminal stays opaque.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Text Editing") {
@@ -240,6 +271,8 @@ struct SettingsView: View {
                         && settings.themeDark == Theme.defaultDarkThemeName
                         && settings.themeLight == Theme.defaultLightThemeName
                         && settings.toolbarVisibility == AppSettings.defaultToolbarVisibility
+                        && settings.terminalBackgroundOpacity == AppSettings.defaultBackgroundOpacity
+                        && !settings.terminalBackgroundBlur
                         && !settings.wrapLines
                         && !settings.restoreTerminalHistory
                         && settings.terminalBackend == .fallback)

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -232,7 +232,7 @@ struct SettingsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
 
-                if settings.reduceTransparency, settings.terminalBackgroundIsTranslucent {
+                if settings.reduceTransparency, settings.terminalBackgroundOpacity < 1 {
                     Text("Reduce Transparency is on in System Settings, so the terminal stays opaque.")
                         .font(.callout)
                         .foregroundStyle(.secondary)

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -135,7 +135,14 @@ final class TerminalManager: nonisolated ObservableObject {
                 AppSettings.shared.$themeDark.removeDuplicates(),
                 AppSettings.shared.$themeLight.removeDuplicates()
             ),
-            AppSettings.shared.$macosOptionAsAlt.removeDuplicates()
+            // Collapse the appearance keys that only need to trigger a refresh
+            // (not their value) into one leg, keeping the CombineLatest within
+            // its arity: option-as-alt plus the terminal translucency keys.
+            Publishers.Merge3(
+                AppSettings.shared.$macosOptionAsAlt.removeDuplicates().map { _ in () },
+                AppSettings.shared.$terminalBackgroundOpacity.removeDuplicates().map { _ in () },
+                AppSettings.shared.$terminalBackgroundBlur.removeDuplicates().map { _ in () }
+            )
         )
             .dropFirst()
             .receive(on: DispatchQueue.main)

--- a/kero/VisualEffectView.swift
+++ b/kero/VisualEffectView.swift
@@ -9,16 +9,53 @@ import SwiftUI
 /// Native translucent material background (behind-window blur).
 struct VisualEffectView: NSViewRepresentable {
     var material: NSVisualEffectView.Material = .sidebar
+    /// `.followsWindowActiveState` dims the material when the window is
+    /// inactive — right for a sidebar, wrong for the terminal backdrop, which
+    /// should keep frosting the desktop even when Kero isn't key.
+    var state: NSVisualEffectView.State = .followsWindowActiveState
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.material = material
         view.blendingMode = .behindWindow
-        view.state = .followsWindowActiveState
+        view.state = state
         return view
     }
 
     func updateNSView(_ view: NSVisualEffectView, context: Context) {
         view.material = material
+        view.state = state
+    }
+}
+
+/// Makes the host `NSWindow` non-opaque so a translucent terminal background
+/// composites against the desktop (and the behind-window blur) instead of an
+/// opaque window fill. Reverts to the standard opaque window when translucency
+/// is off, so the default look is untouched.
+///
+/// A zero-size representable rather than a modifier so it can reach the window
+/// without imposing any layout or drawing of its own.
+struct WindowTranslucencyController: NSViewRepresentable {
+    var isTranslucent: Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        DispatchQueue.main.async { apply(to: view.window) }
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        DispatchQueue.main.async { apply(to: view.window) }
+    }
+
+    private func apply(to window: NSWindow?) {
+        guard let window else { return }
+        if isTranslucent {
+            window.isOpaque = false
+            window.backgroundColor = .clear
+        } else {
+            window.isOpaque = true
+            window.backgroundColor = .windowBackgroundColor
+        }
     }
 }


### PR DESCRIPTION
# Add opt-in terminal background opacity + behind-window blur

Closes #35

Adds terminal transparency and blur, as requested in #35.

## Summary

Two opt-in settings:

- **`terminal.background-opacity`** (`0.2`–`1`, default `1`) — makes the terminal background translucent so the desktop behind the window shows through. Text, cursor, cells with an explicit background colour, and all other panels (header, sidebars, editor, browser, diff) stay opaque.
- **`terminal.background-blur`** (default off) — blurs the desktop behind the translucent terminal. Only has an effect while opacity is below `1`.

Both default to the current look, so nothing changes until the user opts in. Respects the macOS **Reduce Transparency** setting (terminal stays opaque when it's on). Works with both terminal backends.

## How it works

- The window is made non-opaque (`NSWindow.isOpaque = false`), so only the terminal background is translucent — not a whole-window fade.
- Opacity is applied per backend: libghostty via `background-opacity`, Alacritty via the Metal clear colour on the default-background region.
- Blur is a behind-window `NSVisualEffectView` behind the terminal panes.
- Changes apply live through the existing appearance-refresh path.

## Settings UI

Terminal section gets an opacity slider (with a live % readout) and a blur toggle. The blur toggle is disabled unless the background is translucent, and there's a note when Reduce Transparency is overriding the setting. Reset to Defaults covers both.

## Testing

- `xcodebuild -scheme kero -configuration Debug build` → **BUILD SUCCEEDED** on stable Xcode 26.1.1.
- Ran the Debug build with `terminal.background-opacity = 0.6` and `terminal.background-blur = true`: the desktop shows through the terminal and sidebar while text, tabs, and window chrome stay fully opaque.
- Ran the Debug build with no opacity key set: the window renders fully opaque, so the default look is unchanged.

### Build fix included

`ContentView`'s body exceeded the Swift type checker's time budget once these
modifiers were added, failing with *"unable to type-check this expression in
reasonable time"*. Note this **already fails on `main` as-is** with stable Xcode
26.1.1 — `main` currently builds only with Xcode beta — so this is not a
regression introduced here, but the added modifiers keep it over the limit.

The last commit splits the body into explicitly typed sub-views
(`windowColumns` / `overlaidContent` / `mainColumn`). It is a pure structural
move: no code lines were removed, only property boundaries and comments added.
That also un-breaks the stable-toolchain build for `main` generally.

## Screenshots
| Before (default) | Opacity | Opacity + blur |
<img width="1479" height="945" alt="Screenshot 2026-08-03 at 2 59 27 AM" src="https://github.com/user-attachments/assets/6d18baf5-e0ba-4006-8d0b-1d9a1873f87c" />
<img width="1480" height="946" alt="Screenshot 2026-08-03 at 2 58 38 AM" src="https://github.com/user-attachments/assets/c1c3108e-1fb3-4c58-82fa-9f6c92520199" />

<img width="1479" height="944" alt="Screenshot 2026-08-03 at 2 58 27 AM" src="https://github.com/user-attachments/assets/5a7e2424-3a14-45ef-a549-5fc8e21c2813" />

