### PR TITLE
Add built-in terminal multiplexer (finishes #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ the original feature bullet instead of adding separate entries for them.
 - Splitting a pane now divides only the focused pane, preserving the size of neighboring panes in nested layouts
 - The Ctrl-Tab switcher now lists tabs in the order you last used them and opens already pointing at the previous tab, so a quick Ctrl-Tab flips between the two tabs you're working in
 
+- Optionally keep terminal sessions running locally when Kero closes, then reconnect their live processes and output when Kero reopens
+
 ## [0.1.34]
 
 - Show terminal titles verbatim while keeping sidebar project rows stable as titles update or hover controls appear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Optionally keep terminal sessions running locally when Kero closes, then reconnect their live processes and output when Kero reopens
+
 ## [0.1.44]
 
 - Prevent a rare crash while using the Ctrl-Tab switcher
@@ -69,8 +71,6 @@ the original feature bullet instead of adding separate entries for them.
 - Add per-pane live titles and split controls in split layouts
 - Splitting a pane now divides only the focused pane, preserving the size of neighboring panes in nested layouts
 - The Ctrl-Tab switcher now lists tabs in the order you last used them and opens already pointing at the previous tab, so a quick Ctrl-Tab flips between the two tabs you're working in
-
-- Optionally keep terminal sessions running locally when Kero closes, then reconnect their live processes and output when Kero reopens
 
 ## [0.1.34]
 

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -204,6 +204,13 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Let the local Kero multiplexer own PTYs created after this is enabled,
+    /// so closing windows or quitting the app detaches rather than stopping
+    /// their shells. Existing terminals keep their current lifecycle.
+    @Published var durableTerminalSessions: Bool {
+        didSet { save() }
+    }
+
     /// Which emulator drives terminal panes. Only ever holds a backend this
     /// build ships a surface for — see `TerminalBackend` — and a session binds
     /// its backend at creation, so a change here reaches terminals opened
@@ -247,6 +254,7 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = toml["terminal.macos-option-as-alt"]?.bool ?? false
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
+        durableTerminalSessions = toml["terminal.durable-sessions"]?.bool ?? false
         terminalBackend = TerminalBackend(persisted: toml["terminal.backend"]?.string)
         applyAppearance()
         reloadThemeSelection()
@@ -295,6 +303,7 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = false
         wrapLines = false
         restoreTerminalHistory = false
+        durableTerminalSessions = false
         terminalBackend = .fallback
     }
 
@@ -332,6 +341,9 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if restoreTerminalHistory {
             lines.append("terminal.restore-history = true")
+        }
+        if durableTerminalSessions {
+            lines.append("terminal.durable-sessions = true")
         }
         if terminalBackend != .fallback {
             lines.append("terminal.backend = \(TOML.quote(terminalBackend.rawValue))")

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -41,7 +41,52 @@ struct ContentView: View {
         BottomToolbarLayout.height(for: manager.selectedSession)
     }
 
+    // The window's layers are split into explicitly typed sub-views. As one
+    // expression this body exceeds the type checker's time budget on the
+    // release toolchain, and the failure only reappears once it is large
+    // enough again — keep new layers in their own properties.
     var body: some View {
+        overlaidContent
+            .background(WindowChromeAccessor { manager.attach(to: $0) })
+            .onAppear { syncGit() }
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )) { _ in
+                syncGit()
+            }
+            .onChange(of: gitSyncKey) { syncGit() }
+            .onChange(of: colorScheme) {
+                manager.refreshAppearance()
+            }
+    }
+
+    private var overlaidContent: some View {
+        windowColumns
+            .ignoresSafeArea()
+            .overlay(alignment: .topLeading) {
+                TerminalParkingView(sessions: parkedTerminalSessions)
+                    .frame(width: 1, height: 1)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
+            .overlay {
+                if manager.isCommandPaletteVisible {
+                    CommandPaletteView(manager: manager)
+                }
+            }
+            .overlay {
+                if tabSwitcher.isPresented, let project = manager.selectedProject {
+                    TabSwitcherOverlay(project: project, controller: tabSwitcher)
+                        .zIndex(10)
+                }
+            }
+            .background {
+                TabSwitcherEventMonitor(manager: manager, controller: tabSwitcher)
+                    .frame(width: 0, height: 0)
+            }
+    }
+
+    private var windowColumns: some View {
         HStack(spacing: 0) {
             if manager.isLeftSidebarVisible {
                 SidebarView(
@@ -50,69 +95,7 @@ struct ContentView: View {
                 )
             }
 
-            VStack(spacing: 0) {
-                // Above the pane stack so header tooltips, which hang down
-                // into the terminal area, aren't covered by it.
-                MainHeaderView(manager: manager)
-                    .zIndex(1)
-
-                ZStack {
-                    // Diff panes stay mounted after their project has been
-                    // visited: removing a project's stack pulls every
-                    // NSHostingView out of the window at once, making project
-                    // switching block while WebKit tears down and reattaches
-                    // the rendered diffs. Unvisited restored projects remain
-                    // lazy; inactive stacks sit beneath the active opaque pane.
-                    ForEach(manager.projectsWithMountedDiffs) { project in
-                        ForEach(project.diffPlacements, id: \.diff.id) { placement in
-                            let isSelected = manager.selectedProjectID == project.id
-                                && project.selectedTabID == placement.tabID
-                            DiffViewerView(
-                                diff: placement.diff,
-                                isSelected: isSelected
-                            )
-                            .background(Color(nsColor: Theme.background))
-                            .allowsHitTesting(isSelected)
-                            .zIndex(isSelected ? 1 : 0)
-                        }
-                    }
-                    Group {
-                        if let tab = manager.selectedProject?.selectedTab {
-                            PaneLayoutView(
-                                tab: tab,
-                                onSplit: { manager.split(toward: $0) },
-                                onNewBrowserTab: {
-                                    manager.newBrowserTab(initialURL: $0)
-                                },
-                                onNewBrowserPane: {
-                                    manager.newBrowserPane(initialURL: $0)
-                                }
-                            )
-                        } else {
-                            emptyState
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    // Opaque so the pane gaps hide the unselected diffs behind,
-                    // except while a diff tab is up — then stay clear so its
-                    // web view shows through from the stack below.
-                    .background(paneLayerIsOpaque ? AnyShapeStyle(Color(nsColor: Theme.background)) : AnyShapeStyle(Color.clear))
-                    .zIndex(2)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-                if manager.selectedProject != nil
-                    && settings.toolbarVisibility != .hide
-                    && (git.isRepo || settings.toolbarVisibility == .always) {
-                    BottomToolbarView(
-                        model: git,
-                        height: bottomToolbarHeight,
-                        toggleGitPanel: { manager.togglePanel(.git) },
-                        hideToolbar: { settings.toolbarVisibility = .hide }
-                    )
-                }
-            }
-            .background(Color(nsColor: Theme.background))
+            mainColumn
 
             // Dropping the hidden sidebar also drops its expanded file tree
             // and process snapshot. Git stays window-owned because the toolbar
@@ -121,43 +104,109 @@ struct ContentView: View {
                 RightSidebarView(manager: manager, git: git)
             }
         }
-        .ignoresSafeArea()
-        .overlay(alignment: .topLeading) {
-            TerminalParkingView(sessions: parkedTerminalSessions)
-                .frame(width: 1, height: 1)
-                .allowsHitTesting(false)
-                .accessibilityHidden(true)
+    }
+
+    /// Everything the git toolbar derives its root from, in one value. These
+    /// were separate `onChange` modifiers; collapsing them keeps the body's
+    /// modifier chain inside the type checker's budget and coalesces a burst
+    /// of simultaneous changes into a single sync.
+    private struct GitSyncKey: Equatable {
+        var commandCompletions: [UUID: UInt64]
+        var projectID: UUID?
+        var sessionID: UUID?
+        var workingDirectory: String?
+        var foregroundDirectory: String?
+        var customDirectory: String?
+    }
+
+    private var gitSyncKey: GitSyncKey {
+        let session = manager.selectedSession
+        return GitSyncKey(
+            commandCompletions: commandCompletionSequences,
+            projectID: manager.selectedProjectID,
+            sessionID: session?.id,
+            workingDirectory: session?.workingDirectory,
+            foregroundDirectory: session?.foregroundDirectoryPath,
+            customDirectory: manager.selectedProject?.customDirectory
+        )
+    }
+
+    private var mainColumn: some View {
+        VStack(spacing: 0) {
+            // Above the pane stack so header tooltips, which hang down
+            // into the terminal area, aren't covered by it.
+            MainHeaderView(manager: manager)
+                .zIndex(1)
+
+            paneStack
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            bottomToolbar
         }
-        .overlay {
-            if manager.isCommandPaletteVisible {
-                CommandPaletteView(manager: manager)
+        .background(Color(nsColor: Theme.background))
+    }
+
+    private var paneStack: some View {
+        ZStack {
+            mountedDiffLayer
+            activePaneLayer
+        }
+    }
+
+    /// Diff panes stay mounted after their project has been visited: removing
+    /// a project's stack pulls every NSHostingView out of the window at once,
+    /// making project switching block while WebKit tears down and reattaches
+    /// the rendered diffs. Unvisited restored projects remain lazy; inactive
+    /// stacks sit beneath the active opaque pane.
+    private var mountedDiffLayer: some View {
+        ForEach(manager.projectsWithMountedDiffs) { project in
+            ForEach(project.diffPlacements, id: \.diff.id) { placement in
+                let isSelected = manager.selectedProjectID == project.id
+                    && project.selectedTabID == placement.tabID
+                DiffViewerView(
+                    diff: placement.diff,
+                    isSelected: isSelected
+                )
+                .background(Color(nsColor: Theme.background))
+                .allowsHitTesting(isSelected)
+                .zIndex(isSelected ? 1 : 0)
             }
         }
-        .overlay {
-            if tabSwitcher.isPresented, let project = manager.selectedProject {
-                TabSwitcherOverlay(project: project, controller: tabSwitcher)
-                    .zIndex(10)
+    }
+
+    private var activePaneLayer: some View {
+        Group {
+            if let tab = manager.selectedProject?.selectedTab {
+                PaneLayoutView(
+                    tab: tab,
+                    onSplit: { manager.split(toward: $0) },
+                    onNewBrowserTab: {
+                        manager.newBrowserTab(initialURL: $0)
+                    },
+                    onNewBrowserPane: {
+                        manager.newBrowserPane(initialURL: $0)
+                    }
+                )
+            } else {
+                emptyState
             }
         }
-        .background {
-            TabSwitcherEventMonitor(manager: manager, controller: tabSwitcher)
-                .frame(width: 0, height: 0)
-        }
-        .background(WindowChromeAccessor { manager.attach(to: $0) })
-        .onAppear { syncGit() }
-        .onReceive(NotificationCenter.default.publisher(
-            for: NSApplication.didBecomeActiveNotification
-        )) { _ in
-            syncGit()
-        }
-        .onChange(of: commandCompletionSequences) { syncGit() }
-        .onChange(of: manager.selectedProjectID) { syncGit() }
-        .onChange(of: manager.selectedSession?.id) { syncGit() }
-        .onChange(of: manager.selectedSession?.workingDirectory) { syncGit() }
-        .onChange(of: manager.selectedSession?.foregroundDirectoryPath) { syncGit() }
-        .onChange(of: manager.selectedProject?.customDirectory) { syncGit() }
-        .onChange(of: colorScheme) {
-            manager.refreshAppearance()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(paneLayerBackground)
+        .zIndex(2)
+    }
+
+    @ViewBuilder
+    private var bottomToolbar: some View {
+        if manager.selectedProject != nil
+            && settings.toolbarVisibility != .hide
+            && (git.isRepo || settings.toolbarVisibility == .always) {
+            BottomToolbarView(
+                model: git,
+                height: bottomToolbarHeight,
+                toggleGitPanel: { manager.togglePanel(.git) },
+                hideToolbar: { settings.toolbarVisibility = .hide }
+            )
         }
     }
 
@@ -175,9 +224,10 @@ struct ContentView: View {
     /// The pane layer paints an opaque background to hide unselected diffs in
     /// its gaps — but a diff tab's own pane must stay clear so its web view
     /// (mounted in the stack behind) shows through.
-    private var paneLayerIsOpaque: Bool {
-        guard let tab = manager.selectedProject?.selectedTab else { return true }
-        return tab.diffs.isEmpty
+    private var paneLayerBackground: AnyShapeStyle {
+        guard let tab = manager.selectedProject?.selectedTab, !tab.diffs.isEmpty
+        else { return AnyShapeStyle(Color(nsColor: Theme.background)) }
+        return AnyShapeStyle(Color.clear)
     }
 
     private func syncGit() {

--- a/kero/KeroCLIService.swift
+++ b/kero/KeroCLIService.swift
@@ -8,6 +8,28 @@ import Darwin
 import Foundation
 import GhosttyTheme
 
+struct KeroCLIBridgeState: Codable {
+    let statePath: String
+    let token: String
+    let appPID: pid_t
+}
+
+enum KeroCLIBridge {
+    static let currentURL: URL = {
+        #if DEBUG
+        let directory = "kero-dev"
+        #else
+        let directory = "kero"
+        #endif
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        return base
+            .appendingPathComponent(directory, isDirectory: true)
+            .appendingPathComponent("cli-current.json")
+    }()
+}
+
 /// Bridges the bundled `kero` executable back to its owning app process.
 ///
 /// The CLI receives a per-launch secret and a generated catalog file through
@@ -70,6 +92,7 @@ final class KeroCLIService {
         }
 
         writeState()
+        writeCurrentBridge()
 
         notificationObserver = DistributedNotificationCenter.default()
             .addObserver(
@@ -88,6 +111,7 @@ final class KeroCLIService {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
+                self?.removeCurrentBridge()
                 self?.removeStateDirectory()
             }
         }
@@ -284,6 +308,41 @@ final class KeroCLIService {
         } catch {
             NSLog("kero: failed to write CLI theme catalog: \(error)")
         }
+    }
+
+    /// Durable shells retain their original environment across app launches.
+    /// This small same-user pointer lets their bundled `kero` command discover
+    /// the current app's otherwise per-launch token and catalog file.
+    private func writeCurrentBridge() {
+        let bridge = KeroCLIBridgeState(
+            statePath: stateURL.path,
+            token: secret,
+            appPID: getpid()
+        )
+        guard let data = try? JSONEncoder().encode(bridge) else { return }
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(
+                at: KeroCLIBridge.currentURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try data.write(to: KeroCLIBridge.currentURL, options: .atomic)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: KeroCLIBridge.currentURL.path
+            )
+        } catch {
+            NSLog("kero: failed to publish the current CLI bridge: \(error)")
+        }
+    }
+
+    private func removeCurrentBridge() {
+        guard let data = try? Data(contentsOf: KeroCLIBridge.currentURL),
+              let bridge = try? JSONDecoder().decode(KeroCLIBridgeState.self, from: data),
+              bridge.token == secret
+        else { return }
+        try? FileManager.default.removeItem(at: KeroCLIBridge.currentURL)
     }
 
     private func removeStateDirectory() {

--- a/kero/KeroCommandLine.swift
+++ b/kero/KeroCommandLine.swift
@@ -75,8 +75,18 @@ private final class AppConnection {
     let token: String
 
     init(environment: [String: String] = ProcessInfo.processInfo.environment) throws {
-        guard let statePath = environment["KERO_CLI_STATE"],
-              let token = environment["KERO_CLI_TOKEN"],
+        var statePath = environment["KERO_CLI_STATE"]
+        var token = environment["KERO_CLI_TOKEN"]
+        if environment["KERO_MUX_SESSION"] == "1",
+           let data = try? Data(contentsOf: KeroCLIBridge.currentURL),
+           let bridge = try? JSONDecoder().decode(KeroCLIBridgeState.self, from: data),
+           bridge.appPID > 1,
+           Darwin.kill(bridge.appPID, 0) == 0 || errno == EPERM {
+            statePath = bridge.statePath
+            token = bridge.token
+        }
+        guard let statePath,
+              let token,
               !statePath.isEmpty,
               !token.isEmpty
         else {
@@ -538,6 +548,16 @@ private func printHelp() {
 
 private func run() throws {
     let arguments = Array(CommandLine.arguments.dropFirst())
+    if arguments == ["+mux-server"] {
+        try KeroMuxServer.run()
+        return
+    }
+    if arguments.count == 2,
+       arguments.first == "+mux-client",
+       let sessionID = UUID(uuidString: arguments[1]) {
+        try KeroMuxClientProcess.run(sessionID: sessionID)
+        return
+    }
     if arguments == ["+help"] {
         printHelp()
         return

--- a/kero/KeroCommandLine.swift
+++ b/kero/KeroCommandLine.swift
@@ -534,6 +534,8 @@ private func printHelp() {
           kero <command> [arguments...]
           kero +themes [--dark | --light]
           kero +themes --list [--dark | --light]
+          kero +mux-list
+          kero +mux-stop
           kero +help
 
         With no arguments, kero creates a project with a normal login shell.
@@ -542,8 +544,39 @@ private func printHelp() {
         +themes browses Kero's themes in the terminal. Moving through the list
         previews the theme across the whole app; Return saves it and Esc
         restores the previous theme.
+
+        +mux-list shows terminals still running under "Keep terminal sessions
+        running when Kero closes". +mux-stop ends all of them and shuts the
+        multiplexer down.
         """)
     )
+}
+
+/// Durable sessions outlive every Kero window, so they need a way to be seen
+/// and stopped without a running app — otherwise a shell nothing references
+/// is only discoverable in Activity Monitor.
+private func printDurableSessions() {
+    let sessions = KeroMuxControl.list()
+    guard !sessions.isEmpty else {
+        print(String(localized: "No terminal sessions are running."))
+        return
+    }
+    for session in sessions {
+        print("\(session.id)  pid \(session.shellPID)  \(session.shellName)  \(session.workingDirectory)")
+    }
+}
+
+private func stopMultiplexer() throws {
+    switch KeroMuxControl.stop() {
+    case .notRunning:
+        print(String(localized: "No terminal sessions are running."))
+    case .stopped(let count):
+        print(count == 1
+            ? String(localized: "Stopped 1 terminal session.")
+            : String(localized: "Stopped \(count) terminal sessions."))
+    case .failed(let message):
+        throw CLIError.message(message)
+    }
 }
 
 private func run() throws {
@@ -556,6 +589,14 @@ private func run() throws {
        arguments.first == "+mux-client",
        let sessionID = UUID(uuidString: arguments[1]) {
         try KeroMuxClientProcess.run(sessionID: sessionID)
+        return
+    }
+    if arguments == ["+mux-list"] {
+        printDurableSessions()
+        return
+    }
+    if arguments == ["+mux-stop"] {
+        try stopMultiplexer()
         return
     }
     if arguments == ["+help"] {

--- a/kero/KeroMux.swift
+++ b/kero/KeroMux.swift
@@ -1,0 +1,1027 @@
+//
+//  KeroMux.swift
+//  kero
+//
+
+import Darwin
+import Foundation
+
+/// A live PTY owned by Kero's local multiplexer. Layout deliberately stays in
+/// the app: the daemon knows sessions, not projects, tabs, panes, or windows.
+struct KeroMuxSessionInfo: Codable, Sendable {
+    let id: UUID
+    let backend: String
+    let shellName: String
+    let title: String
+    let workingDirectory: String
+    let shellPID: pid_t
+    let foregroundPID: pid_t?
+}
+
+private struct KeroMuxMessage: Codable {
+    var type: String
+    var sessionID: UUID?
+    var program: String?
+    var arguments: [String]?
+    var workingDirectory: String?
+    var environment: [String: String]?
+    var backend: String?
+    var shellName: String?
+    var title: String?
+    var data: Data?
+    var columns: UInt16?
+    var rows: UInt16?
+    var pixelWidth: UInt16?
+    var pixelHeight: UInt16?
+    var session: KeroMuxSessionInfo?
+    var sessions: [KeroMuxSessionInfo]?
+    var message: String?
+
+    init(type: String) {
+        self.type = type
+    }
+}
+
+enum KeroMuxError: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let message): message
+        }
+    }
+}
+
+private enum KeroMuxPaths {
+    static let directory: URL = {
+        #if DEBUG
+        let name = "kero-dev"
+        #else
+        let name = "kero"
+        #endif
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        return base
+            .appendingPathComponent(name, isDirectory: true)
+            .appendingPathComponent("mux", isDirectory: true)
+    }()
+
+    static var socket: URL {
+        directory.appendingPathComponent("mux.sock")
+    }
+
+    static var lock: URL {
+        directory.appendingPathComponent("mux.lock")
+    }
+
+    static var executable: URL {
+        if let executable = Bundle.main.executableURL {
+            return executable
+        }
+        return URL(fileURLWithPath: CommandLine.arguments[0]).standardizedFileURL
+    }
+
+    static func prepareDirectory() throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: directory.path
+        )
+    }
+}
+
+private enum KeroMuxWire {
+    static let maximumFrameSize = 32 * 1024 * 1024
+
+    static func send(_ message: KeroMuxMessage, to fd: Int32) throws {
+        let payload = try JSONEncoder().encode(message)
+        guard payload.count <= maximumFrameSize else {
+            throw KeroMuxError.message("multiplexer message is too large")
+        }
+        var length = UInt32(payload.count).bigEndian
+        try withUnsafeBytes(of: &length) { bytes in
+            try writeAll(fd, bytes)
+        }
+        try payload.withUnsafeBytes { bytes in
+            try writeAll(fd, bytes)
+        }
+    }
+
+    static func receive(from fd: Int32) throws -> KeroMuxMessage? {
+        guard let header = try readExact(fd, count: MemoryLayout<UInt32>.size) else {
+            return nil
+        }
+        let encodedLength = header.withUnsafeBytes {
+            $0.loadUnaligned(as: UInt32.self)
+        }
+        let length = Int(UInt32(bigEndian: encodedLength))
+        guard length >= 0, length <= maximumFrameSize else {
+            throw KeroMuxError.message("invalid multiplexer message length")
+        }
+        guard let payload = try readExact(fd, count: length) else {
+            throw KeroMuxError.message("multiplexer connection closed mid-message")
+        }
+        return try JSONDecoder().decode(KeroMuxMessage.self, from: payload)
+    }
+
+    static func writeAll(_ fd: Int32, _ bytes: UnsafeRawBufferPointer) throws {
+        var offset = 0
+        while offset < bytes.count {
+            let result = Darwin.write(
+                fd,
+                bytes.baseAddress?.advanced(by: offset),
+                bytes.count - offset
+            )
+            if result > 0 {
+                offset += result
+            } else if result < 0, errno == EINTR {
+                continue
+            } else {
+                throw KeroMuxError.message(
+                    "multiplexer write failed: \(String(cString: strerror(errno)))"
+                )
+            }
+        }
+    }
+
+    static func readExact(_ fd: Int32, count: Int) throws -> Data? {
+        if count == 0 { return Data() }
+        var data = Data(count: count)
+        var offset = 0
+        let completed = try data.withUnsafeMutableBytes { bytes -> Bool in
+            while offset < count {
+                let result = Darwin.read(
+                    fd,
+                    bytes.baseAddress?.advanced(by: offset),
+                    count - offset
+                )
+                if result > 0 {
+                    offset += result
+                } else if result == 0 {
+                    return false
+                } else if errno == EINTR {
+                    continue
+                } else {
+                    throw KeroMuxError.message(
+                        "multiplexer read failed: \(String(cString: strerror(errno)))"
+                    )
+                }
+            }
+            return true
+        }
+        return completed ? data : nil
+    }
+}
+
+private final class KeroMuxConnection {
+    let fd: Int32
+    private let sendLock = NSLock()
+    private let closeLock = NSLock()
+    private var isClosed = false
+
+    init(fd: Int32) {
+        self.fd = fd
+        var enabled: Int32 = 1
+        _ = setsockopt(
+            fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled,
+            socklen_t(MemoryLayout.size(ofValue: enabled))
+        )
+    }
+
+    deinit {
+        close()
+    }
+
+    func send(_ message: KeroMuxMessage) throws {
+        sendLock.lock()
+        defer { sendLock.unlock() }
+        try KeroMuxWire.send(message, to: fd)
+    }
+
+    func receive() throws -> KeroMuxMessage? {
+        try KeroMuxWire.receive(from: fd)
+    }
+
+    func close() {
+        closeLock.lock()
+        defer { closeLock.unlock() }
+        guard !isClosed else { return }
+        isClosed = true
+        _ = Darwin.shutdown(fd, SHUT_RDWR)
+        _ = Darwin.close(fd)
+    }
+}
+
+enum KeroMuxControl {
+    static func create(
+        launch: TerminalLaunch,
+        backend: TerminalBackend,
+        shellName: String
+    ) throws -> KeroMuxSessionInfo {
+        var message = KeroMuxMessage(type: "create")
+        message.program = launch.program
+        message.arguments = launch.arguments
+        message.workingDirectory = launch.workingDirectory
+        var environment = ProcessInfo.processInfo.environment
+        environment.merge(launch.environment) { _, terminalValue in terminalValue }
+        environment["KERO_MUX_SESSION"] = "1"
+        message.environment = environment
+        message.backend = backend.rawValue
+        message.shellName = shellName
+        let response = try request(message, startServer: true)
+        guard response.type == "created", let session = response.session else {
+            throw responseError(response)
+        }
+        return session
+    }
+
+    static func info(_ id: UUID) -> KeroMuxSessionInfo? {
+        var message = KeroMuxMessage(type: "info")
+        message.sessionID = id
+        guard let response = try? request(message, startServer: false),
+              response.type == "info"
+        else { return nil }
+        return response.session
+    }
+
+    static func list() -> [KeroMuxSessionInfo] {
+        let message = KeroMuxMessage(type: "list")
+        guard let response = try? request(message, startServer: false),
+              response.type == "sessions"
+        else { return [] }
+        return response.sessions ?? []
+    }
+
+    static func checkpoint(_ data: Data, sessionID: UUID) {
+        var message = KeroMuxMessage(type: "checkpoint")
+        message.sessionID = sessionID
+        message.data = data
+        _ = try? request(message, startServer: false)
+    }
+
+    static func updateMetadata(
+        sessionID: UUID,
+        title: String? = nil,
+        workingDirectory: String? = nil
+    ) {
+        var message = KeroMuxMessage(type: "metadata")
+        message.sessionID = sessionID
+        message.title = title
+        message.workingDirectory = workingDirectory
+        _ = try? request(message, startServer: false)
+    }
+
+    static func terminate(_ id: UUID) {
+        var message = KeroMuxMessage(type: "terminate")
+        message.sessionID = id
+        _ = try? request(message, startServer: false)
+    }
+
+    static func attachmentLaunch(
+        sessionID: UUID,
+        workingDirectory: String,
+        environment: [String: String]
+    ) -> TerminalLaunch {
+        let executable = KeroMuxPaths.executable.path
+        let arguments = ["+mux-client", sessionID.uuidString]
+        let commandLine = ([executable] + arguments)
+            .map(shellQuote)
+            .joined(separator: " ")
+        return TerminalLaunch(
+            program: executable,
+            arguments: arguments,
+            commandLine: commandLine,
+            workingDirectory: workingDirectory,
+            environment: environment
+        )
+    }
+
+    private static func request(
+        _ message: KeroMuxMessage,
+        startServer: Bool
+    ) throws -> KeroMuxMessage {
+        let fd = try connect(startServer: startServer)
+        let connection = KeroMuxConnection(fd: fd)
+        try connection.send(message)
+        guard let response = try connection.receive() else {
+            throw KeroMuxError.message("multiplexer closed the connection")
+        }
+        return response
+    }
+
+    fileprivate static func connect(startServer: Bool) throws -> Int32 {
+        try KeroMuxPaths.prepareDirectory()
+        if let fd = tryConnect() { return fd }
+        guard startServer else {
+            throw KeroMuxError.message("multiplexer is not running")
+        }
+
+        let lockFD = Darwin.open(KeroMuxPaths.lock.path, O_CREAT | O_RDWR, 0o600)
+        guard lockFD >= 0 else {
+            throw KeroMuxError.message("could not open the multiplexer lock")
+        }
+        defer { Darwin.close(lockFD) }
+        guard flock(lockFD, LOCK_EX) == 0 else {
+            throw KeroMuxError.message("could not lock multiplexer startup")
+        }
+
+        if let fd = tryConnect() {
+            _ = flock(lockFD, LOCK_UN)
+            return fd
+        }
+        _ = Darwin.unlink(KeroMuxPaths.socket.path)
+        do {
+            try startDaemon()
+        } catch {
+            _ = flock(lockFD, LOCK_UN)
+            throw error
+        }
+        // The daemon holds this lock for its lifetime. Release the startup
+        // claim before polling so the freshly spawned process can acquire it.
+        _ = flock(lockFD, LOCK_UN)
+
+        for _ in 0..<100 {
+            if let fd = tryConnect() { return fd }
+            usleep(20_000)
+        }
+        throw KeroMuxError.message("multiplexer did not start")
+    }
+
+    private static func tryConnect() -> Int32? {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var enabled: Int32 = 1
+        _ = setsockopt(
+            fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled,
+            socklen_t(MemoryLayout.size(ofValue: enabled))
+        )
+        do {
+            var address = try unixAddress(path: KeroMuxPaths.socket.path)
+            let result = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.connect(fd, $0, unixAddressLength(path: KeroMuxPaths.socket.path))
+                }
+            }
+            guard result == 0 else {
+                Darwin.close(fd)
+                return nil
+            }
+            return fd
+        } catch {
+            Darwin.close(fd)
+            return nil
+        }
+    }
+
+    private static func startDaemon() throws {
+        let process = Process()
+        process.executableURL = KeroMuxPaths.executable
+        process.arguments = ["+mux-server"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+    }
+
+    fileprivate static func unixAddress(path: String) throws -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard bytes.count < capacity else {
+            throw KeroMuxError.message("multiplexer socket path is too long")
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { target in
+            target.initializeMemory(as: UInt8.self, repeating: 0)
+            target.copyBytes(from: bytes)
+        }
+        return address
+    }
+
+    fileprivate static func unixAddressLength(path: String) -> socklen_t {
+        socklen_t(MemoryLayout<sa_family_t>.size + path.utf8.count + 1)
+    }
+
+    private static func responseError(_ response: KeroMuxMessage) -> KeroMuxError {
+        KeroMuxError.message(response.message ?? "multiplexer request failed")
+    }
+
+    nonisolated private static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+/// Hidden CLI attach process. Its PTY belongs to the selected renderer, while
+/// the shell's PTY belongs to the daemon. Keeping the bridge byte-for-byte
+/// makes it equally useful to Ghostty and Alacritty and preserves every escape
+/// sequence those renderers already understand.
+enum KeroMuxClientProcess {
+    static func run(sessionID: UUID) throws {
+        _ = Darwin.signal(SIGPIPE, SIG_IGN)
+        let fd = try KeroMuxControl.connect(startServer: false)
+        let connection = KeroMuxConnection(fd: fd)
+        var attach = KeroMuxMessage(type: "attach")
+        attach.sessionID = sessionID
+        try connection.send(attach)
+        guard let response = try connection.receive() else {
+            throw KeroMuxError.message("multiplexer closed before attaching")
+        }
+        guard response.type == "attached" else {
+            throw KeroMuxError.message(
+                response.message ?? "could not attach to the terminal session"
+            )
+        }
+
+        // Ghostty launches configured commands through a short-lived login
+        // shell, which may print its own "Last login" line before this bridge
+        // starts. Clear that renderer-owned PTY before replaying the daemon
+        // session so reconnect shows only the durable terminal's output.
+        let clearRenderer = Data("\u{1B}[3J\u{1B}[2J\u{1B}[H".utf8)
+        try clearRenderer.withUnsafeBytes { bytes in
+            try KeroMuxWire.writeAll(STDOUT_FILENO, bytes)
+        }
+
+        var original = termios()
+        let hasTerminal = tcgetattr(STDIN_FILENO, &original) == 0
+        if hasTerminal {
+            var raw = original
+            cfmakeraw(&raw)
+            _ = tcsetattr(STDIN_FILENO, TCSANOW, &raw)
+        }
+        defer {
+            if hasTerminal {
+                _ = tcsetattr(STDIN_FILENO, TCSANOW, &original)
+            }
+        }
+
+        var lastSize = winsize()
+        sendSizeIfChanged(
+            connection: connection,
+            previous: &lastSize,
+            force: true
+        )
+
+        var descriptors = [
+            pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: fd, events: Int16(POLLIN), revents: 0),
+        ]
+        var input = [UInt8](repeating: 0, count: 64 * 1024)
+
+        while true {
+            descriptors[0].revents = 0
+            descriptors[1].revents = 0
+            let result = Darwin.poll(&descriptors, nfds_t(descriptors.count), 100)
+            if result < 0 {
+                if errno == EINTR { continue }
+                throw KeroMuxError.message("multiplexer attach poll failed")
+            }
+
+            sendSizeIfChanged(
+                connection: connection,
+                previous: &lastSize,
+                force: false
+            )
+
+            if descriptors[0].revents & Int16(POLLIN) != 0 {
+                let count = Darwin.read(STDIN_FILENO, &input, input.count)
+                if count <= 0 { return }
+                var message = KeroMuxMessage(type: "input")
+                message.data = Data(input[..<count])
+                try connection.send(message)
+            }
+
+            if descriptors[1].revents & Int16(POLLIN) != 0 {
+                guard let message = try connection.receive() else { return }
+                switch message.type {
+                case "output":
+                    if let data = message.data {
+                        try data.withUnsafeBytes { bytes in
+                            try KeroMuxWire.writeAll(STDOUT_FILENO, bytes)
+                        }
+                    }
+                case "exited", "replaced":
+                    return
+                case "error":
+                    throw KeroMuxError.message(message.message ?? "multiplexer error")
+                default:
+                    break
+                }
+            }
+
+            let failureEvents = Int16(POLLERR | POLLHUP | POLLNVAL)
+            if descriptors[0].revents & failureEvents != 0
+                || descriptors[1].revents & failureEvents != 0 {
+                return
+            }
+        }
+    }
+
+    private static func sendSizeIfChanged(
+        connection: KeroMuxConnection,
+        previous: inout winsize,
+        force: Bool
+    ) {
+        var size = winsize()
+        guard ioctl(STDIN_FILENO, TIOCGWINSZ, &size) == 0 else { return }
+        guard force
+            || size.ws_col != previous.ws_col
+            || size.ws_row != previous.ws_row
+            || size.ws_xpixel != previous.ws_xpixel
+            || size.ws_ypixel != previous.ws_ypixel
+        else { return }
+        previous = size
+        var message = KeroMuxMessage(type: "resize")
+        message.columns = max(1, size.ws_col)
+        message.rows = max(1, size.ws_row)
+        message.pixelWidth = size.ws_xpixel
+        message.pixelHeight = size.ws_ypixel
+        try? connection.send(message)
+    }
+}
+
+private final class KeroMuxServerSession {
+    let id = UUID()
+    let backend: String
+    let shellName: String
+    let shellPID: pid_t
+
+    private static let replayLimit = 16 * 1024 * 1024
+    private static let replayTrimThreshold = replayLimit + 2 * 1024 * 1024
+    private let masterFD: Int32
+    private let lock = NSLock()
+    private var attached: KeroMuxConnection?
+    private var replay = Data()
+    private var title: String
+    private var workingDirectory: String
+    private var hasExited = false
+    var onExit: ((UUID) -> Void)?
+
+    init(
+        program: String,
+        arguments: [String],
+        workingDirectory: String,
+        environment: [String: String],
+        backend: String,
+        shellName: String
+    ) throws {
+        self.backend = backend
+        self.shellName = shellName
+        self.title = shellName
+        self.workingDirectory = workingDirectory
+
+        let programCopy = strdup(program)
+        let argumentStrings = [program] + arguments
+        let environmentStrings = environment.map { "\($0.key)=\($0.value)" }
+        let argumentCopies: [UnsafeMutablePointer<CChar>?] = argumentStrings.map {
+            strdup($0)
+        }
+        let environmentCopies: [UnsafeMutablePointer<CChar>?] = environmentStrings.map {
+            strdup($0)
+        }
+        let directoryCopy = strdup(workingDirectory)
+        defer {
+            free(programCopy)
+            free(directoryCopy)
+            argumentCopies.forEach { free($0) }
+            environmentCopies.forEach { free($0) }
+        }
+        guard let programCopy, let directoryCopy,
+              argumentCopies.allSatisfy({ $0 != nil }),
+              environmentCopies.allSatisfy({ $0 != nil })
+        else {
+            throw KeroMuxError.message("could not allocate terminal launch arguments")
+        }
+
+        var argv = argumentCopies + [nil]
+        var envp = environmentCopies + [nil]
+        var master: Int32 = -1
+        var initialSize = winsize(
+            ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0
+        )
+        var spawnedPID: pid_t = -1
+        argv.withUnsafeMutableBufferPointer { argvBuffer in
+            envp.withUnsafeMutableBufferPointer { envBuffer in
+                spawnedPID = forkpty(&master, nil, nil, &initialSize)
+                if spawnedPID == 0 {
+                    guard Darwin.chdir(directoryCopy) == 0 else { _exit(126) }
+                    Darwin.execve(programCopy, argvBuffer.baseAddress, envBuffer.baseAddress)
+                    _exit(127)
+                }
+            }
+        }
+        guard spawnedPID > 0, master >= 0 else {
+            if master >= 0 { Darwin.close(master) }
+            throw KeroMuxError.message(
+                "could not start terminal process: \(String(cString: strerror(errno)))"
+            )
+        }
+        shellPID = spawnedPID
+        masterFD = master
+    }
+
+    deinit {
+        Darwin.close(masterFD)
+    }
+
+    func startReading() {
+        Thread.detachNewThread { [weak self] in
+            self?.readOutput()
+        }
+    }
+
+    func info() -> KeroMuxSessionInfo {
+        lock.lock()
+        defer { lock.unlock() }
+        let foreground = tcgetpgrp(masterFD)
+        return KeroMuxSessionInfo(
+            id: id,
+            backend: backend,
+            shellName: shellName,
+            title: title,
+            workingDirectory: workingDirectory,
+            shellPID: shellPID,
+            foregroundPID: foreground > 0 ? foreground : nil
+        )
+    }
+
+    func attach(_ connection: KeroMuxConnection) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let previous = attached, previous !== connection {
+            var replaced = KeroMuxMessage(type: "replaced")
+            replaced.message = "This terminal session was attached in another window."
+            try? previous.send(replaced)
+            previous.close()
+        }
+        var message = KeroMuxMessage(type: "attached")
+        message.session = infoWithoutLock()
+        try connection.send(message)
+        if !replay.isEmpty {
+            var output = KeroMuxMessage(type: "output")
+            output.data = replay
+            try connection.send(output)
+        }
+        attached = connection
+    }
+
+    func detach(_ connection: KeroMuxConnection) {
+        lock.lock()
+        if attached === connection {
+            attached = nil
+        }
+        lock.unlock()
+    }
+
+    func writeInput(_ data: Data) {
+        data.withUnsafeBytes { bytes in
+            var offset = 0
+            while offset < bytes.count {
+                let result = Darwin.write(
+                    masterFD,
+                    bytes.baseAddress?.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if result > 0 {
+                    offset += result
+                } else if result < 0, errno == EINTR {
+                    continue
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    func resize(
+        columns: UInt16,
+        rows: UInt16,
+        pixelWidth: UInt16,
+        pixelHeight: UInt16
+    ) {
+        var size = winsize(
+            ws_row: max(1, rows),
+            ws_col: max(1, columns),
+            ws_xpixel: pixelWidth,
+            ws_ypixel: pixelHeight
+        )
+        _ = ioctl(masterFD, TIOCSWINSZ, &size)
+    }
+
+    func checkpoint(_ data: Data) {
+        lock.lock()
+        replay = data.suffix(Self.replayLimit)
+        lock.unlock()
+    }
+
+    func updateMetadata(title: String?, workingDirectory: String?) {
+        lock.lock()
+        if let title, !title.isEmpty { self.title = title }
+        if let workingDirectory, !workingDirectory.isEmpty {
+            self.workingDirectory = workingDirectory
+        }
+        lock.unlock()
+    }
+
+    func terminate() {
+        lock.lock()
+        let alreadyExited = hasExited
+        lock.unlock()
+        guard !alreadyExited else { return }
+        _ = Darwin.kill(-shellPID, SIGHUP)
+        _ = Darwin.kill(shellPID, SIGHUP)
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) {
+            _ = Darwin.kill(-self.shellPID, SIGKILL)
+            _ = Darwin.kill(self.shellPID, SIGKILL)
+        }
+    }
+
+    private func readOutput() {
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = Darwin.read(masterFD, &buffer, buffer.count)
+            if count > 0 {
+                receiveOutput(Data(buffer[..<count]))
+            } else if count < 0, errno == EINTR {
+                continue
+            } else {
+                break
+            }
+        }
+
+        var status: Int32 = 0
+        while waitpid(shellPID, &status, 0) < 0, errno == EINTR {}
+
+        lock.lock()
+        hasExited = true
+        let connection = attached
+        attached = nil
+        lock.unlock()
+        if let connection {
+            try? connection.send(KeroMuxMessage(type: "exited"))
+            connection.close()
+        }
+        onExit?(id)
+    }
+
+    private func receiveOutput(_ data: Data) {
+        lock.lock()
+        replay.append(data)
+        // Trim in batches instead of moving a full 16 MB buffer for every
+        // small PTY read once the cap is reached.
+        if replay.count > Self.replayTrimThreshold {
+            replay.removeFirst(replay.count - Self.replayLimit)
+        }
+        let connection = attached
+        if let connection {
+            var message = KeroMuxMessage(type: "output")
+            message.data = data
+            do {
+                try connection.send(message)
+            } catch {
+                attached = nil
+                connection.close()
+            }
+        }
+        lock.unlock()
+    }
+
+    private func infoWithoutLock() -> KeroMuxSessionInfo {
+        let foreground = tcgetpgrp(masterFD)
+        return KeroMuxSessionInfo(
+            id: id,
+            backend: backend,
+            shellName: shellName,
+            title: title,
+            workingDirectory: workingDirectory,
+            shellPID: shellPID,
+            foregroundPID: foreground > 0 ? foreground : nil
+        )
+    }
+}
+
+enum KeroMuxServer {
+    static func run() throws {
+        // The server owns PTYs beyond the launching app's lifetime. Give it a
+        // separate process session and do not inherit a terminal hangup from
+        // the app-side CLI harness.
+        _ = Darwin.setsid()
+        _ = Darwin.signal(SIGHUP, SIG_IGN)
+        _ = Darwin.signal(SIGPIPE, SIG_IGN)
+        try KeroMuxPaths.prepareDirectory()
+
+        let lockFD = Darwin.open(KeroMuxPaths.lock.path, O_CREAT | O_RDWR, 0o600)
+        guard lockFD >= 0, flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
+            if lockFD >= 0 { Darwin.close(lockFD) }
+            return
+        }
+        defer {
+            _ = flock(lockFD, LOCK_UN)
+            _ = Darwin.close(lockFD)
+        }
+
+        let listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listener >= 0 else {
+            throw KeroMuxError.message("could not create multiplexer socket")
+        }
+        defer { Darwin.close(listener) }
+        _ = Darwin.unlink(KeroMuxPaths.socket.path)
+        defer { _ = Darwin.unlink(KeroMuxPaths.socket.path) }
+
+        var address = try KeroMuxControl.unixAddress(path: KeroMuxPaths.socket.path)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(
+                    listener,
+                    $0,
+                    KeroMuxControl.unixAddressLength(path: KeroMuxPaths.socket.path)
+                )
+            }
+        }
+        guard bound == 0 else {
+            throw KeroMuxError.message(
+                "could not bind multiplexer socket: \(String(cString: strerror(errno)))"
+            )
+        }
+        _ = Darwin.chmod(KeroMuxPaths.socket.path, 0o600)
+        guard Darwin.listen(listener, 32) == 0 else {
+            throw KeroMuxError.message("could not listen on multiplexer socket")
+        }
+
+        let daemon = KeroMuxDaemon()
+        while true {
+            let fd = Darwin.accept(listener, nil, nil)
+            if fd < 0 {
+                if errno == EINTR { continue }
+                throw KeroMuxError.message("multiplexer accept failed")
+            }
+            var peerUID = uid_t.max
+            var peerGID = gid_t.max
+            guard getpeereid(fd, &peerUID, &peerGID) == 0,
+                  peerUID == getuid()
+            else {
+                Darwin.close(fd)
+                continue
+            }
+            let connection = KeroMuxConnection(fd: fd)
+            Thread.detachNewThread {
+                daemon.handle(connection)
+            }
+        }
+    }
+}
+
+private final class KeroMuxDaemon {
+    private let lock = NSLock()
+    private var sessions: [UUID: KeroMuxServerSession] = [:]
+
+    func handle(_ connection: KeroMuxConnection) {
+        defer { connection.close() }
+        do {
+            guard let request = try connection.receive() else { return }
+            switch request.type {
+            case "create":
+                try create(request, connection: connection)
+            case "attach":
+                try attach(request, connection: connection)
+            case "list":
+                var response = KeroMuxMessage(type: "sessions")
+                response.sessions = allSessions().map { $0.info() }
+                try connection.send(response)
+            case "info":
+                guard let session = session(for: request.sessionID) else {
+                    try sendError("Terminal session is no longer running.", to: connection)
+                    return
+                }
+                var response = KeroMuxMessage(type: "info")
+                response.session = session.info()
+                try connection.send(response)
+            case "checkpoint":
+                guard let session = session(for: request.sessionID),
+                      let data = request.data
+                else {
+                    try sendError("Terminal session is no longer running.", to: connection)
+                    return
+                }
+                session.checkpoint(data)
+                try connection.send(KeroMuxMessage(type: "ok"))
+            case "metadata":
+                guard let session = session(for: request.sessionID) else {
+                    try sendError("Terminal session is no longer running.", to: connection)
+                    return
+                }
+                session.updateMetadata(
+                    title: request.title,
+                    workingDirectory: request.workingDirectory
+                )
+                try connection.send(KeroMuxMessage(type: "ok"))
+            case "terminate":
+                guard let session = session(for: request.sessionID) else {
+                    try sendError("Terminal session is no longer running.", to: connection)
+                    return
+                }
+                session.terminate()
+                try connection.send(KeroMuxMessage(type: "ok"))
+            default:
+                try sendError("Unknown multiplexer request.", to: connection)
+            }
+        } catch {
+            try? sendError(String(describing: error), to: connection)
+        }
+    }
+
+    private func create(
+        _ request: KeroMuxMessage,
+        connection: KeroMuxConnection
+    ) throws {
+        guard let program = request.program,
+              let arguments = request.arguments,
+              let workingDirectory = request.workingDirectory,
+              let environment = request.environment,
+              let backend = request.backend,
+              let shellName = request.shellName
+        else {
+            try sendError("Incomplete terminal launch request.", to: connection)
+            return
+        }
+        let session = try KeroMuxServerSession(
+            program: program,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            backend: backend,
+            shellName: shellName
+        )
+        session.onExit = { [weak self] id in
+            self?.remove(id)
+        }
+        lock.lock()
+        sessions[session.id] = session
+        lock.unlock()
+        session.startReading()
+
+        var response = KeroMuxMessage(type: "created")
+        response.session = session.info()
+        try connection.send(response)
+    }
+
+    private func attach(
+        _ request: KeroMuxMessage,
+        connection: KeroMuxConnection
+    ) throws {
+        guard let session = session(for: request.sessionID) else {
+            try sendError("Terminal session is no longer running.", to: connection)
+            return
+        }
+        try session.attach(connection)
+        defer { session.detach(connection) }
+        while let message = try connection.receive() {
+            switch message.type {
+            case "input":
+                if let data = message.data { session.writeInput(data) }
+            case "resize":
+                session.resize(
+                    columns: message.columns ?? 80,
+                    rows: message.rows ?? 24,
+                    pixelWidth: message.pixelWidth ?? 0,
+                    pixelHeight: message.pixelHeight ?? 0
+                )
+            case "detach":
+                return
+            default:
+                break
+            }
+        }
+    }
+
+    private func session(for id: UUID?) -> KeroMuxServerSession? {
+        guard let id else { return nil }
+        lock.lock()
+        defer { lock.unlock() }
+        return sessions[id]
+    }
+
+    private func allSessions() -> [KeroMuxServerSession] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(sessions.values)
+    }
+
+    private func remove(_ id: UUID) {
+        lock.lock()
+        sessions[id] = nil
+        lock.unlock()
+    }
+
+    private func sendError(
+        _ text: String,
+        to connection: KeroMuxConnection
+    ) throws {
+        var response = KeroMuxMessage(type: "error")
+        response.message = text
+        try connection.send(response)
+    }
+}

--- a/kero/KeroMux.swift
+++ b/kero/KeroMux.swift
@@ -390,12 +390,33 @@ enum KeroMuxControl {
         qos: .utility
     )
 
-    static func list() -> [KeroMuxSessionInfo] {
+    enum ListOutcome {
+        case sessions([KeroMuxSessionInfo])
+        /// No daemon exists — the ordinary state, with nothing to track.
+        case notRunning
+        /// A daemon exists but did not answer. Callers responsible for
+        /// accounting (launch-time recovery) must treat this as "unknown"
+        /// and try again, never as "empty": conflating the two is how live
+        /// sessions would silently fall off the books.
+        case unreachable
+    }
+
+    static func listOutcome() -> ListOutcome {
         let message = KeroMuxMessage(type: "list")
-        guard let response = try? request(message, startServer: false),
-              response.type == "sessions"
-        else { return [] }
-        return response.sessions ?? []
+        do {
+            let response = try request(message, startServer: false)
+            guard response.type == "sessions" else { return .unreachable }
+            return .sessions(response.sessions ?? [])
+        } catch KeroMuxError.message(let text) where text == notRunningMessage {
+            return .notRunning
+        } catch {
+            return .unreachable
+        }
+    }
+
+    static func list() -> [KeroMuxSessionInfo] {
+        guard case .sessions(let sessions) = listOutcome() else { return [] }
+        return sessions
     }
 
     static func checkpoint(_ data: Data, sessionID: UUID) {
@@ -417,10 +438,30 @@ enum KeroMuxControl {
         _ = try? request(message, startServer: false)
     }
 
+    /// Fire-and-forget with bounded retries. This runs off the caller's
+    /// thread — pane close must not stall on a slow daemon — but a close is
+    /// also a promise that the process is going away, so a request lost to a
+    /// momentary stall is retried rather than dropped. If every attempt
+    /// fails, the session is not lost: its ID leaves the saved layout when
+    /// the pane does, so the next launch surfaces it under Recovered
+    /// Sessions instead of leaking it silently.
     static func terminate(_ id: UUID) {
+        requestQueue.async { terminate(id, attemptsRemaining: 3) }
+    }
+
+    private static func terminate(_ id: UUID, attemptsRemaining: Int) {
         var message = KeroMuxMessage(type: "terminate")
         message.sessionID = id
-        _ = try? request(message, startServer: false)
+        do {
+            _ = try request(message, startServer: false)
+        } catch KeroMuxError.message(let text) where text == notRunningMessage {
+            // No daemon means no session to stop.
+        } catch {
+            guard attemptsRemaining > 1 else { return }
+            requestQueue.asyncAfter(deadline: .now() + 2) {
+                terminate(id, attemptsRemaining: attemptsRemaining - 1)
+            }
+        }
     }
 
     enum StopOutcome {
@@ -1299,9 +1340,18 @@ private final class KeroMuxDaemon {
             .asyncAfter(deadline: .now() + Self.idleShutdownDelay) { [weak self] in
                 guard let self else { return }
                 self.lock.lock()
-                let stillIdle = self.sessions.isEmpty
-                self.lock.unlock()
-                guard stillIdle else { return }
+                // Exit while still holding the lock. `create` inserts under
+                // the same lock, so a request racing this check either lands
+                // before it (not idle, no exit) or blocks here and dies with
+                // the process — its client sees the connection drop and falls
+                // back to a local PTY. Checking, unlocking, and then exiting
+                // would let that create be told "created" by a daemon that is
+                // about to disappear, leaving the app tracking a session that
+                // no longer exists.
+                guard self.sessions.isEmpty else {
+                    self.lock.unlock()
+                    return
+                }
                 KeroMuxServer.exitNow()
             }
     }

--- a/kero/KeroMux.swift
+++ b/kero/KeroMux.swift
@@ -18,8 +18,19 @@ struct KeroMuxSessionInfo: Codable, Sendable {
     let foregroundPID: pid_t?
 }
 
+enum KeroMuxProtocol {
+    /// Bump only when a change would make an older peer misread a frame.
+    /// The app can be replaced underneath a running daemon — Sparkle swaps
+    /// the bundle in place, and the daemon goes on running the code it was
+    /// launched from — so both sides stamp every frame and refuse a peer
+    /// they cannot speak to, rather than misinterpreting its fields.
+    static let version = 1
+}
+
 private struct KeroMuxMessage: Codable {
     var type: String
+    /// Absent on frames from a build that predates versioning.
+    var protocolVersion: Int?
     var sessionID: UUID?
     var program: String?
     var arguments: [String]?
@@ -71,8 +82,17 @@ private enum KeroMuxPaths {
         directory.appendingPathComponent("mux.sock")
     }
 
-    static var lock: URL {
-        directory.appendingPathComponent("mux.lock")
+    /// Held briefly by whichever client is spawning the daemon, so several
+    /// windows opening at once start exactly one.
+    static var startupLock: URL {
+        directory.appendingPathComponent("startup.lock")
+    }
+
+    /// Held by the daemon for its whole life. Deliberately a different file
+    /// from ``startupLock``: the daemon takes this the moment it starts, which
+    /// is while the spawning client still holds the startup lock.
+    static var daemonLock: URL {
+        directory.appendingPathComponent("daemon.lock")
     }
 
     static var executable: URL {
@@ -94,10 +114,42 @@ private enum KeroMuxPaths {
     }
 }
 
+private enum KeroMuxLock {
+    /// `O_CLOEXEC` is the whole point of this helper. A lock descriptor that
+    /// survives `exec` is inherited by the daemon and then by every shell it
+    /// spawns, and an `flock` belongs to the open file description, so one
+    /// durable shell outliving the app would hold the lock for its own
+    /// lifetime and wedge every later launch.
+    static func open(_ url: URL) throws -> Int32 {
+        let fd = Darwin.open(url.path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard fd >= 0 else {
+            throw KeroMuxError.message(
+                "could not open \(url.lastPathComponent): "
+                    + String(cString: strerror(errno))
+            )
+        }
+        return fd
+    }
+
+    /// Polls instead of blocking in `flock(LOCK_EX)` so a caller can never
+    /// wait longer than it asked to.
+    static func acquire(_ fd: Int32, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if flock(fd, LOCK_EX | LOCK_NB) == 0 { return true }
+            if errno != EWOULDBLOCK { return false }
+            usleep(20_000)
+        } while Date() < deadline
+        return false
+    }
+}
+
 private enum KeroMuxWire {
     static let maximumFrameSize = 32 * 1024 * 1024
 
     static func send(_ message: KeroMuxMessage, to fd: Int32) throws {
+        var message = message
+        message.protocolVersion = KeroMuxProtocol.version
         let payload = try JSONEncoder().encode(message)
         guard payload.count <= maximumFrameSize else {
             throw KeroMuxError.message("multiplexer message is too large")
@@ -192,6 +244,33 @@ private final class KeroMuxConnection {
         )
     }
 
+    /// Bounds writes on this connection. A peer that stops draining its
+    /// socket must not be able to block the writer forever: on the daemon
+    /// side that writer is the PTY reader thread, so an undrained client
+    /// would otherwise stall the shell itself.
+    func setSendTimeout(_ seconds: TimeInterval) {
+        setTimeout(seconds, option: SO_SNDTIMEO)
+    }
+
+    /// Only for one-shot request/response exchanges. An attach connection
+    /// blocks on `receive` by design while it waits for the next keystroke,
+    /// so it must never carry a receive timeout.
+    func setReceiveTimeout(_ seconds: TimeInterval) {
+        setTimeout(seconds, option: SO_RCVTIMEO)
+    }
+
+    private func setTimeout(_ seconds: TimeInterval, option: Int32) {
+        let whole = seconds.rounded(.down)
+        var timeout = timeval(
+            tv_sec: Int(whole),
+            tv_usec: Int32((seconds - whole) * 1_000_000)
+        )
+        _ = setsockopt(
+            fd, SOL_SOCKET, option, &timeout,
+            socklen_t(MemoryLayout<timeval>.size)
+        )
+    }
+
     deinit {
         close()
     }
@@ -248,6 +327,35 @@ enum KeroMuxControl {
         return response.session
     }
 
+    /// Off-main variants. `TerminalSession` is `@MainActor` and some of its
+    /// properties are read while SwiftUI evaluates a body, so nothing on that
+    /// path may perform a socket round trip.
+    static func info(
+        _ id: UUID,
+        completion: @escaping @Sendable (KeroMuxSessionInfo?) -> Void
+    ) {
+        requestQueue.async { completion(info(id)) }
+    }
+
+    static func updateMetadataAsync(
+        sessionID: UUID,
+        title: String? = nil,
+        workingDirectory: String? = nil
+    ) {
+        requestQueue.async {
+            updateMetadata(
+                sessionID: sessionID,
+                title: title,
+                workingDirectory: workingDirectory
+            )
+        }
+    }
+
+    private static let requestQueue = DispatchQueue(
+        label: "sh.kero.mux.control",
+        qos: .utility
+    )
+
     static func list() -> [KeroMuxSessionInfo] {
         let message = KeroMuxMessage(type: "list")
         guard let response = try? request(message, startServer: false),
@@ -281,6 +389,28 @@ enum KeroMuxControl {
         _ = try? request(message, startServer: false)
     }
 
+    enum StopOutcome {
+        case notRunning
+        case stopped(Int)
+        case failed(String)
+    }
+
+    static func stop() -> StopOutcome {
+        let message = KeroMuxMessage(type: "shutdown")
+        do {
+            let response = try request(message, startServer: false)
+            guard response.type == "stopped" else {
+                return .failed(response.message ?? "The multiplexer refused to stop.")
+            }
+            return .stopped(response.sessions?.count ?? 0)
+        } catch KeroMuxError.message(let text)
+            where text == Self.notRunningMessage {
+            return .notRunning
+        } catch {
+            return .failed(String(describing: error))
+        }
+    }
+
     static func attachmentLaunch(
         sessionID: UUID,
         workingDirectory: String,
@@ -300,15 +430,40 @@ enum KeroMuxControl {
         )
     }
 
+    /// Control requests are one-shot: connect, send, read one reply. They are
+    /// bounded so that a wedged daemon degrades to a failed request instead of
+    /// blocking the caller — app teardown issues the final checkpoint through
+    /// here and must still be able to quit.
+    private static let requestTimeout: TimeInterval = 2
+
+    /// Distinguishes "no daemon" from a real failure, so callers can treat a
+    /// missing multiplexer as the ordinary state it usually is.
+    fileprivate static let notRunningMessage = "multiplexer is not running"
+
     private static func request(
         _ message: KeroMuxMessage,
         startServer: Bool
     ) throws -> KeroMuxMessage {
         let fd = try connect(startServer: startServer)
         let connection = KeroMuxConnection(fd: fd)
+        connection.setSendTimeout(requestTimeout)
+        connection.setReceiveTimeout(requestTimeout)
         try connection.send(message)
         guard let response = try connection.receive() else {
             throw KeroMuxError.message("multiplexer closed the connection")
+        }
+        // Either side can be the stale one: a daemon launched from a bundle
+        // Sparkle has since replaced answers with its own version, and a
+        // daemon predating versioning answers with none at all.
+        guard response.protocolVersion == KeroMuxProtocol.version,
+              response.type != "versionMismatch"
+        else {
+            throw KeroMuxError.message(
+                response.message ?? """
+                    The running terminal multiplexer speaks a different \
+                    protocol than this copy of Kero.
+                    """
+            )
         }
         return response
     }
@@ -317,32 +472,21 @@ enum KeroMuxControl {
         try KeroMuxPaths.prepareDirectory()
         if let fd = tryConnect() { return fd }
         guard startServer else {
-            throw KeroMuxError.message("multiplexer is not running")
+            throw KeroMuxError.message(notRunningMessage)
         }
 
-        let lockFD = Darwin.open(KeroMuxPaths.lock.path, O_CREAT | O_RDWR, 0o600)
-        guard lockFD >= 0 else {
-            throw KeroMuxError.message("could not open the multiplexer lock")
-        }
+        let lockFD = try KeroMuxLock.open(KeroMuxPaths.startupLock)
         defer { Darwin.close(lockFD) }
-        guard flock(lockFD, LOCK_EX) == 0 else {
+        guard KeroMuxLock.acquire(lockFD, timeout: startupLockTimeout) else {
             throw KeroMuxError.message("could not lock multiplexer startup")
         }
+        defer { _ = flock(lockFD, LOCK_UN) }
 
-        if let fd = tryConnect() {
-            _ = flock(lockFD, LOCK_UN)
-            return fd
-        }
+        // Another client may have won the race and started the daemon while
+        // this one waited for the lock.
+        if let fd = tryConnect() { return fd }
         _ = Darwin.unlink(KeroMuxPaths.socket.path)
-        do {
-            try startDaemon()
-        } catch {
-            _ = flock(lockFD, LOCK_UN)
-            throw error
-        }
-        // The daemon holds this lock for its lifetime. Release the startup
-        // claim before polling so the freshly spawned process can acquire it.
-        _ = flock(lockFD, LOCK_UN)
+        try startDaemon()
 
         for _ in 0..<100 {
             if let fd = tryConnect() { return fd }
@@ -350,6 +494,12 @@ enum KeroMuxControl {
         }
         throw KeroMuxError.message("multiplexer did not start")
     }
+
+    /// The startup lock is only ever held across a spawn, so waiting on it
+    /// should be brief. It is bounded anyway because `connect` runs on the
+    /// main thread when a pane is created, and no lock-holder bug may be
+    /// allowed to turn into an unkillable app hang.
+    private static let startupLockTimeout: TimeInterval = 3
 
     private static func tryConnect() -> Int32? {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -607,6 +757,19 @@ private final class KeroMuxServerSession {
             envp.withUnsafeMutableBufferPointer { envBuffer in
                 spawnedPID = forkpty(&master, nil, nil, &initialSize)
                 if spawnedPID == 0 {
+                    // Only async-signal-safe calls are legal between fork and
+                    // exec. `forkpty` has already wired the PTY onto the
+                    // standard descriptors; everything above them belongs to
+                    // the daemon — the listening socket, live client
+                    // connections, other sessions' PTY masters — and would
+                    // otherwise be inherited by the user's shell and by every
+                    // process it spawns.
+                    var fd = Int32(3)
+                    let limit = min(Int32(getdtablesize()), 4096)
+                    while fd < limit {
+                        _ = Darwin.close(fd)
+                        fd += 1
+                    }
                     guard Darwin.chdir(directoryCopy) == 0 else { _exit(126) }
                     Darwin.execve(programCopy, argvBuffer.baseAddress, envBuffer.baseAddress)
                     _exit(127)
@@ -660,6 +823,9 @@ private final class KeroMuxServerSession {
         var message = KeroMuxMessage(type: "attached")
         message.session = infoWithoutLock()
         try connection.send(message)
+        // Unlike the streaming path this writes under the lock on purpose:
+        // it keeps live output from interleaving ahead of the replay it is
+        // supposed to follow. The send timeout bounds how long that costs.
         if !replay.isEmpty {
             var output = KeroMuxMessage(type: "output")
             output.data = replay
@@ -776,17 +942,24 @@ private final class KeroMuxServerSession {
             replay.removeFirst(replay.count - Self.replayLimit)
         }
         let connection = attached
-        if let connection {
-            var message = KeroMuxMessage(type: "output")
-            message.data = data
-            do {
-                try connection.send(message)
-            } catch {
-                attached = nil
-                connection.close()
-            }
-        }
         lock.unlock()
+
+        // Deliberately outside the lock. This runs on the PTY reader thread,
+        // so holding the lock across a socket write would let a client that
+        // stopped draining block both the shell's output and every control
+        // request for this session.
+        guard let connection else { return }
+        var message = KeroMuxMessage(type: "output")
+        message.data = data
+        do {
+            try connection.send(message)
+        } catch {
+            // The write timed out or the peer went away. Drop the client
+            // rather than wait for it: the replay buffer already holds
+            // everything it missed, so reattaching recovers the screen.
+            detach(connection)
+            connection.close()
+        }
     }
 
     private func infoWithoutLock() -> KeroMuxSessionInfo {
@@ -804,6 +977,17 @@ private final class KeroMuxServerSession {
 }
 
 enum KeroMuxServer {
+    /// How long a single write to an attached client may block the PTY
+    /// reader thread before that client is treated as gone.
+    static let clientWriteTimeout: TimeInterval = 5
+
+    /// Leaves no socket behind for the next daemon to trip over. `run`'s
+    /// cleanup is a `defer`, which `exit` would skip.
+    static func exitNow() -> Never {
+        _ = Darwin.unlink(KeroMuxPaths.socket.path)
+        exit(0)
+    }
+
     static func run() throws {
         // The server owns PTYs beyond the launching app's lifetime. Give it a
         // separate process session and do not inherit a terminal hangup from
@@ -813,9 +997,11 @@ enum KeroMuxServer {
         _ = Darwin.signal(SIGPIPE, SIG_IGN)
         try KeroMuxPaths.prepareDirectory()
 
-        let lockFD = Darwin.open(KeroMuxPaths.lock.path, O_CREAT | O_RDWR, 0o600)
-        guard lockFD >= 0, flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
-            if lockFD >= 0 { Darwin.close(lockFD) }
+        // Taken immediately and held for this process's life. Losing it means
+        // another daemon is already serving, so this one is redundant.
+        let lockFD = try KeroMuxLock.open(KeroMuxPaths.daemonLock)
+        guard flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
+            Darwin.close(lockFD)
             return
         }
         defer {
@@ -867,6 +1053,10 @@ enum KeroMuxServer {
                 continue
             }
             let connection = KeroMuxConnection(fd: fd)
+            // Writes are bounded so no client can pin a daemon thread, but
+            // reads are not: an attached client blocks here between
+            // keystrokes for as long as its pane is open.
+            connection.setSendTimeout(Self.clientWriteTimeout)
             Thread.detachNewThread {
                 daemon.handle(connection)
             }
@@ -878,10 +1068,29 @@ private final class KeroMuxDaemon {
     private let lock = NSLock()
     private var sessions: [UUID: KeroMuxServerSession] = [:]
 
+    init() {
+        // A daemon spawned for a create that then failed would otherwise
+        // linger with nothing to own.
+        scheduleIdleShutdown()
+    }
+
     func handle(_ connection: KeroMuxConnection) {
         defer { connection.close() }
         do {
             guard let request = try connection.receive() else { return }
+            // A peer speaking a different dialect is refused before any of
+            // its fields are trusted. The reply still carries this daemon's
+            // version, so the caller can say which side is stale.
+            guard request.protocolVersion == KeroMuxProtocol.version else {
+                var response = KeroMuxMessage(type: "versionMismatch")
+                response.message = """
+                    This terminal multiplexer is running an older version of \
+                    Kero. Quit Kero and run `kero +mux-stop` once no durable \
+                    terminals are needed, or restart your Mac.
+                    """
+                try connection.send(response)
+                return
+            }
             switch request.type {
             case "create":
                 try create(request, connection: connection)
@@ -925,6 +1134,14 @@ private final class KeroMuxDaemon {
                 }
                 session.terminate()
                 try connection.send(KeroMuxMessage(type: "ok"))
+            case "shutdown":
+                let running = allSessions()
+                var response = KeroMuxMessage(type: "stopped")
+                response.sessions = running.map { $0.info() }
+                try? connection.send(response)
+                running.forEach { $0.terminate() }
+                // Reply first: the caller is waiting, and this never returns.
+                KeroMuxServer.exitNow()
             default:
                 try sendError("Unknown multiplexer request.", to: connection)
             }
@@ -1013,8 +1230,28 @@ private final class KeroMuxDaemon {
     private func remove(_ id: UUID) {
         lock.lock()
         sessions[id] = nil
+        let isIdle = sessions.isEmpty
         lock.unlock()
+        guard isIdle else { return }
+        scheduleIdleShutdown()
     }
+
+    /// Nothing else stops this process, so an idle daemon would linger for the
+    /// rest of the login session. The delay keeps closing the last durable
+    /// pane and opening another from paying for a fresh daemon launch.
+    private func scheduleIdleShutdown() {
+        DispatchQueue.global(qos: .utility)
+            .asyncAfter(deadline: .now() + Self.idleShutdownDelay) { [weak self] in
+                guard let self else { return }
+                self.lock.lock()
+                let stillIdle = self.sessions.isEmpty
+                self.lock.unlock()
+                guard stillIdle else { return }
+                KeroMuxServer.exitNow()
+            }
+    }
+
+    private static let idleShutdownDelay: TimeInterval = 60
 
     private func sendError(
         _ text: String,

--- a/kero/KeroMux.swift
+++ b/kero/KeroMux.swift
@@ -114,6 +114,40 @@ private enum KeroMuxPaths {
     }
 }
 
+/// Turns a signal into something `poll` can wait on. The write end is
+/// non-blocking so a burst of signals can never stall the handler.
+private final class SelfPipe {
+    let readEnd: Int32
+    let writeEnd: Int32
+
+    init() throws {
+        var fds: [Int32] = [-1, -1]
+        guard pipe(&fds) == 0 else {
+            throw KeroMuxError.message(
+                "could not create the resize pipe: " + String(cString: strerror(errno))
+            )
+        }
+        readEnd = fds[0]
+        writeEnd = fds[1]
+        for fd in fds {
+            _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK)
+            _ = fcntl(fd, F_SETFD, FD_CLOEXEC)
+        }
+    }
+
+    /// Collapses however many signals arrived into the single check the
+    /// caller is about to make.
+    func drain() {
+        var scratch = [UInt8](repeating: 0, count: 64)
+        while Darwin.read(readEnd, &scratch, scratch.count) > 0 {}
+    }
+
+    func close() {
+        _ = Darwin.close(readEnd)
+        _ = Darwin.close(writeEnd)
+    }
+}
+
 private enum KeroMuxLock {
     /// `O_CLOEXEC` is the whole point of this helper. A lock descriptor that
     /// survives `exec` is inherited by the daemon and then by every shell it
@@ -615,26 +649,41 @@ enum KeroMuxClientProcess {
             force: true
         )
 
+        // One of these runs per durable pane for as long as the pane is open.
+        // Waiting on SIGWINCH through a self-pipe instead of re-reading the
+        // window size on a timer keeps an idle pane at zero wakeups, and makes
+        // a resize take effect immediately rather than up to a tick later.
+        let resizeSignal = try SelfPipe()
+        defer { resizeSignal.close() }
+        Self.resizeSignalPipe = resizeSignal.writeEnd
+        _ = Darwin.signal(SIGWINCH, { _ in
+            var byte: UInt8 = 0
+            _ = Darwin.write(KeroMuxClientProcess.resizeSignalPipe, &byte, 1)
+        })
+
         var descriptors = [
             pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
             pollfd(fd: fd, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: resizeSignal.readEnd, events: Int16(POLLIN), revents: 0),
         ]
         var input = [UInt8](repeating: 0, count: 64 * 1024)
 
         while true {
-            descriptors[0].revents = 0
-            descriptors[1].revents = 0
-            let result = Darwin.poll(&descriptors, nfds_t(descriptors.count), 100)
+            for index in descriptors.indices { descriptors[index].revents = 0 }
+            let result = Darwin.poll(&descriptors, nfds_t(descriptors.count), -1)
             if result < 0 {
                 if errno == EINTR { continue }
                 throw KeroMuxError.message("multiplexer attach poll failed")
             }
 
-            sendSizeIfChanged(
-                connection: connection,
-                previous: &lastSize,
-                force: false
-            )
+            if descriptors[2].revents & Int16(POLLIN) != 0 {
+                resizeSignal.drain()
+                sendSizeIfChanged(
+                    connection: connection,
+                    previous: &lastSize,
+                    force: false
+                )
+            }
 
             if descriptors[0].revents & Int16(POLLIN) != 0 {
                 let count = Darwin.read(STDIN_FILENO, &input, input.count)
@@ -669,6 +718,12 @@ enum KeroMuxClientProcess {
             }
         }
     }
+
+    /// Written to from the `SIGWINCH` handler, which may only call
+    /// async-signal-safe functions. `nonisolated(unsafe)` because a signal
+    /// handler cannot participate in actor isolation; it is assigned once
+    /// before the handler is installed and only ever read from there.
+    nonisolated(unsafe) fileprivate static var resizeSignalPipe: Int32 = -1
 
     private static func sendSizeIfChanged(
         connection: KeroMuxConnection,

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -255,7 +255,9 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         directory: String? = nil,
         restoredHistory: String? = nil,
         commandArguments: [String]? = nil,
-        environmentPath: String? = nil
+        environmentPath: String? = nil,
+        restoredMuxSessionID: UUID? = nil,
+        restoredBackend: TerminalBackend? = nil
     ) -> TerminalSession {
         let session = TerminalSession(
             initialDirectory: directory
@@ -263,7 +265,9 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
                 ?? selectedSession?.currentDirectoryPath,
             restoredHistory: restoredHistory,
             commandArguments: commandArguments,
-            environmentPath: environmentPath
+            environmentPath: environmentPath,
+            restoredMuxSessionID: restoredMuxSessionID,
+            restoredBackend: restoredBackend
         )
         session.onExited = { [weak self] session in
             // Already dead — just drop its pane, no second terminate.
@@ -279,6 +283,26 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         for session in sessions {
             session.terminate()
         }
+    }
+
+    /// Window/app lifecycle closure detaches durable sessions while preserving
+    /// the longstanding stop behavior for ordinary terminals.
+    func closeSessionsForAppLifecycle() {
+        for session in sessions {
+            session.closeForAppLifecycle()
+        }
+    }
+
+    /// Surfaces a daemon session that no saved pane references. This commonly
+    /// follows an app crash between creating a terminal and saving its layout.
+    func recoverMuxSession(_ info: KeroMuxSessionInfo) {
+        let session = makeSession(
+            directory: info.workingDirectory,
+            restoredMuxSessionID: info.id,
+            restoredBackend: TerminalBackend(persisted: info.backend)
+        )
+        let tab = makeTab(content: .session(session))
+        append(tab)
     }
 
     // MARK: - Splits
@@ -746,7 +770,7 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         case .pane(let pane):
             let restoredHistory = pane.historyKey.flatMap { histories[$0] }
             return .pane(Pane(content: makeContent(
-                from: pane.content, restoredHistory: restoredHistory
+                from: pane, restoredHistory: restoredHistory
             )))
         case .split(let axis, let fraction, let first, let second):
             return .split(PaneSplit(
@@ -759,12 +783,19 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
     }
 
     private func makeContent(
-        from snap: SessionSnapshot.ProjectSnapshot.PaneContentSnapshot,
+        from pane: SessionSnapshot.ProjectSnapshot.PaneSnapshot,
         restoredHistory: String? = nil
     ) -> PaneContent {
-        switch snap {
+        switch pane.content {
         case .session(let workingDirectory):
-            return .session(makeSession(directory: workingDirectory, restoredHistory: restoredHistory))
+            return .session(makeSession(
+                directory: workingDirectory,
+                restoredHistory: restoredHistory,
+                restoredMuxSessionID: pane.muxSessionID,
+                restoredBackend: pane.terminalBackend.map {
+                    TerminalBackend(persisted: $0)
+                }
+            ))
         case .file(let path, let editorState):
             let file = FileTab(path: path)
             if let editorState { file.editorState = editorState }

--- a/kero/SessionStore.swift
+++ b/kero/SessionStore.swift
@@ -6,11 +6,10 @@
 import Foundation
 
 /// Snapshot of open projects and tabs, saved so a relaunch restores the
-/// previous layout. Terminal sessions restore as fresh shells started in
-/// their last known working directory — with their previous scrollback
-/// replayed above the prompt when the "Restore session history" setting is on
-/// (see `historyKey` and `TerminalHistoryStore`); file and diff panes reload
-/// from disk.
+/// previous layout. Durable terminal sessions reconnect to their daemon-owned
+/// PTY; ordinary terminals restore as fresh shells started in their last known
+/// working directory, with previous scrollback replayed when "Restore session
+/// history" is on. File and diff panes reload from disk.
 struct SessionSnapshot: Codable {
     struct ProjectSnapshot: Codable {
         /// A single pane's content — the terminal, file, browser, or diff it
@@ -37,7 +36,13 @@ struct SessionSnapshot: Codable {
             /// Key into the sidecar terminal-history store for a session pane;
             /// nil for files, browsers, diffs, or when history restore is off.
             /// Optional so snapshots written before this feature still decode.
-            var historyKey: String?
+            var historyKey: String? = nil
+            /// Live daemon session to reconnect, when this terminal opted into
+            /// durable sessions. Optional keeps older snapshots compatible.
+            var muxSessionID: UUID? = nil
+            /// Renderer fixed when the durable session was created. A later
+            /// Settings change applies only to newly created terminals.
+            var terminalBackend: String? = nil
         }
 
         struct ColumnSnapshot: Codable {

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -206,6 +206,17 @@ struct SettingsView: View {
                     )
                     .labelsHidden()
                 }
+
+                DescribedSettingsRow(
+                    "Keep terminal sessions running when Kero closes",
+                    description: "New terminals continue running locally and reconnect when Kero reopens"
+                ) {
+                    Toggle(
+                        "Keep terminal sessions running when Kero closes",
+                        isOn: $settings.durableTerminalSessions
+                    )
+                    .labelsHidden()
+                }
             }
 
             Section("Text Editing") {
@@ -242,6 +253,7 @@ struct SettingsView: View {
                         && settings.toolbarVisibility == AppSettings.defaultToolbarVisibility
                         && !settings.wrapLines
                         && !settings.restoreTerminalHistory
+                        && !settings.durableTerminalSessions
                         && settings.terminalBackend == .fallback)
                 }
             }

--- a/kero/TerminalHistory.swift
+++ b/kero/TerminalHistory.swift
@@ -35,6 +35,19 @@ enum TerminalHistorySerializer {
         return .captured(normalizedHistory(from: capturedVT, maxLines: maxLines))
     }
 
+    /// Backend-neutral VT checkpoint for a durable session. Unlike relaunch
+    /// history this is not normalized, capped by lines, or decorated: the mux
+    /// will prepend it to output received while Kero is detached, rebuilding
+    /// the exact emulator state on the next attachment.
+    @MainActor
+    static func captureRaw(from surface: any TerminalBackendSurface) -> Data? {
+        guard let captureFile = validatedCaptureFile(for: surface.exportScreenFile()) else {
+            return nil
+        }
+        defer { removeCaptureFile(captureFile) }
+        return try? Data(contentsOf: captureFile.fileURL)
+    }
+
     /// Plain visible rows for the Ctrl-Tab thumbnail. This uses the backend's
     /// screen export instead of AppKit bitmap caching because a framebuffer-
     /// only Metal layer cannot be captured reliably. Only the tail of a large

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -104,17 +104,22 @@ final class TerminalManager: nonisolated ObservableObject {
     /// `historyKey` each restoring session pane carries. Shared across windows
     /// (keys are unique per pane), so restores read from it without consuming.
     private static var pendingHistories: [String: String] = [:]
+    /// Every durable ID referenced by the complete saved window set. Recovery
+    /// must consider all windows before the first manager claims one.
+    private static var savedMuxSessionIDs = Set<UUID>()
     private static var hasLoadedStore = false
     /// Set on app termination so window teardown can't re-save a partial
     /// snapshot over the final full one.
     private static var isQuitting = false
     private static var didReopenWindows = false
+    private static var didRecoverMuxSessions = false
 
     init() {
         if !Self.hasLoadedStore {
             Self.hasLoadedStore = true
             Self.pendingRestores = SessionStore.load()
             Self.pendingHistories = TerminalHistoryStore.load()
+            Self.savedMuxSessionIDs = Self.muxSessionIDs(in: Self.pendingRestores)
         }
         Self.registry.append(self)
         var restored = false
@@ -128,7 +133,8 @@ final class TerminalManager: nonisolated ObservableObject {
             Self.pendingHistories = [:]
         }
         let queuedDirectories = Self.takePendingDirectories()
-        if !restored, queuedDirectories.isEmpty {
+        let recoveredMuxSessions = recoverUnreferencedMuxSessions()
+        if !restored, queuedDirectories.isEmpty, !recoveredMuxSessions {
             startupProjectID = newProject().id
         }
         for directory in queuedDirectories {
@@ -173,6 +179,11 @@ final class TerminalManager: nonisolated ObservableObject {
                 guard !TerminalManager.isQuitting else { return }
                 TerminalManager.isQuitting = true
                 TerminalManager.saveAll(captureTerminalHistory: true)
+                for manager in TerminalManager.registry {
+                    for project in manager.projects {
+                        project.closeSessionsForAppLifecycle()
+                    }
+                }
             }
     }
 
@@ -800,7 +811,7 @@ final class TerminalManager: nonisolated ObservableObject {
             Self.saveAll(captureTerminalHistory: false)
         }
         for project in projects {
-            project.terminateAll()
+            project.closeSessionsForAppLifecycle()
         }
     }
 
@@ -874,8 +885,10 @@ final class TerminalManager: nonisolated ObservableObject {
         typealias ProjectSnapshot = SessionSnapshot.ProjectSnapshot
         switch layout {
         case .pane(let pane):
+            var session: TerminalSession?
+            if case .session(let paneSession) = pane.content { session = paneSession }
             var historyKey: String?
-            if case .session(let session) = pane.content,
+            if let session,
                let history = session.serializedHistory(
                    captureLive: captureTerminalHistory
                ), !history.isEmpty {
@@ -883,10 +896,16 @@ final class TerminalManager: nonisolated ObservableObject {
                 histories[key] = history
                 historyKey = key
             }
+            // The backend is only worth persisting alongside a durable session:
+            // it tells a reconnect which renderer to rebuild if the daemon is
+            // gone. Ordinary panes take the current setting on restore.
+            let muxSessionID = session?.muxSessionID
             return .pane(ProjectSnapshot.PaneSnapshot(
                 content: contentSnapshot(pane.content),
                 weight: 1,
-                historyKey: historyKey
+                historyKey: historyKey,
+                muxSessionID: muxSessionID,
+                terminalBackend: muxSessionID == nil ? nil : session?.backend.rawValue
             ))
         case .split(let split):
             return .split(
@@ -932,6 +951,56 @@ final class TerminalManager: nonisolated ObservableObject {
                 untracked: diff.untracked, origPath: diff.origPath
             )
         }
+    }
+
+    private static func muxSessionIDs(in snapshots: [SessionSnapshot]) -> Set<UUID> {
+        Set(snapshots.flatMap { window in
+            window.projects.flatMap { project in
+                project.tabs.flatMap { tab in
+                    muxSessionIDs(in: tab.layout)
+                }
+            }
+        })
+    }
+
+    private static func muxSessionIDs(
+        in layout: SessionSnapshot.ProjectSnapshot.LayoutSnapshot
+    ) -> [UUID] {
+        switch layout {
+        case .pane(let pane):
+            return pane.muxSessionID.map { [$0] } ?? []
+        case .split(_, _, let first, let second):
+            return muxSessionIDs(in: first) + muxSessionIDs(in: second)
+        }
+    }
+
+    /// A live daemon can outlast an unsaved app process. Put sessions missing
+    /// from the complete saved layout into one ordinary project so they are
+    /// visible and closable instead of becoming hidden background processes.
+    private func recoverUnreferencedMuxSessions() -> Bool {
+        guard !Self.didRecoverMuxSessions else { return false }
+        Self.didRecoverMuxSessions = true
+        // Restoring a legacy snapshot while the setting is enabled can create
+        // fresh durable sessions before recovery runs. They are already owned
+        // by panes even though the old on-disk snapshot has no mux IDs yet.
+        let claimedNow = Set(projects.flatMap { project in
+            project.sessions.compactMap(\.muxSessionID)
+        })
+        let sessions = KeroMuxControl.list()
+            .filter {
+                !Self.savedMuxSessionIDs.contains($0.id)
+                    && !claimedNow.contains($0.id)
+            }
+            .sorted { $0.shellPID < $1.shellPID }
+        guard !sessions.isEmpty else { return false }
+        let project = makeProject(createInitialSession: false)
+        project.customName = String(localized: "Recovered Sessions")
+        for session in sessions {
+            project.recoverMuxSession(session)
+        }
+        projects.append(project)
+        selectedProjectID = project.id
+        return true
     }
 
     /// Rebuilds projects and tabs from a saved window snapshot. Returns

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -980,13 +980,33 @@ final class TerminalManager: nonisolated ObservableObject {
     private func recoverUnreferencedMuxSessions() -> Bool {
         guard !Self.didRecoverMuxSessions else { return false }
         Self.didRecoverMuxSessions = true
-        // Restoring a legacy snapshot while the setting is enabled can create
-        // fresh durable sessions before recovery runs. They are already owned
-        // by panes even though the old on-disk snapshot has no mux IDs yet.
-        let claimedNow = Set(projects.flatMap { project in
-            project.sessions.compactMap(\.muxSessionID)
+        switch KeroMuxControl.listOutcome() {
+        case .notRunning:
+            return false
+        case .sessions(let sessions):
+            return integrateUnreferencedMuxSessions(sessions)
+        case .unreachable:
+            // A daemon exists but did not answer, so what it owns is unknown
+            // — not empty. Giving up here would hide its sessions until the
+            // next launch; keep asking in the background instead.
+            Self.scheduleMuxRecoveryRetry(attemptsRemaining: 5)
+            return false
+        }
+    }
+
+    private func integrateUnreferencedMuxSessions(
+        _ all: [KeroMuxSessionInfo]
+    ) -> Bool {
+        // Sessions already owned by a pane in any window are not orphans.
+        // This covers panes restored from the snapshot, fresh durable panes
+        // created before a delayed recovery ran, and — for legacy snapshots
+        // with no mux IDs — sessions the restore itself just created.
+        let claimedNow = Set(Self.registry.flatMap { manager in
+            manager.projects.flatMap { project in
+                project.sessions.compactMap(\.muxSessionID)
+            }
         })
-        let sessions = KeroMuxControl.list()
+        let sessions = all
             .filter {
                 !Self.savedMuxSessionIDs.contains($0.id)
                     && !claimedNow.contains($0.id)
@@ -1001,6 +1021,30 @@ final class TerminalManager: nonisolated ObservableObject {
         projects.append(project)
         selectedProjectID = project.id
         return true
+    }
+
+    /// Bounded so a daemon that never answers cannot poll forever; the next
+    /// launch's recovery is the backstop for anything still unaccounted.
+    private static func scheduleMuxRecoveryRetry(attemptsRemaining: Int) {
+        guard attemptsRemaining > 0 else { return }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 5) {
+            let outcome = KeroMuxControl.listOutcome()
+            Task { @MainActor in
+                guard !isQuitting else { return }
+                switch outcome {
+                case .notRunning:
+                    break
+                case .unreachable:
+                    scheduleMuxRecoveryRetry(attemptsRemaining: attemptsRemaining - 1)
+                case .sessions(let sessions):
+                    // Integrate into whichever window still exists; with none
+                    // open there is nowhere to show a recovered project, and
+                    // the next launch picks these sessions up instead.
+                    guard let manager = registry.first else { return }
+                    _ = manager.integrateUnreferencedMuxSessions(sessions)
+                }
+            }
+        }
     }
 
     /// Rebuilds projects and tabs from a saved window snapshot. Returns

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -48,6 +48,14 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     private var lastHistorySnapshot: String?
     private var isTerminating = false
     private var commandExecutionStartedAtNanos: UInt64?
+    /// The daemon's shell PID never changes for the life of a session, so it
+    /// is captured once at create or reconnect and never re-queried.
+    private let muxShellPID: pid_t?
+    /// The daemon's foreground PID does change, but reading it costs a socket
+    /// round trip and callers sit on paths that must not block — see
+    /// ``refreshMuxForegroundPID()`` for when this is renewed.
+    private var muxForegroundPID: pid_t?
+    private var isRefreshingMuxForegroundPID = false
 
     init(
         initialDirectory: String? = nil,
@@ -112,6 +120,8 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         self.shellPath = shellPath
         self.backend = backend
         self.muxSessionID = muxSessionID
+        muxShellPID = muxInfo?.shellPID
+        muxForegroundPID = muxInfo?.foregroundPID
         launchWorkingDirectory = directory
         launchDirectoryURL = artifacts.directoryURL
         shellPidFileURL = artifacts.pidFileURL
@@ -281,12 +291,33 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     /// keeps describing the old tree. This is deliberately a separate fact:
     /// `currentDirectoryPath` must stay true to the shell.
     var foregroundDirectoryPath: String? {
-        let foreground = muxSessionID.flatMap { KeroMuxControl.info($0)?.foregroundPID }
-            ?? surface.foregroundPid
-        guard let foreground, foreground > 0,
+        guard let foreground = foregroundPid, foreground > 0,
               foreground != shellPid
         else { return nil }
         return processWorkingDirectory(pid: foreground)
+    }
+
+    /// Foreground job of the terminal, whoever owns the PTY. Reading the
+    /// daemon's copy would mean a socket round trip, and this is read while
+    /// SwiftUI evaluates a body, so durable sessions serve the cached value
+    /// that ``refreshMuxForegroundPID()`` renews on shell-integration events.
+    private var foregroundPid: pid_t? {
+        muxSessionID == nil ? surface.foregroundPid : muxForegroundPID
+    }
+
+    /// The daemon's foreground process changes when a command starts or ends,
+    /// which is exactly what shell integration reports, so this is renewed
+    /// from those events rather than polled.
+    private func refreshMuxForegroundPID() {
+        guard let muxSessionID, !isRefreshingMuxForegroundPID else { return }
+        isRefreshingMuxForegroundPID = true
+        KeroMuxControl.info(muxSessionID) { [weak self] info in
+            Task { @MainActor in
+                guard let self else { return }
+                self.isRefreshingMuxForegroundPID = false
+                self.muxForegroundPID = info?.foregroundPID
+            }
+        }
     }
 
     func sendCommand(_ text: String) {
@@ -306,11 +337,8 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         guard AppSettings.shared.restoreTerminalHistory else { return nil }
         guard captureLive else { return lastHistorySnapshot }
 
-        let foregroundPID = muxSessionID.flatMap {
-            KeroMuxControl.info($0)?.foregroundPID
-        } ?? surface.foregroundPid
         let rootShellIsForeground = shellPid != nil
-            && foregroundPID == shellPid
+            && foregroundPid == shellPid
         if !rootShellIsForeground,
            !TerminalHistorySerializer.hasPrimaryScrollback(surface) {
             // A primary screen with no rows above the viewport and an
@@ -338,9 +366,7 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     /// before `exec`, so this remains stable while a shell's foreground PID
     /// moves to child jobs and back.
     var shellPid: pid_t? {
-        if let muxSessionID {
-            return KeroMuxControl.info(muxSessionID)?.shellPID
-        }
+        if muxSessionID != nil { return muxShellPID }
         if let cachedShellPid, cachedShellPid > 0 { return cachedShellPid }
         guard !hasExited, let shellPidFileURL,
               let text = try? String(contentsOf: shellPidFileURL, encoding: .utf8),
@@ -496,7 +522,7 @@ extension TerminalSession: TerminalBackendEvents {
         guard !title.isEmpty else { return }
         self.title = title
         if let muxSessionID {
-            KeroMuxControl.updateMetadata(sessionID: muxSessionID, title: title)
+            KeroMuxControl.updateMetadataAsync(sessionID: muxSessionID, title: title)
         }
     }
 
@@ -505,7 +531,7 @@ extension TerminalSession: TerminalBackendEvents {
         workingDirectory = path.hasPrefix("/")
             ? URL(fileURLWithPath: path).absoluteString : path
         if let muxSessionID {
-            KeroMuxControl.updateMetadata(
+            KeroMuxControl.updateMetadataAsync(
                 sessionID: muxSessionID,
                 workingDirectory: path
             )
@@ -552,6 +578,9 @@ extension TerminalSession: TerminalBackendEvents {
             commandExecutionStartedAtNanos = nil
         }
         commandLifecycle = lifecycle
+        // A command starting or ending is precisely when the daemon's
+        // foreground process group moves.
+        refreshMuxForegroundPID()
     }
 
     func terminalDidClose(processAlive: Bool) {

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -29,6 +29,9 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     /// The emulator driving this session. Fixed for the session's lifetime —
     /// changing the setting only affects terminals opened afterwards.
     let backend: TerminalBackend
+    /// Daemon-owned PTY this pane attaches to. Nil for the traditional
+    /// renderer-owned process lifecycle.
+    let muxSessionID: UUID?
     let surface: any TerminalBackendSurface
     let overlayScrollbar = OverlayScrollbarView()
     /// Find-in-terminal state for this session's pane (⌘F).
@@ -50,13 +53,23 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         initialDirectory: String? = nil,
         restoredHistory: String? = nil,
         commandArguments: [String]? = nil,
-        environmentPath: String? = nil
+        environmentPath: String? = nil,
+        restoredMuxSessionID: UUID? = nil,
+        restoredBackend: TerminalBackend? = nil
     ) {
         let directCommand = commandArguments.flatMap { $0.isEmpty ? nil : $0 }
         let shellPath = directCommand?.first ?? Self.loginShell()
         let directory = Self.validWorkingDirectory(initialDirectory)
         let artifacts = Self.makeLaunchArtifacts(restoredHistory: restoredHistory)
-        let backend = AppSettings.shared.terminalBackend
+        let restoredMuxInfo = restoredMuxSessionID.flatMap {
+            KeroMuxControl.info($0)
+        }
+        // The daemon's renderer is authoritative for a live session. The
+        // snapshot copy remains useful if the daemon disappeared and this pane
+        // falls back to starting a replacement terminal.
+        let backend = restoredMuxInfo.map {
+            TerminalBackend(persisted: $0.backend)
+        } ?? restoredBackend ?? AppSettings.shared.terminalBackend
         let script = Self.makeLaunchScript(
             backend: backend,
             shellPath: shellPath,
@@ -72,14 +85,40 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
             environment: Self.surfaceEnvironment(pathOverride: environmentPath)
         )
 
+        var muxInfo = restoredMuxInfo
+        if muxInfo == nil, AppSettings.shared.durableTerminalSessions {
+            do {
+                muxInfo = try KeroMuxControl.create(
+                    launch: launch,
+                    backend: backend,
+                    shellName: (shellPath as NSString).lastPathComponent
+                )
+            } catch {
+                NSLog("kero: durable session unavailable, using a local PTY: \(error)")
+            }
+        }
+        let muxSessionID = muxInfo?.id
+        let surfaceLaunch: TerminalLaunch
+        if let muxSessionID {
+            surfaceLaunch = KeroMuxControl.attachmentLaunch(
+                sessionID: muxSessionID,
+                workingDirectory: directory,
+                environment: launch.environment
+            )
+        } else {
+            surfaceLaunch = launch
+        }
+
         self.shellPath = shellPath
         self.backend = backend
+        self.muxSessionID = muxSessionID
         launchWorkingDirectory = directory
         launchDirectoryURL = artifacts.directoryURL
         shellPidFileURL = artifacts.pidFileURL
-        title = (shellPath as NSString).lastPathComponent
+        title = muxInfo?.title ?? (shellPath as NSString).lastPathComponent
+        workingDirectory = muxInfo?.workingDirectory
 
-        let surface = Self.makeSurface(backend: backend, launch: launch)
+        let surface = Self.makeSurface(backend: backend, launch: surfaceLaunch)
         self.surface = surface
         find = TerminalFind(surface: surface)
         lastHistorySnapshot = restoredHistory
@@ -126,7 +165,35 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     func terminate() {
         guard !hasExited, !isTerminating else { return }
         isTerminating = true
+        if let muxSessionID {
+            KeroMuxControl.terminate(muxSessionID)
+            beginTeardown(processAlive: false, notifyExit: false)
+            return
+        }
         beginTeardown(processAlive: true, notifyExit: false)
+    }
+
+    /// A window close or app quit is a detach for daemon-owned terminals and
+    /// the traditional close for renderer-owned terminals. Capturing before
+    /// releasing the renderer gives reconnect a compact, exact VT baseline.
+    func closeForAppLifecycle() {
+        guard !hasExited, !isTerminating else { return }
+        guard let muxSessionID else {
+            terminate()
+            return
+        }
+        isTerminating = true
+        if let checkpoint = TerminalHistorySerializer.captureRaw(from: surface) {
+            KeroMuxControl.checkpoint(checkpoint, sessionID: muxSessionID)
+        }
+        surface.setSurfaceVisible(false)
+        surface.onBecomeFirstResponder = nil
+        surface.splitTarget.onSplit = nil
+        surface.splitTarget.onNewBrowserTab = nil
+        surface.splitTarget.onNewBrowserPane = nil
+        surface.detach()
+        hasExited = true
+        removeLaunchArtifacts()
     }
 
     /// Keeps the session and surface alive until the child has either exited
@@ -214,7 +281,9 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     /// keeps describing the old tree. This is deliberately a separate fact:
     /// `currentDirectoryPath` must stay true to the shell.
     var foregroundDirectoryPath: String? {
-        guard let foreground = surface.foregroundPid, foreground > 0,
+        let foreground = muxSessionID.flatMap { KeroMuxControl.info($0)?.foregroundPID }
+            ?? surface.foregroundPid
+        guard let foreground, foreground > 0,
               foreground != shellPid
         else { return nil }
         return processWorkingDirectory(pid: foreground)
@@ -237,8 +306,11 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         guard AppSettings.shared.restoreTerminalHistory else { return nil }
         guard captureLive else { return lastHistorySnapshot }
 
+        let foregroundPID = muxSessionID.flatMap {
+            KeroMuxControl.info($0)?.foregroundPID
+        } ?? surface.foregroundPid
         let rootShellIsForeground = shellPid != nil
-            && surface.foregroundPid == shellPid
+            && foregroundPID == shellPid
         if !rootShellIsForeground,
            !TerminalHistorySerializer.hasPrimaryScrollback(surface) {
             // A primary screen with no rows above the viewport and an
@@ -266,6 +338,9 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     /// before `exec`, so this remains stable while a shell's foreground PID
     /// moves to child jobs and back.
     var shellPid: pid_t? {
+        if let muxSessionID {
+            return KeroMuxControl.info(muxSessionID)?.shellPID
+        }
         if let cachedShellPid, cachedShellPid > 0 { return cachedShellPid }
         guard !hasExited, let shellPidFileURL,
               let text = try? String(contentsOf: shellPidFileURL, encoding: .utf8),
@@ -420,12 +495,21 @@ extension TerminalSession: TerminalBackendEvents {
     func terminalDidChangeTitle(_ title: String) {
         guard !title.isEmpty else { return }
         self.title = title
+        if let muxSessionID {
+            KeroMuxControl.updateMetadata(sessionID: muxSessionID, title: title)
+        }
     }
 
     func terminalDidChangeWorkingDirectory(_ path: String) {
         guard !path.isEmpty else { return }
         workingDirectory = path.hasPrefix("/")
             ? URL(fileURLWithPath: path).absoluteString : path
+        if let muxSessionID {
+            KeroMuxControl.updateMetadata(
+                sessionID: muxSessionID,
+                workingDirectory: path
+            )
+        }
     }
 
     func terminalDidChangeCellSize(_ size: CGSize) {


### PR DESCRIPTION
## Summary

This continues and finishes #82. The first commit is #82's commit with authorship preserved, rebased onto current main (the snapshot format moved from columns/rows to the layout tree in the meantime); the rest hardens it to where leaving sessions running is actually safe.

Everything #82 described still holds: an opt-in local multiplexer whose detached daemon owns only PTY sessions, panes that reconnect to the same live process and replayed output on relaunch, a Recovered Sessions project for live sessions missing from the saved layout, and one byte-for-byte attach client shared by the Ghostty and Alacritty renderers. On top of that:

- Fixed a launch deadlock: the multiplexer lock descriptor leaked into every durable shell (no `O_CLOEXEC`, `flock` held across the daemon spawn, inherited through `forkpty`), so a single shell outliving the app wedged every later launch inside `flock` on the main thread with no recovery except killing the shell by hand. The forked child now also closes every descriptor above stderr, keeping the listener, client connections, and other sessions' PTY masters out of user shells.
- Removed synchronous daemon round trips from the main thread: `shellPid`, `foregroundDirectoryPath`, and history capture were each doing a connect/send/receive during SwiftUI body evaluation. The shell PID is captured once (it is fixed per session) and the foreground PID is cached and refreshed off-main from shell-integration events. All control requests are bounded by timeouts.
- A client that stops draining its socket can no longer stall the PTY reader thread, and with it the shell and every control request for that session; streaming writes happen outside the session lock and drop the client on timeout, with the replay buffer covering whatever it missed.
- Frames carry a protocol version. Sparkle can replace the bundle underneath a running daemon; both sides now refuse a peer they cannot speak to instead of misreading its fields.
- Attach clients wait on SIGWINCH through a self-pipe instead of polling the window size ten times a second, so an idle pane sits at zero wakeups and resizes apply immediately.
- The daemon exits after being empty for a minute, and `kero +mux-list` / `kero +mux-stop` make durable sessions visible and stoppable without a running app.

Session accounting is closed against loss: a session is always either owned by a live pane, referenced by the saved layout (which is written before detach on both window close and quit), or picked up by launch recovery. Recovery distinguishes "no daemon" from "a daemon that did not answer" and retries the latter in the background; the idle shutdown exits under the sessions lock so it cannot race a create into a dying daemon; a terminate that fails despite retries resurfaces the session under Recovered Sessions on the next launch instead of leaking it silently.

## Implementation

Two locks instead of one: clients hold a startup lock only while spawning the daemon, and the daemon holds its own lock for its lifetime, which also removes a race where a freshly spawned daemon could lose its singleton check to the spawning client and exit. Both are `O_CLOEXEC` and acquired with bounded polls rather than blocking waits.

Also includes one build fix independent of the feature: `ContentView`'s body exceeded the type checker's time budget on stable Xcode 26.1.1 (main currently builds only with the beta), so its layers moved into typed sub-views and the six git-sync `onChange` modifiers collapsed into one Equatable key.

The settings toggle extends the SwiftUI `SettingsView`; when Settings migrates to AppKit the toggle moves with it.

## Validation

- built Debug with stable Xcode 26.1.1 → **BUILD SUCCEEDED** (`main` itself currently fails on the stable toolchain; the `ContentView` split below fixes that)
- exercised quit and relaunch: shell PID unchanged, output produced while Kero was closed replayed on reattach (a per-second tick counter ran to 220 across the cycle without resetting)
- SIGKILLed the app, relaunched: the orphaned session appeared under Recovered Sessions and reattached
- verified with `lsof` that a durable shell inherits no descriptors above stderr, that an idle attach client accrues no CPU time, and that the daemon's PTY carries the pane's real size rather than the 80x24 default
- verified explicit pane close terminates the daemon session, `kero +mux-stop` ends every session and the daemon, and both new CLI commands degrade cleanly when no daemon is running

### Re-verified after rebasing onto current main

- `+mux-list` reports the live session; quitting the app leaves the shell process alive (same PID before and after), and relaunching reattaches to that same PID and session UUID
- `lsof` on the durable shell shows only fds 0/1/2 (plus zsh's own 10) — no listener, client, or PTY-master descriptors leak into user shells
- `+mux-stop` cleanly ends the session and the daemon

## Open items

- The VT checkpoint is written on clean detach only; after an app crash the replay is a raw byte tail, so a full-screen TUI can reattach garbled until it repaints.
- No live descriptor handoff between daemons, so an app update still cannot migrate running sessions; version skew fails loudly rather than silently.

