### PR TITLE
Fix runaway git metadata probe outside repositories

### DIFF
--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -1367,13 +1367,18 @@ final class GitStatusModel: nonisolated ObservableObject {
     /// of offering to initialize a nested repository on top of broken metadata.
     private nonisolated static func containsGitMetadata(atOrAbove root: String) -> Bool {
         let fm = FileManager.default
-        var directory = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        // Walk path strings, not URLs: `URL.deletingLastPathComponent()` keeps
+        // appending ".." at the filesystem root, so a URL ascent never
+        // reaches its fixed point and spins forever. The NSString walk
+        // terminates at "/".
+        var directory = URL(fileURLWithPath: root, isDirectory: true)
+            .standardizedFileURL.path as NSString
         while true {
-            if fm.fileExists(atPath: directory.appendingPathComponent(".git").path) {
+            if fm.fileExists(atPath: directory.appendingPathComponent(".git")) {
                 return true
             }
-            let parent = directory.deletingLastPathComponent()
-            if parent.path == directory.path { return false }
+            let parent = directory.deletingLastPathComponent as NSString
+            if parent.isEqual(to: directory as String) { return false }
             directory = parent
         }
     }


### PR DESCRIPTION
containsGitMetadata ascended with URL.deletingLastPathComponent(), which keeps appending ".." at the filesystem root, so a session outside any repository spun forever and each refresh piled on another stuck worker which resulted in a levitating laptop.

Walk path strings instead, which reach their fixed point at "/".