### PR TITLE
Fix runaway memory when a project is outside any Git repository

### DIFF
--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -1365,15 +1365,19 @@ final class GitStatusModel: nonisolated ObservableObject {
     /// A malformed `.git` directory/file can produce the same rev-parse text
     /// as a plain folder. Preserve that as an actionable status error instead
     /// of offering to initialize a nested repository on top of broken metadata.
+    /// Walks up using the string path APIs: `URL.deletingLastPathComponent()`
+    /// has no fixed point at `/`, where it yields `/..`, then `/../..`, so a
+    /// `parent == directory` test never ends the loop.
     private nonisolated static func containsGitMetadata(atOrAbove root: String) -> Bool {
         let fm = FileManager.default
-        var directory = URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        var directory = (root as NSString).standardizingPath
+        guard directory.hasPrefix("/") else { return false }
         while true {
-            if fm.fileExists(atPath: directory.appendingPathComponent(".git").path) {
+            if fm.fileExists(atPath: (directory as NSString).appendingPathComponent(".git")) {
                 return true
             }
-            let parent = directory.deletingLastPathComponent()
-            if parent.path == directory.path { return false }
+            let parent = (directory as NSString).deletingLastPathComponent
+            if parent == directory { return false }
             directory = parent
         }
     }


### PR DESCRIPTION
Fixes #99.

`containsGitMetadata(atOrAbove:)` walks up from the project root looking for a `.git` entry, and stops when a directory is its own parent. `URL.deletingLastPathComponent()` has no such fixed point at `/` — it appends `..` rather than returning the receiver:

```
/Users → /  →  /..  →  /../..  →  /../../..  →  ...
```

so `parent.path == directory.path` is never satisfied and the loop never ends. `Project.closestGitRepository(containing:)` does the same walk with the `NSString` path APIs, which do have a fixed point at `/`, and is unaffected.

The function is only reached when `git rev-parse --show-toplevel` exits 128 with "not a git repository", so the trigger is opening a directory that is not inside any Git repository as a project.

Because the loop runs on a background thread with no `autoreleasepool`, each iteration's `NSURL`, path `CFString` and CoreServices `_FileCache` accumulate in a pool that is never drained, and the path grows 3 characters per iteration — so the process grows quadratically until swap is exhausted rather than merely spinning. On the reporter's machine `phys_footprint` reached 38 GB in 100 seconds; on mine, 10.5 GB in 4 minutes, with `heap` showing 84,399 `CFString` totalling 5.39 GB whose sizes form an even ladder from 36 KB to 176 KB — the path strings themselves.

This switches the walk to the `NSString` path APIs, matching `Project.closestGitRepository(containing:)`. That fixes termination, and also removes the `CFURL`/`_FileCache` churn, since string path operations do not touch the filesystem. The other six `URL.deletingLastPathComponent()` call sites in the tree are single calls rather than walk-up loops, so this is the only instance of the pattern.

### Verification

Please read this section before merging — I was not able to complete a full app build, for a reason unrelated to this change.

`GitStatusModel.swift` compiles clean with the change (no errors, no warnings). The build then fails in `ContentView.swift:175` with `the compiler is unable to type-check this expression in reasonable time`, on Xcode 26.3 with the project's `objectVersion = 110` locally lowered so that Xcode could open it at all. Raising `-solver-expression-time-threshold` and `-solver-scope-threshold` does not get past it. I take this to mean the project currently needs a newer Xcode than 26.3, so I could not run the patched app.

What I did verify, on the released 0.1.43 build, is the trigger and the mechanism. Same binary, same Files panel, only the project directory changed:

| project directory | `phys_footprint` | CPU |
| --- | --- | --- |
| outside any repository | 0 → 819 MB in 42 s, linear, no plateau | ~90% sustained |
| inside a repository | rises to 91 MB, settles at 72 MB | 0.0% once idle |

In the first case `git rev-parse --show-toplevel` exits 128 with `fatal: not a git repository`, which is exactly the guard at GitStatusModel.swift:1240 that leads into this function.

Behaviour of the rewritten function, checked against the real Foundation APIs:

| root | result |
| --- | --- |
| inside a repository | `true` |
| repository root | `true` |
| directory outside any repository | `false` |
| `/` | `false` |
| home directory | `false` |

All five terminate; 1,000 calls from `/` allocate 0.0 MB.

One note for anyone reproducing the original report: `leaks` reports **0 leaks** for the whole footprint, because every object is reachable from the autorelease pool. Instruments' Leaks template will not surface this; the Allocations template or `heap` will.
