### PR TITLE
Keep visited project diffs mounted to speed up switching

### DIFF
--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -57,22 +57,23 @@ struct ContentView: View {
                     .zIndex(1)
 
                 ZStack {
-                    // Diff panes stay mounted while unselected: removing one
-                    // would pull its NSHostingView out of the window, which
-                    // tears down and re-creates the WKWebView inside (losing
-                    // the rendered diff and scroll position). Unselected ones
-                    // just sit covered by the active tab's opaque pane layer.
-                    // Diffs are always their own single-pane tab, so a selected
-                    // diff fills the whole content area, unchanged.
-                    if let project = manager.selectedProject {
+                    // Diff panes stay mounted after their project has been
+                    // visited: removing a project's stack pulls every
+                    // NSHostingView out of the window at once, making project
+                    // switching block while WebKit tears down and reattaches
+                    // the rendered diffs. Unvisited restored projects remain
+                    // lazy; inactive stacks sit beneath the active opaque pane.
+                    ForEach(manager.projectsWithMountedDiffs) { project in
                         ForEach(project.diffPlacements, id: \.diff.id) { placement in
+                            let isSelected = manager.selectedProjectID == project.id
+                                && project.selectedTabID == placement.tabID
                             DiffViewerView(
                                 diff: placement.diff,
-                                isSelected: project.selectedTabID == placement.tabID
+                                isSelected: isSelected
                             )
                             .background(Color(nsColor: Theme.background))
-                            .allowsHitTesting(project.selectedTabID == placement.tabID)
-                            .zIndex(project.selectedTabID == placement.tabID ? 1 : 0)
+                            .allowsHitTesting(isSelected)
+                            .zIndex(isSelected ? 1 : 0)
                         }
                     }
                     Group {

--- a/kero/DiffViewerView.swift
+++ b/kero/DiffViewerView.swift
@@ -235,6 +235,16 @@ final class DiffTab: nonisolated ObservableObject, nonisolated Identifiable {
         }
     }
 
+    /// Refreshes a live diff when navigation brings it back on screen.
+    /// Historical blobs are immutable and already loaded by `init`; rerunning
+    /// four Git processes and republishing both files on every project switch
+    /// only makes WebKit render the same diff again. An initial live load also
+    /// stays in flight rather than being duplicated by the view's first mount.
+    func refreshWhenSelected() {
+        guard commitHash == nil, !isLoading else { return }
+        reload()
+    }
+
     /// Accepts the updated side emitted by Pierre's editor. The web view owns
     /// the live document; this mirrored value drives dirty state and saving.
     func updateEditedContent(fileID: String, contents: String) {
@@ -648,10 +658,14 @@ struct DiffViewerView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .onAppear { diff.reload() }
+        .onAppear {
+            if isSelected {
+                diff.refreshWhenSelected()
+            }
+        }
         .onChange(of: isSelected) {
             if isSelected {
-                diff.reload()
+                diff.refreshWhenSelected()
             }
         }
     }

--- a/kero/DiffViewerView.swift
+++ b/kero/DiffViewerView.swift
@@ -97,9 +97,10 @@ final class DiffTab: nonisolated ObservableObject, nonisolated Identifiable {
     /// The web view lives on the tab (not in the SwiftUI view) so switching
     /// tabs re-parents the same rendered view instead of booting a fresh
     /// WKWebView — same pattern as `TerminalSession.terminalView`.
-    private(set) lazy var webHostView: NSView = NSHostingView(
-        rootView: DiffWebRoot(model: web)
-    )
+    ///
+    /// It starts nil so project selection can commit its skeleton before the
+    /// selected diff creates WebKit's AppKit hierarchy on the main actor.
+    @Published private(set) var webHostView: NSView?
 
     private nonisolated static let maxBytes = 5 << 20
     private var savedNewContent = ""
@@ -243,6 +244,17 @@ final class DiffTab: nonisolated ObservableObject, nonisolated Identifiable {
     func refreshWhenSelected() {
         guard commitHash == nil, !isLoading else { return }
         reload()
+    }
+
+    /// WebKit views are main-actor objects, but their creation does not need to
+    /// be part of the project-selection transaction. Yielding lets SwiftUI
+    /// display the existing skeleton first and avoids materializing every
+    /// hidden diff in a project at once.
+    func materializeWebHostView() async {
+        guard webHostView == nil else { return }
+        await Task.yield()
+        guard !Task.isCancelled, webHostView == nil else { return }
+        webHostView = NSHostingView(rootView: DiffWebRoot(model: web))
     }
 
     /// Accepts the updated side emitted by Pierre's editor. The web view owns
@@ -630,7 +642,7 @@ struct DiffViewerView: View {
                     placeholder(icon: "exclamationmark.triangle", text: error)
                 } else if web.oldContent == web.newContent {
                     if diff.isLoading {
-                        DiffSkeletonView()
+                        initialLoadingSkeleton
                     } else if diff.isUnmerged {
                         placeholder(
                             icon: "arrow.triangle.merge",
@@ -642,17 +654,25 @@ struct DiffViewerView: View {
                 } else {
                     VStack(spacing: 0) {
                         controlBar
-                        DiffWebHostView(view: diff.webHostView)
-                            // Cover (never hide) the webview while it boots:
-                            // making it invisible lets WebKit throttle rendering
-                            // and the initial diff render can be dropped entirely.
-                            .overlay {
-                                if !web.isReady {
-                                    DiffSkeletonView()
-                                        .background(Color(nsColor: Theme.background))
-                                        .transition(.opacity)
+                        if let webHostView = diff.webHostView {
+                            DiffWebHostView(view: webHostView)
+                                // Cover (never hide) the webview while it boots:
+                                // making it invisible lets WebKit throttle rendering
+                                // and the initial diff render can be dropped entirely.
+                                .overlay {
+                                    if !web.isReady {
+                                        DiffSkeletonView()
+                                            .background(Color(nsColor: Theme.background))
+                                            .transition(.opacity)
+                                    }
                                 }
-                            }
+                        } else {
+                            DiffSkeletonView()
+                                .task(id: isSelected) {
+                                    guard isSelected else { return }
+                                    await diff.materializeWebHostView()
+                                }
+                        }
                     }
                 }
             }
@@ -704,7 +724,20 @@ struct DiffViewerView: View {
             ),
             canEdit: diff.isEditable
         )
-        .frame(height: 37)
+        .frame(height: DiffViewerLayout.controlsHeight)
+    }
+
+    /// The WebKit skeleton later sits below the real controls. Reserve that
+    /// exact toolbar row during the file load too, so the code-shaped lines do
+    /// not jump down when the diff contents become available.
+    private var initialLoadingSkeleton: some View {
+        VStack(spacing: 0) {
+            DiffControlsSkeletonBar(
+                showsModePlaceholder: diff.commitHash == nil && !diff.staged
+            )
+            .frame(height: DiffViewerLayout.controlsHeight)
+            DiffSkeletonView()
+        }
     }
 
     private func placeholder(icon: String, text: String) -> some View {
@@ -737,6 +770,10 @@ struct DiffViewerView: View {
     }
 }
 
+private enum DiffViewerLayout {
+    static let controlsHeight: CGFloat = 37
+}
+
 /// Native controls for the materially changed diff toolbar. The surrounding
 /// diff view is legacy SwiftUI, but new interaction stays in AppKit.
 private struct DiffControlsBar: NSViewRepresentable {
@@ -756,6 +793,75 @@ private struct DiffControlsBar: NSViewRepresentable {
             onDiffStyleChange: { diffStyle = $0 },
             onEditingChange: { isEditing = $0 }
         )
+    }
+}
+
+/// Matches the native controls row while the diff metadata is still loading.
+/// Keeping this in AppKit gives the placeholder the same sizing and divider
+/// behavior as the toolbar that replaces it.
+private struct DiffControlsSkeletonBar: NSViewRepresentable {
+    let showsModePlaceholder: Bool
+
+    func makeNSView(context: Context) -> DiffControlsSkeletonNSView {
+        DiffControlsSkeletonNSView()
+    }
+
+    func updateNSView(_ view: DiffControlsSkeletonNSView, context: Context) {
+        view.update(showsModePlaceholder: showsModePlaceholder)
+    }
+}
+
+private final class DiffControlsSkeletonNSView: NSView {
+    private let modePlaceholder = NSView()
+    private let layoutPlaceholder = NSView()
+    private let divider = NSView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        setAccessibilityElement(false)
+
+        for placeholder in [modePlaceholder, layoutPlaceholder] {
+            placeholder.wantsLayer = true
+            placeholder.layer?.cornerRadius = 5
+            placeholder.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(placeholder)
+        }
+
+        divider.wantsLayer = true
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(divider)
+
+        NSLayoutConstraint.activate([
+            layoutPlaceholder.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            layoutPlaceholder.centerYAnchor.constraint(equalTo: centerYAnchor),
+            layoutPlaceholder.widthAnchor.constraint(equalToConstant: 111),
+            layoutPlaceholder.heightAnchor.constraint(equalToConstant: 20),
+            modePlaceholder.trailingAnchor.constraint(
+                equalTo: layoutPlaceholder.leadingAnchor, constant: -8
+            ),
+            modePlaceholder.centerYAnchor.constraint(equalTo: centerYAnchor),
+            modePlaceholder.widthAnchor.constraint(equalToConstant: 93),
+            modePlaceholder.heightAnchor.constraint(equalToConstant: 20),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.bottomAnchor.constraint(equalTo: bottomAnchor),
+            divider.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(showsModePlaceholder: Bool) {
+        layer?.backgroundColor = Theme.background.cgColor
+        divider.layer?.backgroundColor = Theme.divider.cgColor
+        let fill = NSColor.labelColor.withAlphaComponent(0.05).cgColor
+        modePlaceholder.layer?.backgroundColor = fill
+        layoutPlaceholder.layer?.backgroundColor = fill
+        modePlaceholder.isHidden = !showsModePlaceholder
     }
 }
 

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -723,17 +723,19 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     /// Rebuilds a saved tab's pane layout — recreating its sessions (wired for
     /// exit + observation), files and diffs — then registers and appends it.
     /// Skips panes whose content can't be rebuilt; a tab with none is dropped.
+    @discardableResult
     func restoreTab(
         from snap: SessionSnapshot.ProjectSnapshot.TabSnapshot,
         histories: [String: String] = [:]
-    ) {
+    ) -> PaneTab? {
         let layout = restoreLayout(from: snap.layout, histories: histories)
         let panes = layout.allPanes
-        guard !panes.isEmpty else { return }
+        guard !panes.isEmpty else { return nil }
         let focusedIndex = min(max(0, snap.focusedPaneIndex), panes.count - 1)
         let tab = PaneTab(layout: layout, focusedPaneID: panes[focusedIndex].id)
         tab.customName = snap.customName
         append(tab)
+        return tab
     }
 
     private func restoreLayout(

--- a/kero/SessionStore.swift
+++ b/kero/SessionStore.swift
@@ -67,18 +67,23 @@ struct SessionSnapshot: Codable {
             /// User-assigned tab name; nil when the title is automatic.
             /// Optional so older snapshots still decode.
             var customName: String?
+            /// Position of the terminal this non-terminal tab was opened
+            /// from in the project's flattened session list. Optional so
+            /// snapshots written before context persistence still decode.
+            var contextSessionIndex: Int?
 
             init(
                 layout: LayoutSnapshot, focusedPaneIndex: Int,
-                customName: String? = nil
+                customName: String? = nil, contextSessionIndex: Int? = nil
             ) {
                 self.layout = layout
                 self.focusedPaneIndex = focusedPaneIndex
                 self.customName = customName
+                self.contextSessionIndex = contextSessionIndex
             }
 
             enum CodingKeys: String, CodingKey {
-                case layout, focusedPaneIndex, customName
+                case layout, focusedPaneIndex, customName, contextSessionIndex
                 case columns, focusedColumn, focusedRow
             }
 
@@ -89,6 +94,9 @@ struct SessionSnapshot: Codable {
                     focusedPaneIndex =
                         (try? container.decode(Int.self, forKey: .focusedPaneIndex)) ?? 0
                     customName = try? container.decode(String.self, forKey: .customName)
+                    contextSessionIndex = try? container.decode(
+                        Int.self, forKey: .contextSessionIndex
+                    )
                     return
                 }
                 if let container = try? decoder.container(keyedBy: CodingKeys.self),
@@ -116,6 +124,7 @@ struct SessionSnapshot: Codable {
                             max(0, columns[clampedColumn].panes.count - 1)
                         )
                     customName = try? container.decode(String.self, forKey: .customName)
+                    contextSessionIndex = nil
                     return
                 }
                 // Legacy: the tab was a single content enum. Wrap it in a
@@ -124,6 +133,7 @@ struct SessionSnapshot: Codable {
                 layout = .pane(PaneSnapshot(content: content, weight: 1))
                 focusedPaneIndex = 0
                 customName = nil
+                contextSessionIndex = nil
             }
 
             func encode(to encoder: any Encoder) throws {
@@ -131,6 +141,9 @@ struct SessionSnapshot: Codable {
                 try container.encode(layout, forKey: .layout)
                 try container.encode(focusedPaneIndex, forKey: .focusedPaneIndex)
                 try container.encodeIfPresent(customName, forKey: .customName)
+                try container.encodeIfPresent(
+                    contextSessionIndex, forKey: .contextSessionIndex
+                )
             }
 
             /// Converts the former row-of-columns layout to an equivalent

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -833,6 +833,7 @@ final class TerminalManager: nonisolated ObservableObject {
         let snapshot = SessionSnapshot(
             projects: projects.compactMap { project in
                 guard !project.tabs.isEmpty else { return nil }
+                let projectSessions = project.sessions
                 let tabs = project.tabs.map { tab -> ProjectSnapshot.TabSnapshot in
                     let layout = Self.layoutSnapshot(
                         tab.layout,
@@ -844,7 +845,10 @@ final class TerminalManager: nonisolated ObservableObject {
                     } ?? 0
                     return ProjectSnapshot.TabSnapshot(
                         layout: layout, focusedPaneIndex: focusedPaneIndex,
-                        customName: tab.customName
+                        customName: tab.customName,
+                        contextSessionIndex: tab.contextSession.flatMap { context in
+                            projectSessions.firstIndex { $0.id == context.id }
+                        }
                     )
                 }
                 return ProjectSnapshot(
@@ -941,8 +945,19 @@ final class TerminalManager: nonisolated ObservableObject {
             let project = makeProject(createInitialSession: false)
             project.customName = Project.normalizedCustomName(saved.customName)
             project.customDirectory = saved.customDirectory
-            for tab in saved.tabs {
-                project.restoreTab(from: tab, histories: Self.pendingHistories)
+            var restoredContexts: [(tab: PaneTab, sessionIndex: Int)] = []
+            for savedTab in saved.tabs {
+                guard let tab = project.restoreTab(
+                    from: savedTab, histories: Self.pendingHistories
+                ) else { continue }
+                if let sessionIndex = savedTab.contextSessionIndex {
+                    restoredContexts.append((tab, sessionIndex))
+                }
+            }
+            let restoredSessions = project.sessions
+            for context in restoredContexts
+            where restoredSessions.indices.contains(context.sessionIndex) {
+                context.tab.contextSession = restoredSessions[context.sessionIndex]
             }
             guard !project.tabs.isEmpty else {
                 projectObservations[project.id] = nil

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -364,11 +364,11 @@ final class TerminalManager: nonisolated ObservableObject {
         guard let index = projects.firstIndex(where: { $0.id == project.id }) else { return }
         projects.remove(at: index)
         projectObservations[project.id] = nil
-        retainedDiffProjectIDs.remove(project.id)
         if selectedProjectID == project.id {
             let neighbor = min(index, projects.count - 1)
             selectedProjectID = neighbor >= 0 ? projects[neighbor].id : nil
         }
+        retainedDiffProjectIDs.remove(project.id)
         // Nothing left to inspect once the last project is gone, so collapse
         // the right sidebar — its panels all track the selected session.
         if projects.isEmpty {

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -35,7 +35,18 @@ enum FindAction {
 @MainActor
 final class TerminalManager: nonisolated ObservableObject {
     @Published var projects: [Project] = []
-    @Published var selectedProjectID: UUID?
+    @Published var selectedProjectID: UUID? {
+        willSet {
+            // Diff hosts are expensive WebKit trees. Once a project has put
+            // them in this window, keep that project's stack mounted across
+            // project switches just as ContentView already does across tab
+            // switches. Reattaching every open diff can otherwise block the
+            // main thread while AppKit rebuilds the window/view hierarchy.
+            if let selectedProjectID, selectedProjectID != newValue {
+                retainedDiffProjectIDs.insert(selectedProjectID)
+            }
+        }
+    }
     @Published var isPanelVisible = false
     @Published var panelTab: RightPanel = .files
     /// Visibility of the left project sidebar (⌘B). `isPanelVisible` above is
@@ -46,6 +57,10 @@ final class TerminalManager: nonisolated ObservableObject {
     /// Projects publish their own changes (session list, session selection);
     /// re-publish them so views observing the manager stay current.
     private var projectObservations: [UUID: AnyCancellable] = [:]
+    /// Projects whose diff stacks have already been mounted in this window.
+    /// Unvisited restored projects stay lazy so launch does not instantiate all
+    /// of their WKWebViews at once.
+    private var retainedDiffProjectIDs: Set<UUID> = []
     private var projectCounter = 0
     private var settingsObservation: AnyCancellable?
     private var autosaveObservation: AnyCancellable?
@@ -167,6 +182,16 @@ final class TerminalManager: nonisolated ObservableObject {
 
     var selectedSession: TerminalSession? {
         selectedProject?.selectedSession
+    }
+
+    /// Diff stacks that should remain in the window hierarchy. The selected
+    /// project is included immediately; previously selected projects remain
+    /// only when they actually own a diff.
+    var projectsWithMountedDiffs: [Project] {
+        projects.filter {
+            $0.id == selectedProjectID
+                || (retainedDiffProjectIDs.contains($0.id) && $0.hasDiffs)
+        }
     }
 
     // MARK: - Projects
@@ -339,6 +364,7 @@ final class TerminalManager: nonisolated ObservableObject {
         guard let index = projects.firstIndex(where: { $0.id == project.id }) else { return }
         projects.remove(at: index)
         projectObservations[project.id] = nil
+        retainedDiffProjectIDs.remove(project.id)
         if selectedProjectID == project.id {
             let neighbor = min(index, projects.count - 1)
             selectedProjectID = neighbor >= 0 ? projects[neighbor].id : nil


### PR DESCRIPTION
## Summary

- Keep diff viewer stacks mounted after a project has been visited to avoid expensive WebKit teardown and reattachment during project switching.
- Preserve lazy loading for unvisited restored projects.
- Refresh live diffs only when selected and not already loading.
- Remove retained diff state when a project is deleted.

## Testing

Not run (not requested)