### PR TITLE
Add worktree navigation to the Git panel

### DIFF
--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -12,6 +12,22 @@ import Foundation
 /// source-control operations without blocking the UI.
 @MainActor
 final class GitStatusModel: nonisolated ObservableObject {
+    nonisolated struct Worktree: Identifiable, Equatable, Sendable {
+        var id: String { path }
+        let path: String
+        let headOID: String?
+        let branch: String?
+        let isDetached: Bool
+        let isBare: Bool
+        let lockedReason: String?
+        let prunableReason: String?
+
+        var shortHeadOID: String {
+            guard let headOID else { return "" }
+            return String(headOID.prefix(7))
+        }
+    }
+
     nonisolated struct Entry: Identifiable, Equatable, Sendable {
         var id: String { path }
         /// Relative to the repository root, as porcelain v2 reports it.
@@ -157,6 +173,7 @@ final class GitStatusModel: nonisolated ObservableObject {
     @Published private(set) var mergeEntries: [Entry] = []
     @Published private(set) var stagedEntries: [Entry] = []
     @Published private(set) var changedEntries: [Entry] = []
+    @Published private(set) var worktrees: [Worktree] = []
     @Published private(set) var branches: [String] = []
     @Published private(set) var defaultBranch: String?
     @Published private(set) var remotes: [String] = []
@@ -199,6 +216,11 @@ final class GitStatusModel: nonisolated ObservableObject {
     /// Keeps a mutation globally exclusive even if the terminal changes cwd
     /// while its Git process is still running.
     private var runningOperationID: UUID?
+    /// Watches Git's shared worktree administration directory. Agents often
+    /// add/remove worktrees inside one long-running shell command, so command
+    /// completion alone would not update the navigator until the agent exits.
+    private var worktreeMetadataWatcher: DispatchSourceFileSystemObject?
+    private var worktreeMetadataWatchedPath = ""
     var totalChangeCount: Int {
         mergeEntries.count + stagedEntries.count + changedEntries.count
     }
@@ -221,6 +243,14 @@ final class GitStatusModel: nonisolated ObservableObject {
 
     func isCurrent(_ entry: Entry) -> Bool {
         entry.repositoryRoot.isEmpty || entry.repositoryRoot == repoRoot
+    }
+
+    func isCurrent(_ worktree: Worktree) -> Bool {
+        Self.normalizedPath(worktree.path) == Self.normalizedPath(repoRoot)
+    }
+
+    func worktree(forBranch branch: String) -> Worktree? {
+        worktrees.first { $0.branch == branch }
     }
 
     /// Returns a Git decoration only when `absolutePath` belongs to the
@@ -267,6 +297,7 @@ final class GitStatusModel: nonisolated ObservableObject {
             recentCommitLimit = recentCommitLimitByRoot[root]
                 ?? Self.recentCommitPageSize
             hasResolvedStatus = false
+            stopWorktreeMetadataWatcher()
             clearRepositoryState(preserveIdentity: true)
             if let cachedStatus = cachedStatusByRoot[root] {
                 apply(cachedStatus)
@@ -999,6 +1030,7 @@ final class GitStatusModel: nonisolated ObservableObject {
         mergeEntries = []
         stagedEntries = []
         changedEntries = []
+        worktrees = []
         fileDecorations = [:]
         ignoredPaths = []
         branches = []
@@ -1030,6 +1062,7 @@ final class GitStatusModel: nonisolated ObservableObject {
             } else {
                 preserveFailure = false
             }
+            stopWorktreeMetadataWatcher()
             clearRepositoryState(preserveFailedOperation: preserveFailure)
             return
         case .failed(let message):
@@ -1066,6 +1099,7 @@ final class GitStatusModel: nonisolated ObservableObject {
         topLevel = result.topLevel
         repositoryIdentity = result.topLevel
         if result.loadedDetails {
+            worktrees = result.worktrees
             branches = result.branches
             defaultBranch = result.defaultBranch
             remotes = result.remotes
@@ -1073,6 +1107,9 @@ final class GitStatusModel: nonisolated ObservableObject {
             hasMoreRecentCommits = result.hasMoreRecentCommits
             repositoryOperation = result.repositoryOperation
             stashCount = result.stashCount
+            configureWorktreeMetadataWatcher(
+                commonGitDirectory: result.commonGitDirectory
+            )
         }
 
         let entries = result.entries.map { entry in
@@ -1093,6 +1130,57 @@ final class GitStatusModel: nonisolated ObservableObject {
         }
     }
 
+    private func configureWorktreeMetadataWatcher(commonGitDirectory: String) {
+        guard !commonGitDirectory.isEmpty else {
+            stopWorktreeMetadataWatcher()
+            return
+        }
+        let worktreesDirectory = (commonGitDirectory as NSString)
+            .appendingPathComponent("worktrees")
+        var isDirectory: ObjCBool = false
+        let watchedPath: String
+        if FileManager.default.fileExists(
+            atPath: worktreesDirectory, isDirectory: &isDirectory
+        ), isDirectory.boolValue {
+            watchedPath = worktreesDirectory
+        } else {
+            // Before the first linked worktree exists, watch the common Git
+            // directory so creation of its `worktrees` child is still seen.
+            watchedPath = commonGitDirectory
+        }
+        guard watchedPath != worktreeMetadataWatchedPath else { return }
+        stopWorktreeMetadataWatcher()
+
+        let descriptor = Darwin.open(watchedPath, O_EVTONLY)
+        guard descriptor >= 0 else { return }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .delete, .rename, .attrib, .extend, .link],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            guard let self,
+                  self.worktreeMetadataWatchedPath == watchedPath else { return }
+            let event = self.worktreeMetadataWatcher?.data ?? []
+            if event.contains(.delete) || event.contains(.rename) {
+                self.stopWorktreeMetadataWatcher()
+            }
+            self.refresh()
+        }
+        source.setCancelHandler {
+            Darwin.close(descriptor)
+        }
+        worktreeMetadataWatchedPath = watchedPath
+        worktreeMetadataWatcher = source
+        source.resume()
+    }
+
+    private func stopWorktreeMetadataWatcher() {
+        worktreeMetadataWatcher?.cancel()
+        worktreeMetadataWatcher = nil
+        worktreeMetadataWatchedPath = ""
+    }
+
     nonisolated enum StatusLoadResult: Equatable, Sendable {
         case repository(StatusResult)
         case notRepository
@@ -1109,8 +1197,10 @@ final class GitStatusModel: nonisolated ObservableObject {
         var lineAdditions = 0
         var lineDeletions = 0
         var topLevel = ""
+        var commonGitDirectory = ""
         var entries: [Entry] = []
         var ignoredPaths: Set<String> = []
+        var worktrees: [Worktree] = []
         var branches: [String] = []
         var defaultBranch: String?
         var remotes: [String] = []
@@ -1264,6 +1354,26 @@ final class GitStatusModel: nonisolated ObservableObject {
         var result = parseStatus(status.stdout)
         result.topLevel = resolvedRoot
 
+        let commonGitDirectory = statusGit(
+            ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+            in: resolvedRoot
+        )
+        if commonGitDirectory.status == 0 {
+            result.commonGitDirectory = strippingTrailingLineEnding(
+                commonGitDirectory.stdout
+            )
+        }
+
+        // Worktrees belong to the repository family rather than only this
+        // checkout. `-z` keeps agent-created paths lossless, including spaces
+        // and newlines, while porcelain fields remain forward-compatible.
+        let worktreeList = statusGit(
+            ["worktree", "list", "--porcelain", "-z"], in: resolvedRoot
+        )
+        if worktreeList.status == 0 {
+            result.worktrees = parseWorktrees(worktreeList.stdout)
+        }
+
         let diff = statusGit(
             result.hasHead
                 ? ["diff", "--numstat", "HEAD", "--"]
@@ -1385,6 +1495,10 @@ final class GitStatusModel: nonisolated ObservableObject {
         return value
     }
 
+    private nonisolated static func normalizedPath(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+
     private nonisolated static func gitFailureMessage(
         _ run: (status: Int32, stdout: String, stderr: String), fallback: String
     ) -> String {
@@ -1459,6 +1573,77 @@ final class GitStatusModel: nonisolated ObservableObject {
             }
             index += 1
         }
+        return result
+    }
+
+    /// Parses `git worktree list --porcelain -z`. Records are separated by an
+    /// empty NUL field and each attribute is itself NUL-terminated, so paths
+    /// never need Git's quoting rules. Unknown attributes are ignored.
+    nonisolated static func parseWorktrees(_ output: String) -> [Worktree] {
+        var result: [Worktree] = []
+        var path: String?
+        var headOID: String?
+        var branch: String?
+        var isDetached = false
+        var isBare = false
+        var lockedReason: String?
+        var prunableReason: String?
+
+        func appendCurrent() {
+            guard let path, !path.isEmpty else { return }
+            result.append(Worktree(
+                path: path,
+                headOID: headOID,
+                branch: branch,
+                isDetached: isDetached,
+                isBare: isBare,
+                lockedReason: lockedReason,
+                prunableReason: prunableReason
+            ))
+        }
+
+        func resetCurrent() {
+            path = nil
+            headOID = nil
+            branch = nil
+            isDetached = false
+            isBare = false
+            lockedReason = nil
+            prunableReason = nil
+        }
+
+        for token in output.split(separator: "\0", omittingEmptySubsequences: false) {
+            let record = String(token)
+            if record.isEmpty {
+                appendCurrent()
+                resetCurrent()
+                continue
+            }
+            if record.hasPrefix("worktree ") {
+                path = String(record.dropFirst("worktree ".count))
+            } else if record.hasPrefix("HEAD ") {
+                headOID = String(record.dropFirst("HEAD ".count))
+            } else if record.hasPrefix("branch ") {
+                let ref = String(record.dropFirst("branch ".count))
+                let prefix = "refs/heads/"
+                branch = ref.hasPrefix(prefix) ? String(ref.dropFirst(prefix.count)) : ref
+            } else if record == "detached" {
+                isDetached = true
+            } else if record == "bare" {
+                isBare = true
+            } else if record == "locked" {
+                lockedReason = ""
+            } else if record.hasPrefix("locked ") {
+                lockedReason = String(record.dropFirst("locked ".count))
+            } else if record == "prunable" {
+                prunableReason = ""
+            } else if record.hasPrefix("prunable ") {
+                prunableReason = String(record.dropFirst("prunable ".count))
+            }
+        }
+        // Be tolerant of producers that omit the porcelain block's final
+        // empty field even though Git itself currently emits one.
+        appendCurrent()
         return result
     }
 

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -294,6 +294,12 @@
         }
       }
     },
+    "%lld open" : {
+
+    },
+    "%lld open sessions" : {
+
+    },
     "%lld outgoing commits" : {
       "localizations" : {
         "en" : {
@@ -708,6 +714,9 @@
           }
         }
       }
+    },
+    "Bare repository" : {
+
     },
     "Binary file" : {
       "localizations" : {
@@ -1663,6 +1672,9 @@
         }
       }
     },
+    "Copy Worktree Path" : {
+
+    },
     "Could not enter interactive terminal mode." : {
       "localizations" : {
         "ja" : {
@@ -1939,6 +1951,9 @@
         }
       }
     },
+    "current worktree" : {
+
+    },
     "Dark" : {
       "comment" : "Dark app appearance.",
       "localizations" : {
@@ -2037,6 +2052,9 @@
           }
         }
       }
+    },
+    "Detached at %@" : {
+
     },
     "detached HEAD" : {
       "localizations" : {
@@ -3499,6 +3517,12 @@
         }
       }
     },
+    "locked" : {
+
+    },
+    "locked, %@" : {
+
+    },
     "Lower memory footprint" : {
       "localizations" : {
         "ja" : {
@@ -4425,6 +4449,9 @@
     "Open Link in New Window" : {
 
     },
+    "Open the worktree using this branch" : {
+
+    },
     "Open to the Side" : {
       "localizations" : {
         "ja" : {
@@ -4440,6 +4467,9 @@
           }
         }
       }
+    },
+    "Open Worktree" : {
+
     },
     "Opens changes" : {
       "localizations" : {
@@ -4472,6 +4502,9 @@
           }
         }
       }
+    },
+    "Opens or reveals this worktree as a Kero project" : {
+
     },
     "Paste" : {
       "localizations" : {
@@ -4728,6 +4761,12 @@
           }
         }
       }
+    },
+    "prunable" : {
+
+    },
+    "prunable, %@" : {
+
     },
     "Publish branch" : {
       "localizations" : {
@@ -5488,6 +5527,9 @@
         }
       }
     },
+    "Reveal Worktree in Finder" : {
+
+    },
     "Revert in progress" : {
       "localizations" : {
         "ja" : {
@@ -5844,6 +5886,9 @@
       }
     },
     "Shows files changed in this commit" : {
+
+    },
+    "Shows or hides Git worktrees" : {
 
     },
     "Shows the toolbar in every project" : {
@@ -6682,6 +6727,9 @@
         }
       }
     },
+    "This worktree cannot be opened" : {
+
+    },
     "Toggle Files Panel" : {
       "localizations" : {
         "ja" : {
@@ -7342,6 +7390,12 @@
           }
         }
       }
+    },
+    "WORKTREES" : {
+
+    },
+    "Worktrees, %lld items" : {
+
     },
     "Wrap lines to editor width" : {
       "localizations" : {

--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -72,6 +72,16 @@ struct RightSidebarView: View {
                         GitPanel(
                             model: git,
                             session: manager.selectedSession,
+                            worktreeSessionCounts: manager.sessionCountsByWorktree(git.worktrees),
+                            openWorktree: { worktree in
+                                manager.openOrRevealWorktree(
+                                    at: worktree.path,
+                                    suggestedName: worktree.branch
+                                        ?? (worktree.shortHeadOID.isEmpty
+                                            ? nil
+                                            : "Detached \(worktree.shortHeadOID)")
+                                )
+                            },
                             openFile: { manager.openFile($0) },
                             openToSide: { manager.openFileToSide($0) },
                             openDiff: { entry, staged in
@@ -687,6 +697,8 @@ private struct GitPanel: View {
 
     @ObservedObject var model: GitStatusModel
     let session: TerminalSession?
+    let worktreeSessionCounts: [String: Int]
+    let openWorktree: (GitStatusModel.Worktree) -> Void
     let openFile: (String) -> Void
     let openToSide: (String) -> Void
     let openDiff: (_ entry: GitStatusModel.Entry, _ staged: Bool) -> Void
@@ -703,6 +715,7 @@ private struct GitPanel: View {
     @State private var stagedCollapsed = false
     @State private var changesCollapsed = false
     @State private var historyCollapsed = false
+    @State private var worktreesCollapsed = false
     @State private var expandedCommitIDs: Set<String> = []
     @State private var filterText = ""
     @State private var showFilter = false
@@ -844,18 +857,28 @@ private struct GitPanel: View {
         Menu {
             if !model.branches.isEmpty {
                 ForEach(model.branches, id: \.self) { branch in
-                    Button {
-                        performOperation(.branchMenu) {
-                            model.switchBranch(to: branch)
+                    if let worktree = model.worktree(forBranch: branch),
+                       !model.isCurrent(worktree) {
+                        Button {
+                            openWorktree(worktree)
+                        } label: {
+                            Label(branch, systemImage: "rectangle.stack")
                         }
-                    } label: {
-                        if branch == model.branch {
-                            Label(branch, systemImage: "checkmark")
-                        } else {
-                            Text(branch)
+                        .help(String(localized: "Open the worktree using this branch"))
+                    } else {
+                        Button {
+                            performOperation(.branchMenu) {
+                                model.switchBranch(to: branch)
+                            }
+                        } label: {
+                            if branch == model.branch {
+                                Label(branch, systemImage: "checkmark")
+                            } else {
+                                Text(branch)
+                            }
                         }
+                        .disabled(branch == model.branch || model.isBusy)
                     }
-                    .disabled(branch == model.branch || model.isBusy)
                 }
                 Divider()
             }
@@ -1406,6 +1429,17 @@ private struct GitPanel: View {
     private var changeList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 1) {
+                if model.worktrees.count > 1 {
+                    WorktreesSectionView(
+                        worktrees: model.worktrees,
+                        currentPath: model.repoRoot,
+                        sessionCounts: worktreeSessionCounts,
+                        fontScale: sidebarFontScale,
+                        isCollapsed: $worktreesCollapsed,
+                        openWorktree: openWorktree
+                    )
+                    .frame(maxWidth: .infinity)
+                }
                 if model.totalChangeCount == 0 {
                     cleanState
                 } else if visibleChangeCount == 0 {

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -203,6 +203,75 @@ final class TerminalManager: nonisolated ObservableObject {
         return project
     }
 
+    /// Treats a linked checkout as a parallel workspace. Selecting one never
+    /// injects `cd` into a live shell or switches the current checkout's
+    /// branch: an existing project/session is revealed, otherwise a new
+    /// pinned project is opened with its first terminal rooted there.
+    @discardableResult
+    func openOrRevealWorktree(
+        at path: String, suggestedName: String? = nil
+    ) -> Project? {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return nil }
+        let target = Self.directoryIdentity(path)
+
+        for project in projects {
+            if let session = project.sessions.first(where: { session in
+                let root = project.panelRoot(
+                    followingSessionAt: session.currentDirectoryPath,
+                    foregroundAt: session.foregroundDirectoryPath
+                ).root
+                return Self.directoryIdentity(root) == target
+            }) {
+                revealSession(session)
+                return project
+            }
+            // An empty restored project can still own this worktree. Reopen a
+            // terminal in it instead of creating a duplicate project row.
+            if project.sessions.isEmpty,
+               project.customDirectory.map(Self.directoryIdentity) == target {
+                selectedProjectID = project.id
+                project.newSession(directory: target)
+                return project
+            }
+        }
+
+        let project = makeProject(createInitialSession: false)
+        project.customName = Project.normalizedCustomName(suggestedName)
+        project.customDirectory = target
+        project.newSession(directory: target)
+        insert(project)
+        return project
+    }
+
+    /// Session counts make already-open worktrees recognizable in the Git
+    /// navigator without pretending to know whether a foreground process is
+    /// specifically an agent.
+    func sessionCountsByWorktree(
+        _ worktrees: [GitStatusModel.Worktree]
+    ) -> [String: Int] {
+        let pathsByIdentity = Dictionary(
+            uniqueKeysWithValues: worktrees.map {
+                (Self.directoryIdentity($0.path), $0.path)
+            }
+        )
+        var counts: [String: Int] = [:]
+        for project in projects {
+            for session in project.sessions {
+                let root = project.panelRoot(
+                    followingSessionAt: session.currentDirectoryPath,
+                    foregroundAt: session.foregroundDirectoryPath
+                ).root
+                guard let originalPath = pathsByIdentity[Self.directoryIdentity(root)] else {
+                    continue
+                }
+                counts[originalPath, default: 0] += 1
+            }
+        }
+        return counts
+    }
+
     /// Creates a project rooted at `directory`, with its first terminal
     /// launched there. Used by Kero's Finder service.
     private func newProject(directory: String) {
@@ -239,6 +308,10 @@ final class TerminalManager: nonisolated ObservableObject {
             projects.append(project)
         }
         selectedProjectID = project.id
+    }
+
+    private static func directoryIdentity(_ path: String) -> String {
+        URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
     }
 
     /// Routes folders from the Finder service into the active Kero window.

--- a/kero/WorktreesSectionView.swift
+++ b/kero/WorktreesSectionView.swift
@@ -1,0 +1,528 @@
+//
+//  WorktreesSectionView.swift
+//  kero
+//
+
+import AppKit
+import SwiftUI
+
+/// Native worktree navigation embedded in the legacy SwiftUI Git panel.
+/// Rows intentionally open parallel Kero projects instead of mutating the
+/// current terminal or checkout.
+struct WorktreesSectionView: NSViewRepresentable {
+    @Binding private var isCollapsed: Bool
+    @ObservedObject private var themeChanges = Theme.changes
+
+    let worktrees: [GitStatusModel.Worktree]
+    let currentPath: String
+    let sessionCounts: [String: Int]
+    let fontScale: CGFloat
+    let openWorktree: (GitStatusModel.Worktree) -> Void
+
+    init(
+        worktrees: [GitStatusModel.Worktree],
+        currentPath: String,
+        sessionCounts: [String: Int],
+        fontScale: CGFloat,
+        isCollapsed: Binding<Bool>,
+        openWorktree: @escaping (GitStatusModel.Worktree) -> Void
+    ) {
+        self.worktrees = worktrees
+        self.currentPath = currentPath
+        self.sessionCounts = sessionCounts
+        self.fontScale = fontScale
+        _isCollapsed = isCollapsed
+        self.openWorktree = openWorktree
+    }
+
+    func makeNSView(context: Context) -> WorktreesSectionNSView {
+        WorktreesSectionNSView()
+    }
+
+    func updateNSView(_ view: WorktreesSectionNSView, context: Context) {
+        _ = themeChanges
+        view.onToggleCollapsed = { isCollapsed.toggle() }
+        view.onOpenWorktree = openWorktree
+        view.configure(
+            worktrees: worktrees,
+            currentPath: currentPath,
+            sessionCounts: sessionCounts,
+            fontScale: fontScale,
+            isCollapsed: isCollapsed
+        )
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        nsView: WorktreesSectionNSView,
+        context: Context
+    ) -> CGSize? {
+        CGSize(width: proposal.width ?? 240, height: nsView.requiredHeight)
+    }
+}
+
+@MainActor
+final class WorktreesSectionNSView: NSView {
+    private struct Snapshot: Equatable {
+        let worktrees: [GitStatusModel.Worktree]
+        let currentPath: String
+        let sessionCounts: [String: Int]
+        let fontScale: CGFloat
+        let isCollapsed: Bool
+    }
+
+    var onToggleCollapsed: (() -> Void)?
+    var onOpenWorktree: ((GitStatusModel.Worktree) -> Void)?
+
+    private var snapshot: Snapshot?
+    private var orderedRows: [NSView] = []
+    private(set) var requiredHeight: CGFloat = 0
+
+    override var isFlipped: Bool { true }
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: requiredHeight)
+    }
+
+    func configure(
+        worktrees: [GitStatusModel.Worktree],
+        currentPath: String,
+        sessionCounts: [String: Int],
+        fontScale: CGFloat,
+        isCollapsed: Bool
+    ) {
+        let normalizedCurrentPath = Self.normalizedPath(currentPath)
+        let sortedWorktrees = worktrees.sorted { lhs, rhs in
+            let lhsCurrent = Self.normalizedPath(lhs.path) == normalizedCurrentPath
+            let rhsCurrent = Self.normalizedPath(rhs.path) == normalizedCurrentPath
+            if lhsCurrent != rhsCurrent { return lhsCurrent }
+            let lhsOpen = sessionCounts[lhs.path, default: 0] > 0
+            let rhsOpen = sessionCounts[rhs.path, default: 0] > 0
+            if lhsOpen != rhsOpen { return lhsOpen }
+            return Self.title(for: lhs).localizedStandardCompare(Self.title(for: rhs))
+                == .orderedAscending
+        }
+        let next = Snapshot(
+            worktrees: sortedWorktrees,
+            currentPath: normalizedCurrentPath,
+            sessionCounts: sessionCounts,
+            fontScale: fontScale,
+            isCollapsed: isCollapsed
+        )
+        guard snapshot != next else {
+            orderedRows.forEach { $0.needsDisplay = true }
+            return
+        }
+        snapshot = next
+        rebuildRows(using: next)
+    }
+
+    override func layout() {
+        super.layout()
+        var y: CGFloat = 0
+        for row in orderedRows {
+            let height = row.intrinsicContentSize.height
+            row.frame = NSRect(x: 0, y: y, width: bounds.width, height: height)
+            y += height
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        orderedRows.forEach { $0.needsDisplay = true }
+    }
+
+    private func rebuildRows(using snapshot: Snapshot) {
+        orderedRows.forEach { $0.removeFromSuperview() }
+        orderedRows.removeAll(keepingCapacity: true)
+
+        let metrics = WorktreeMetrics(fontScale: snapshot.fontScale)
+        let header = WorktreeSectionHeaderView(
+            count: snapshot.worktrees.count,
+            isCollapsed: snapshot.isCollapsed,
+            metrics: metrics
+        )
+        header.onToggle = { [weak self] in self?.onToggleCollapsed?() }
+        addArrangedRow(header)
+
+        if !snapshot.isCollapsed {
+            for worktree in snapshot.worktrees {
+                let row = WorktreeRowView(
+                    worktree: worktree,
+                    isCurrent: Self.normalizedPath(worktree.path) == snapshot.currentPath,
+                    sessionCount: snapshot.sessionCounts[worktree.path, default: 0],
+                    metrics: metrics
+                )
+                row.onOpen = { [weak self] worktree in
+                    self?.onOpenWorktree?(worktree)
+                }
+                addArrangedRow(row)
+            }
+        }
+
+        requiredHeight = orderedRows.reduce(0) { $0 + $1.intrinsicContentSize.height }
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    private func addArrangedRow(_ row: NSView) {
+        addSubview(row)
+        orderedRows.append(row)
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+
+    fileprivate static func title(for worktree: GitStatusModel.Worktree) -> String {
+        if let branch = worktree.branch { return branch }
+        if worktree.isBare { return String(localized: "Bare repository") }
+        if !worktree.shortHeadOID.isEmpty {
+            return String(localized: "Detached at \(worktree.shortHeadOID)")
+        }
+        return String(localized: "Detached HEAD")
+    }
+}
+
+@MainActor
+private struct WorktreeMetrics {
+    let scale: CGFloat
+    let headerHeight: CGFloat
+    let rowHeight: CGFloat
+    let titleFont: NSFont
+    let pathFont: NSFont
+    let accessoryFont: NSFont
+    let headerFont: NSFont
+
+    init(fontScale: CGFloat) {
+        scale = fontScale
+        headerHeight = max(27, (27 * fontScale).rounded(.up))
+        rowHeight = max(38, (40 * fontScale).rounded(.up))
+        titleFont = .systemFont(ofSize: 11 * fontScale, weight: .regular)
+        pathFont = .systemFont(ofSize: 9.5 * fontScale, weight: .regular)
+        accessoryFont = .systemFont(ofSize: 8.5 * fontScale, weight: .medium)
+        headerFont = .systemFont(ofSize: 9.5 * fontScale, weight: .medium)
+    }
+}
+
+@MainActor
+private final class WorktreeSectionHeaderView: NSView {
+    var onToggle: (() -> Void)?
+
+    private let count: Int
+    private let isCollapsed: Bool
+    private let metrics: WorktreeMetrics
+    private let chevron = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: String(localized: "WORKTREES"))
+    private let countLabel = NSTextField(labelWithString: "")
+
+    init(count: Int, isCollapsed: Bool, metrics: WorktreeMetrics) {
+        self.count = count
+        self.isCollapsed = isCollapsed
+        self.metrics = metrics
+        super.init(frame: .zero)
+
+        focusRingType = .default
+        titleLabel.font = metrics.headerFont
+        titleLabel.textColor = .secondaryLabelColor.withAlphaComponent(0.7)
+        countLabel.stringValue = "\(count)"
+        countLabel.font = metrics.accessoryFont
+        countLabel.textColor = .tertiaryLabelColor
+        countLabel.alignment = .center
+        chevron.image = NSImage(
+            systemSymbolName: isCollapsed ? "chevron.right" : "chevron.down",
+            accessibilityDescription: nil
+        )
+        chevron.symbolConfiguration = .init(pointSize: 7 * metrics.scale, weight: .semibold)
+        chevron.contentTintColor = .secondaryLabelColor.withAlphaComponent(0.7)
+
+        addSubview(chevron)
+        addSubview(titleLabel)
+        addSubview(countLabel)
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(String(localized: "Worktrees, \(count) items"))
+        setAccessibilityValue(
+            isCollapsed ? String(localized: "Collapsed") : String(localized: "Expanded")
+        )
+        setAccessibilityHelp(String(localized: "Shows or hides Git worktrees"))
+    }
+
+    required init?(coder: NSCoder) { nil }
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: metrics.headerHeight)
+    }
+    override var focusRingMaskBounds: NSRect { bounds.insetBy(dx: 5, dy: 2) }
+
+    override func drawFocusRingMask() {
+        NSBezierPath(roundedRect: focusRingMaskBounds, xRadius: 4, yRadius: 4).fill()
+    }
+
+    override func layout() {
+        super.layout()
+        let contentY = max(0, metrics.headerHeight - 19)
+        chevron.frame = NSRect(x: 8, y: contentY + 3, width: 8, height: 10)
+        let countWidth = max(18, countLabel.intrinsicContentSize.width + 8)
+        countLabel.frame = NSRect(
+            x: bounds.width - countWidth - 8,
+            y: contentY,
+            width: countWidth,
+            height: 16
+        )
+        titleLabel.frame = NSRect(
+            x: 20,
+            y: contentY,
+            width: max(0, bounds.width - 20 - countWidth - 12),
+            height: 16
+        )
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        onToggle?()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 36 || event.keyCode == 49 {
+            onToggle?()
+        } else if event.keyCode == 123, !isCollapsed {
+            onToggle?()
+        } else if event.keyCode == 124, isCollapsed {
+            onToggle?()
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        onToggle?()
+        return true
+    }
+}
+
+@MainActor
+private final class WorktreeRowView: NSView {
+    let worktree: GitStatusModel.Worktree
+    var onOpen: ((GitStatusModel.Worktree) -> Void)?
+
+    private let isCurrent: Bool
+    private let sessionCount: Int
+    private let metrics: WorktreeMetrics
+    private let canOpen: Bool
+    private let icon = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let pathLabel = NSTextField(labelWithString: "")
+    private let accessoryLabel = NSTextField(labelWithString: "")
+    private var trackingAreaReference: NSTrackingArea?
+    private var isHovered = false
+
+    init(
+        worktree: GitStatusModel.Worktree,
+        isCurrent: Bool,
+        sessionCount: Int,
+        metrics: WorktreeMetrics
+    ) {
+        self.worktree = worktree
+        self.isCurrent = isCurrent
+        self.sessionCount = sessionCount
+        self.metrics = metrics
+        canOpen = !worktree.isBare && worktree.prunableReason == nil
+        super.init(frame: .zero)
+
+        focusRingType = .default
+        let title = WorktreesSectionNSView.title(for: worktree)
+        var titleParts = [title]
+        if worktree.lockedReason != nil { titleParts.append(String(localized: "locked")) }
+        if worktree.prunableReason != nil { titleParts.append(String(localized: "prunable")) }
+        titleLabel.stringValue = titleParts.joined(separator: " · ")
+        titleLabel.font = metrics.titleFont
+        titleLabel.textColor = canOpen ? .labelColor : .secondaryLabelColor
+        titleLabel.lineBreakMode = .byTruncatingTail
+        pathLabel.stringValue = (worktree.path as NSString).abbreviatingWithTildeInPath
+        pathLabel.font = metrics.pathFont
+        pathLabel.textColor = .tertiaryLabelColor
+        pathLabel.lineBreakMode = .byTruncatingMiddle
+        var accessories: [String] = []
+        if isCurrent { accessories.append("✓") }
+        if sessionCount > 0 {
+            accessories.append(String(localized: "\(sessionCount) open"))
+        }
+        accessoryLabel.stringValue = accessories.joined(separator: "  ")
+        accessoryLabel.font = metrics.accessoryFont
+        accessoryLabel.textColor = isCurrent ? Theme.accent : .tertiaryLabelColor
+        accessoryLabel.alignment = .right
+
+        icon.image = NSImage(
+            systemSymbolName: worktree.isBare ? "externaldrive" : "arrow.triangle.branch",
+            accessibilityDescription: nil
+        )
+        icon.symbolConfiguration = .init(pointSize: 9.5 * metrics.scale, weight: .medium)
+        icon.contentTintColor = isCurrent ? Theme.accent : .secondaryLabelColor
+
+        addSubview(icon)
+        addSubview(titleLabel)
+        addSubview(pathLabel)
+        addSubview(accessoryLabel)
+
+        let stateDescription = [
+            isCurrent ? String(localized: "current worktree") : nil,
+            sessionCount > 0 ? String(localized: "\(sessionCount) open sessions") : nil,
+            worktree.lockedReason.map { reason in
+                reason.isEmpty ? String(localized: "locked") : String(localized: "locked, \(reason)")
+            },
+            worktree.prunableReason.map { reason in
+                reason.isEmpty ? String(localized: "prunable") : String(localized: "prunable, \(reason)")
+            },
+        ].compactMap { $0 }.joined(separator: ", ")
+        let accessibilityLabel = [title, worktree.path, stateDescription]
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(accessibilityLabel)
+        setAccessibilityHelp(
+            canOpen
+                ? String(localized: "Opens or reveals this worktree as a Kero project")
+                : String(localized: "This worktree cannot be opened")
+        )
+        setAccessibilityEnabled(canOpen)
+        toolTip = accessibilityLabel
+    }
+
+    required init?(coder: NSCoder) { nil }
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { canOpen }
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: metrics.rowHeight)
+    }
+    override var focusRingMaskBounds: NSRect { bounds.insetBy(dx: 3, dy: 1) }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let background: NSColor?
+        if isCurrent {
+            background = Theme.accent.withAlphaComponent(0.10)
+        } else if isHovered {
+            background = NSColor.labelColor.withAlphaComponent(0.055)
+        } else {
+            background = nil
+        }
+        if let background {
+            background.setFill()
+            NSBezierPath(roundedRect: bounds.insetBy(dx: 2, dy: 1), xRadius: 5, yRadius: 5).fill()
+        }
+    }
+
+    override func drawFocusRingMask() {
+        NSBezierPath(roundedRect: focusRingMaskBounds, xRadius: 5, yRadius: 5).fill()
+    }
+
+    override func layout() {
+        super.layout()
+        let iconSize = max(12, 12 * metrics.scale)
+        icon.frame = NSRect(x: 8, y: 8, width: iconSize, height: iconSize)
+        let contentX = 27 * metrics.scale
+        let accessoryWidth = min(
+            62 * metrics.scale,
+            max(0, accessoryLabel.intrinsicContentSize.width)
+        )
+        accessoryLabel.frame = NSRect(
+            x: max(contentX, bounds.width - accessoryWidth - 8),
+            y: 4,
+            width: accessoryWidth,
+            height: 15 * metrics.scale
+        )
+        titleLabel.frame = NSRect(
+            x: contentX,
+            y: 3,
+            width: max(0, bounds.width - contentX - accessoryWidth - 12),
+            height: 16 * metrics.scale
+        )
+        pathLabel.frame = NSRect(
+            x: contentX,
+            y: 20 * metrics.scale,
+            width: max(0, bounds.width - contentX - 8),
+            height: 14 * metrics.scale
+        )
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaReference { removeTrackingArea(trackingAreaReference) }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingAreaReference = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        needsDisplay = true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard canOpen else { return }
+        window?.makeFirstResponder(self)
+        onOpen?(worktree)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if canOpen && (event.keyCode == 36 || event.keyCode == 49) {
+            onOpen?(worktree)
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        guard canOpen else { return false }
+        onOpen?(worktree)
+        return true
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        let open = menu.addItem(
+            withTitle: String(localized: "Open Worktree"),
+            action: #selector(openFromMenu),
+            keyEquivalent: ""
+        )
+        open.target = self
+        open.isEnabled = canOpen
+        menu.addItem(.separator())
+        let copy = menu.addItem(
+            withTitle: String(localized: "Copy Worktree Path"),
+            action: #selector(copyPath),
+            keyEquivalent: ""
+        )
+        copy.target = self
+        let reveal = menu.addItem(
+            withTitle: String(localized: "Reveal Worktree in Finder"),
+            action: #selector(revealInFinder),
+            keyEquivalent: ""
+        )
+        reveal.target = self
+        reveal.isEnabled = FileManager.default.fileExists(atPath: worktree.path)
+        return menu
+    }
+
+    @objc private func openFromMenu() { onOpen?(worktree) }
+    @objc private func copyPath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(worktree.path, forType: .string)
+    }
+    @objc private func revealInFinder() {
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: worktree.path)])
+    }
+}


### PR DESCRIPTION
## Summary

- add a native AppKit Worktrees section to the Git panel, with current/open state, detached and unavailable states, paths, keyboard accessibility, and context actions
- discover worktrees through `git worktree list --porcelain -z` and refresh when the repository's shared worktree metadata changes
- open an existing Kero project for a worktree when possible, or create a pinned project rooted at that worktree without changing the current terminal or checkout
- route branch-menu selections to the corresponding worktree when that branch is already checked out elsewhere
- extract the new user-facing strings into the localization catalog

## Why

Coding agents increasingly use several Git worktrees in parallel. Kero could already follow a running foreground process into its worktree, but there was no direct way to see the repository's other worktrees or jump between them before or while agents were running.

This makes worktrees first-class navigation targets while preserving each terminal and agent's checkout.

Closes #28.

## Validation

- `xcodebuild -project kero.xcodeproj -scheme kero -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/kero-worktrees-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- standalone parser fixture covering named branches, detached worktrees, locked and prunable records, unusual paths, and unknown future porcelain fields
- live macOS exercise against 10 Kero worktrees:
  - revealed an existing worktree project
  - opened an unused worktree as a pinned project
  - confirmed repeated opening is idempotent
  - navigated to a checked-out branch through the branch menu without running `git switch`
  - exercised collapse/expand and accessibility state
- `git diff --check`


<img width="1224" height="768" alt="image" src="https://github.com/user-attachments/assets/07e28504-ec19-4b82-a089-797ea522ad4d" />
