### PR TITLE
Render markdown files in the file preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Markdown files open rendered instead of as raw source, with headings, lists, task boxes, links, blockquotes, tables, images, and syntax-highlighted code blocks. A chip in the corner of the pane switches to the source and back, and the choice sticks; ⇧⌘V does the same from the keyboard
+
 ## [0.1.44]
 
 - Prevent a rare crash while using the Ctrl-Tab switcher

--- a/kero.xcodeproj/project.pbxproj
+++ b/kero.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 				AA20000000000000000000A1 /* STTextView-Plugin-Neon */,
 				AA30000000000000000000A1 /* TreeSitterTSX */,
 				AA60000000000000000000A1 /* FuzzyMatch */,
+				AA70000000000000000000A1 /* Markdown */,
 			);
 			productName = kero;
 			productReference = FF3FDD73300B6A7400112486 /* Kero Debug.app */;
@@ -153,6 +154,7 @@
 				AA10000000000000000000E0 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				AA20000000000000000000A0 /* XCRemoteSwiftPackageReference "STTextView-Plugin-Neon" */,
 				AA60000000000000000000A0 /* XCRemoteSwiftPackageReference "FuzzyMatch" */,
+				AA70000000000000000000A0 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = FF3FDD74300B6A7400112486 /* Products */;
@@ -487,6 +489,14 @@
 				minimumVersion = 1.3.2;
 			};
 		};
+		AA70000000000000000000A0 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/swiftlang/swift-markdown";
+			requirement = {
+				kind = revision;
+				revision = 27b7fc1a19068bcea3d2072db0ce86360d1400ed;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -525,6 +535,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA60000000000000000000A0 /* XCRemoteSwiftPackageReference "FuzzyMatch" */;
 			productName = FuzzyMatch;
+		};
+		AA70000000000000000000A1 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA70000000000000000000A0 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/kero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/kero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "944056b7ed6438af06aa572f2d570efbf9437d68d4617a21b3148e00642fb307",
+  "originHash" : "fb90edad64fb4f07d26d49103225e355bca348dd4efebfd10c3c92d2e3ca10de",
   "pins" : [
     {
       "identity" : "coretextswift",
@@ -79,6 +79,23 @@
       "location" : "https://github.com/krzyzanowskim/STTextView-Plugin-Neon",
       "state" : {
         "revision" : "5a30db4ce7908a5414e7b499e2379bdc49991cd1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "branch" : "gfm",
+        "revision" : "7898f1b3e4befeecee56cb4a3bc8eebd2cb63219"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown",
+      "state" : {
+        "revision" : "27b7fc1a19068bcea3d2072db0ce86360d1400ed"
       }
     },
     {

--- a/kero/CommandPaletteView.swift
+++ b/kero/CommandPaletteView.swift
@@ -258,6 +258,16 @@ struct CommandPaletteView: View {
                 manager.togglePanel(.info)
             },
             PaletteCommand(
+                id: "toggle-markdown-preview",
+                title: MarkdownViewPreferences.shared.showsSource
+                    ? "Preview Markdown"
+                    : "Edit Markdown Source",
+                systemImage: "doc.richtext",
+                shortcut: "⇧⌘V"
+            ) {
+                manager.toggleMarkdownPreview()
+            },
+            PaletteCommand(
                 id: "toggle-fps-counter",
                 title: manager.isFPSCounterVisible ? "Hide FPS Counter" : "Show FPS Counter",
                 systemImage: "gauge.with.needle"

--- a/kero/EditorFind.swift
+++ b/kero/EditorFind.swift
@@ -20,8 +20,19 @@ extension FileTab {
         (editorView as? NSScrollView)?.documentView as? STTextView
     }
 
+    /// The mounted markdown preview's text view, when this file is showing its
+    /// rendered form instead of the editor.
+    private var previewTextView: NSTextView? {
+        (editorView as? MarkdownPreviewView)?.findTarget
+    }
+
+    /// Whether this file is currently on screen as rendered markdown, which is
+    /// read-only — so Find works but Replace has nothing to act on.
+    var showsRenderedMarkdown: Bool {
+        editorView is MarkdownPreviewView
+    }
+
     func performFindAction(_ action: FindAction) {
-        guard let textView else { return }
         let finderAction: NSTextFinder.Action =
             switch action {
             case .show: .showFindInterface
@@ -31,9 +42,17 @@ extension FileTab {
             case .previous: .previousMatch
             case .useSelection: .setSearchString
             }
-        // Asking for the next match before anything has been searched for, or
-        // for the selection with none, does nothing rather than beeping.
-        guard textView.textFinder.validateAction(finderAction) else { return }
-        textView.textFinder.performAction(finderAction)
+        if let textView {
+            // Asking for the next match before anything has been searched for,
+            // or for the selection with none, does nothing rather than beeping.
+            guard textView.textFinder.validateAction(finderAction) else { return }
+            textView.textFinder.performAction(finderAction)
+        } else if let previewTextView {
+            // NSTextView keeps its own finder private and reads the action off
+            // the sender's tag, so a rendered document is searched this way.
+            let sender = NSMenuItem()
+            sender.tag = finderAction.rawValue
+            previewTextView.performTextFinderAction(sender)
+        }
     }
 }

--- a/kero/FileViewerView.swift
+++ b/kero/FileViewerView.swift
@@ -212,10 +212,11 @@ final class FileTab: nonisolated ObservableObject, nonisolated Identifiable {
     }
 }
 
-/// Content of a file tab: an STTextView editor (line numbers, system find
-/// bar), an image preview, or a placeholder for anything binary or
-/// oversized.
-struct FileViewerView: View {
+/// Content of a file tab, hosted in AppKit: the source editor, the rendered
+/// markdown preview, an image, or a placeholder for anything binary or
+/// oversized. SwiftUI is only the mount point — `FileViewerContainerView` owns
+/// the views and the switching between them.
+struct FileViewerView: NSViewRepresentable {
     @ObservedObject var file: FileTab
     /// Whether this file's pane is the focused one in its tab.
     var isFocused: Bool = true
@@ -226,73 +227,401 @@ struct FileViewerView: View {
     var onSplit: (PaneDropEdge) -> Void = { _ in }
 
     @ObservedObject private var settings = AppSettings.shared
+    @ObservedObject private var markdownPreferences = MarkdownViewPreferences.shared
     @Environment(\.colorScheme) private var colorScheme
 
-    var body: some View {
-        Group {
-            switch file.content {
-            case .text:
-                VStack(spacing: 0) {
-                    if let error = file.saveError {
-                        saveErrorBar(error)
-                    }
-                    SourceTextEditor(
-                        file: file,
-                        font: TerminalFont.current(),
-                        palette: .theme(dark: colorScheme == .dark),
-                        wrapLines: settings.wrapLines,
-                        isFocused: isFocused,
-                        onFocused: onFocused,
-                        onSplit: onSplit
-                    )
-                    .id(file.reloadRevision)
-                }
-            case .image(let image):
-                ScrollView([.horizontal, .vertical]) {
-                    Image(nsImage: image)
-                        .padding(16)
-                }
-            case .unavailable(let reason):
-                VStack(spacing: 8) {
-                    MaterialFileIconView(path: file.path, size: 28, opacity: 0.72)
-                    Text(reason)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.tertiary)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
+    func makeNSView(context: Context) -> FileViewerContainerView {
+        let view = FileViewerContainerView(file: file)
+        apply(to: view)
+        return view
+    }
+
+    func updateNSView(_ view: FileViewerContainerView, context: Context) {
+        apply(to: view)
+    }
+
+    private func apply(to view: FileViewerContainerView) {
+        view.update(
+            font: TerminalFont.current(),
+            palette: .theme(dark: colorScheme == .dark),
+            wrapLines: settings.wrapLines,
+            isFocused: isFocused,
+            showsSource: markdownPreferences.showsSource,
+            onFocused: onFocused,
+            onSplit: onSplit
+        )
+    }
+
+    /// Take exactly the space SwiftUI offers. Without this, SwiftUI sizes the
+    /// pane from the content's `fittingSize`, which a text view derives from the
+    /// entire document — enormous for a large file, and degenerate for an empty
+    /// one. Because the main window tracks its content's ideal size, that runaway
+    /// measurement drives the window size and drops it into an unbounded layout
+    /// loop (a hard crash: "more Layout Window passes than there are views").
+    func sizeThatFits(
+        _ proposal: ProposedViewSize, nsView: FileViewerContainerView, context: Context
+    ) -> CGSize? {
+        func resolve(_ value: CGFloat?, fallback: CGFloat) -> CGFloat {
+            guard let value, value.isFinite else { return fallback }
+            return value
         }
-        .onAppear {
-            file.reloadFromDiskIfClean()
+        return CGSize(
+            width: resolve(proposal.width, fallback: nsView.frame.width),
+            height: resolve(proposal.height, fallback: nsView.frame.height)
+        )
+    }
+}
+
+/// The AppKit body of a file tab. Holds whichever content view the tab's state
+/// calls for, plus the markdown mode chip and the save-error bar, and swaps
+/// content in place as the file reloads or the reader toggles modes.
+@MainActor
+final class FileViewerContainerView: NSView {
+    private let file: FileTab
+
+    private var editor: SourceEditorController?
+    private var preview: MarkdownPreviewView?
+    /// The currently mounted content view, whichever kind it is.
+    private var contentView: NSView?
+    private var contentKind: ContentKind?
+    private let chip = MarkdownModeChipView()
+    private let errorBar = FileSaveErrorBar()
+
+    private var font: NSFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
+    private var palette = EditorPalette.theme(dark: true)
+    private var wrapLines = false
+    private var isFocused = false
+    private var showsSource = false
+    private var onFocused: () -> Void = {}
+    private var onSplit: (PaneDropEdge) -> Void = { _ in }
+
+    /// Last reload the mounted content was built from. A bump means the bytes
+    /// on disk changed under a clean tab, so the content has to be rebuilt.
+    private var mountedRevision: UInt = 0
+    /// Path the mounted content was built for, so a rename can re-resolve the
+    /// preview's relative links and images against the new directory.
+    private var mountedPath: String?
+    private var errorBarHeight: NSLayoutConstraint?
+
+    /// Which view the tab's current state calls for.
+    private enum ContentKind: Equatable {
+        case source
+        case preview
+        case image
+        case unavailable(String)
+    }
+
+    init(file: FileTab) {
+        self.file = file
+        super.init(frame: .zero)
+
+        errorBar.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(errorBar)
+        let height = errorBar.heightAnchor.constraint(equalToConstant: 0)
+        errorBarHeight = height
+        NSLayoutConstraint.activate([
+            errorBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            errorBar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            errorBar.topAnchor.constraint(equalTo: topAnchor),
+            height,
+        ])
+
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.isHidden = true
+        chip.onToggle = { [weak self] in
+            // Clicking the chip in an unfocused split has to move the model's
+            // focus too, or the pane swaps modes while ⌘F and the Find menu
+            // keep acting on whichever pane was focused before.
+            self?.onFocused()
+            MarkdownViewPreferences.shared.showsSource.toggle()
         }
-        // The selected file view stays mounted while Kero is inactive, so
-        // returning from an external editor does not trigger `onAppear`.
-        .onReceive(NotificationCenter.default.publisher(
-            for: NSApplication.didBecomeActiveNotification
-        )) { _ in
-            file.reloadFromDiskIfClean()
-        }
-        // A window can become key without the app itself transitioning from
-        // inactive (for example when moving between Kero windows).
-        .onReceive(NotificationCenter.default.publisher(
-            for: NSWindow.didBecomeKeyNotification
-        )) { _ in
-            file.reloadFromDiskIfClean()
+        addSubview(chip)
+        NSLayoutConstraint.activate([
+            chip.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -MarkdownModeChipView.trailingInset
+            ),
+            chip.topAnchor.constraint(
+                equalTo: errorBar.bottomAnchor,
+                constant: MarkdownModeChipView.topInset
+            ),
+        ])
+
+        // The selected file view stays mounted while kero is inactive, so
+        // returning from an external editor does not trigger a fresh mount.
+        for name in [
+            NSApplication.didBecomeActiveNotification,
+            NSWindow.didBecomeKeyNotification,
+        ] {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(reloadFromDisk),
+                name: name,
+                object: nil
+            )
         }
     }
 
-    private func saveErrorBar(_ message: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 10))
-            Text("Could not save: \(message)")
-                .font(.system(size: 11))
-                .lineLimit(1)
-            Spacer(minLength: 0)
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        file.reloadFromDiskIfClean()
+    }
+
+    @objc private func reloadFromDisk() {
+        file.reloadFromDiskIfClean()
+    }
+
+    func update(
+        font: NSFont,
+        palette: EditorPalette,
+        wrapLines: Bool,
+        isFocused: Bool,
+        showsSource: Bool,
+        onFocused: @escaping () -> Void,
+        onSplit: @escaping (PaneDropEdge) -> Void
+    ) {
+        self.font = font
+        self.palette = palette
+        self.wrapLines = wrapLines
+        self.isFocused = isFocused
+        self.showsSource = showsSource
+        self.onFocused = onFocused
+        self.onSplit = onSplit
+
+        errorBar.message = file.saveError
+        errorBarHeight?.constant = file.saveError == nil ? 0 : FileSaveErrorBar.height
+
+        // Markdown is the only file type with two ways to read it, so the chip
+        // exists only there.
+        let isMarkdown = Self.isMarkdown(file.path)
+        chip.isHidden = !isMarkdown || !isTextContent
+        chip.update(showsSource: showsSource)
+
+        installContentIfNeeded()
+        // A rename re-points the tab without touching the bytes, so nothing
+        // above notices — but the preview resolves `./img.png` against the
+        // file's directory, which just moved.
+        if mountedPath != file.path {
+            mountedPath = file.path
+            preview?.reloadForPathChange()
         }
-        .foregroundStyle(Color(red: 0.82, green: 0.60, blue: 0.13))
-        .padding(.horizontal, 12)
-        .padding(.vertical, 5)
-        .background(Color.primary.opacity(0.04))
+        editor?.update(
+            font: font,
+            palette: palette,
+            wrapLines: wrapLines,
+            isFocused: isFocused,
+            onFocused: onFocused,
+            onSplit: onSplit
+        )
+        preview?.onSplit = onSplit
+    }
+
+    private var isTextContent: Bool {
+        if case .text = file.content { return true }
+        return false
+    }
+
+    /// Rendered by default, source on request — and always source for anything
+    /// that is not markdown.
+    private var desiredKind: ContentKind {
+        switch file.content {
+        case .text:
+            Self.isMarkdown(file.path) && !showsSource ? .preview : .source
+        case .image:
+            .image
+        case .unavailable(let reason):
+            .unavailable(reason)
+        }
+    }
+
+    private func installContentIfNeeded() {
+        let kind = desiredKind
+        let revision = file.reloadRevision
+        guard kind != contentKind || revision != mountedRevision else { return }
+        let isModeSwitch = contentKind != nil && revision == mountedRevision
+        // Only new bytes on disk make the cached views stale. Toggling modes
+        // keeps them: rebuilding the editor would hand it a fresh STTextView,
+        // and with it a fresh undo manager, so a round trip through the preview
+        // would silently throw away everything ⌘Z could have undone.
+        if revision != mountedRevision {
+            editor = nil
+            preview = nil
+        }
+        contentKind = kind
+        mountedRevision = revision
+
+        contentView?.removeFromSuperview()
+        contentView = nil
+
+        let view: NSView
+        switch kind {
+        case .source:
+            let controller = editor ?? SourceEditorController(
+                file: file,
+                font: font,
+                palette: palette,
+                wrapLines: wrapLines,
+                isFocused: isFocused,
+                onFocused: onFocused,
+                onSplit: onSplit
+            )
+            editor = controller
+            // Find acts on whichever view is mounted, and a reused controller
+            // set this only when it was first built.
+            file.editorView = controller.scrollView
+            view = controller.scrollView
+        case .preview:
+            let markdown: MarkdownPreviewView
+            if let existing = preview {
+                markdown = existing
+            } else {
+                markdown = MarkdownPreviewView(file: file)
+                markdown.onFocused = onFocused
+                markdown.onSplit = onSplit
+                preview = markdown
+            }
+            // Edits made in the source since this view last drew. The image
+            // cache survives, so toggling back does not refetch remote images,
+            // and the scroll position is kept by the re-render.
+            markdown.refresh()
+            file.editorView = markdown
+            view = markdown
+        case .image:
+            view = Self.imageView(for: file, palette: palette)
+        case .unavailable(let reason):
+            view = Self.placeholderView(path: file.path, reason: reason, palette: palette)
+        }
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(view, positioned: .below, relativeTo: chip)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            view.topAnchor.constraint(equalTo: errorBar.bottomAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        contentView = view
+
+        // Toggling modes should leave the keyboard where the reader is looking;
+        // a plain remount (a disk reload) must not steal focus from elsewhere.
+        if isModeSwitch, isFocused {
+            switch kind {
+            case .preview: preview?.takeFocus()
+            case .source: editor?.takeFocus()
+            case .image, .unavailable: break
+            }
+        }
+    }
+
+    /// v1 renders `.md` only. Other markdown spellings still open as source.
+    static func isMarkdown(_ path: String) -> Bool {
+        (path as NSString).pathExtension.lowercased() == "md"
+    }
+
+    private static func imageView(for file: FileTab, palette: EditorPalette) -> NSView {
+        guard case .image(let image) = file.content else { return NSView() }
+        let imageView = NSImageView()
+        imageView.image = image
+        imageView.imageScaling = .scaleNone
+        imageView.frame = CGRect(origin: .zero, size: image.size)
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = imageView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = palette.background
+        return scrollView
+    }
+
+    private static func placeholderView(
+        path: String,
+        reason: String,
+        palette: EditorPalette
+    ) -> NSView {
+        let container = NSView()
+        let icon = NSImageView()
+        icon.image = MaterialFileIcon.image(forPath: path)
+        icon.alphaValue = 0.72
+        let label = NSTextField(labelWithString: reason)
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = palette.gutterText
+
+        for view in [icon, label] as [NSView] {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(view)
+        }
+        NSLayoutConstraint.activate([
+            icon.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 28),
+            icon.heightAnchor.constraint(equalToConstant: 28),
+            icon.bottomAnchor.constraint(equalTo: container.centerYAnchor, constant: -4),
+            label.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            label.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 8),
+        ])
+        return container
+    }
+}
+
+/// The strip above a file's content that reports a failed save.
+private final class FileSaveErrorBar: NSView {
+    static let height: CGFloat = 22
+
+    var message: String? {
+        didSet {
+            isHidden = message == nil
+            guard let message else { return }
+            label.stringValue = String(localized: "Could not save: \(message)")
+        }
+    }
+
+    private let label = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        isHidden = true
+        layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.04).cgColor
+
+        let icon = NSImageView()
+        icon.image = NSImage(
+            systemSymbolName: "exclamationmark.triangle.fill",
+            accessibilityDescription: nil
+        )
+        let warning = NSColor(red: 0.82, green: 0.60, blue: 0.13, alpha: 1)
+        icon.contentTintColor = warning
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = warning
+        label.lineBreakMode = .byTruncatingTail
+
+        for view in [icon, label] as [NSView] {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(view)
+        }
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 10),
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/kero/MarkdownCodeHighlighter.swift
+++ b/kero/MarkdownCodeHighlighter.swift
@@ -1,0 +1,109 @@
+//
+//  MarkdownCodeHighlighter.swift
+//  kero
+//
+
+import AppKit
+import STPluginNeon
+import SwiftTreeSitter
+
+/// Colors a fenced code block in the markdown preview with the same grammars
+/// and palette the source editor uses, so ` ```swift ` in a rendered README
+/// looks like the same code open in a tab beside it.
+///
+/// The editor's highlighter (`SyntaxHighlightCoordinator`) can't be reused
+/// here: it drives Neon incrementally against a live STTextView's TextKit 2
+/// content manager. A preview fence is a short, immutable string, so it takes
+/// the same path the editor uses for *injected* regions — parse once, run the
+/// highlights query, color the ranges — with no incremental machinery at all.
+@MainActor
+final class MarkdownCodeHighlighter {
+    static let shared = MarkdownCodeHighlighter()
+
+    /// Posted when a grammar's query finishes compiling off the main thread, so
+    /// every mounted preview can render again with the fence now colored. A
+    /// notification rather than a callback because the highlighter is shared
+    /// and several markdown panes can be open at once.
+    static let grammarReadyNotification = Notification.Name("kero.markdownGrammarReady")
+
+    private var pendingCompiles: Set<SyntaxLanguage> = []
+
+    /// `code` styled with `font`/`color`, plus syntax colors when the fence's
+    /// info string names a grammar kero bundles. Unknown or absent languages
+    /// come back as plain text.
+    func attributedCode(
+        _ code: String,
+        language: String?,
+        font: NSFont,
+        color: NSColor
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString(
+            string: code,
+            attributes: [.font: font, .foregroundColor: color]
+        )
+        guard let language,
+              let syntaxLanguage = SyntaxHighlighting.language(forInjectionName: language),
+              let query = highlightsQuery(for: syntaxLanguage)
+        else {
+            return result
+        }
+
+        let parser = Parser()
+        do {
+            try parser.setLanguage(syntaxLanguage.parser)
+        } catch {
+            return result
+        }
+        guard let tree = parser.parse(code), let root = tree.rootNode else {
+            return result
+        }
+
+        let context = SwiftTreeSitter.Predicate.Context(string: code)
+        let limit = result.length
+        for named in query.execute(node: root, in: tree).resolve(with: context).highlights() {
+            // Clamped rather than trusted: a query range that ran past the end
+            // of the string would trap on `addAttribute`.
+            guard named.range.length > 0,
+                  named.range.location >= 0,
+                  named.range.upperBound <= limit,
+                  !SyntaxHighlightCoordinator.ignoredCaptures.contains(named.name),
+                  let tokenColor = SyntaxHighlightCoordinator.themeColor(
+                      for: named.name,
+                      theme: SyntaxHighlighting.theme
+                  )
+            else {
+                continue
+            }
+            result.addAttribute(.foregroundColor, value: tokenColor, range: named.range)
+        }
+        return result
+    }
+
+    /// The compiled highlights query for a grammar, reusing the editor's shared
+    /// cache. On a miss the compile — up to a couple hundred milliseconds for a
+    /// big grammar — runs off the main thread and the ready notification
+    /// re-renders when it lands; the fence stays plain until then. Mirrors the
+    /// editor's `injectedHighlightsQuery`.
+    private func highlightsQuery(for language: SyntaxLanguage) -> SwiftTreeSitter.Query? {
+        if let query = HighlightQueryCache.cached(language) {
+            return query
+        }
+        guard !pendingCompiles.contains(language) else { return nil }
+        pendingCompiles.insert(language)
+
+        let data = SyntaxHighlighting.highlightsData(for: language)
+        let parser = language.parser
+        DispatchQueue.global(qos: .userInitiated).async {
+            let query = try? SwiftTreeSitter.Query(language: Language(language: parser), data: data)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.pendingCompiles.remove(language)
+                if let query {
+                    HighlightQueryCache.store(query, for: language)
+                }
+                NotificationCenter.default.post(name: Self.grammarReadyNotification, object: nil)
+            }
+        }
+        return nil
+    }
+}

--- a/kero/MarkdownImageLoader.swift
+++ b/kero/MarkdownImageLoader.swift
@@ -84,12 +84,30 @@ final class MarkdownImageLoader {
 
     private nonisolated static func fetch(_ url: URL) async -> NSImage? {
         var request = URLRequest(url: url)
+        // Idle timeout: it also covers a stalling body, since receiving data
+        // resets it.
         request.timeoutInterval = 15
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        // Streamed rather than `data(for:)`, which would buffer the entire
+        // response before the size check could reject it — the cap has to hold
+        // against a server that ignores or misstates Content-Length.
+        guard let (bytes, response) = try? await URLSession.shared.bytes(for: request),
               let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode),
-              data.count <= maxBytes
+              http.expectedContentLength <= Int64(maxBytes) // -1 when unknown
         else { return nil }
+
+        var data = Data()
+        data.reserveCapacity(http.expectedContentLength > 0
+            ? Int(http.expectedContentLength)
+            : 1 << 20)
+        do {
+            for try await byte in bytes {
+                guard data.count < maxBytes else { return nil }
+                data.append(byte)
+            }
+        } catch {
+            return nil
+        }
         return NSImage(data: data)
     }
 }

--- a/kero/MarkdownImageLoader.swift
+++ b/kero/MarkdownImageLoader.swift
@@ -1,0 +1,95 @@
+//
+//  MarkdownImageLoader.swift
+//  kero
+//
+
+import AppKit
+
+/// Loads the images a rendered markdown document references, and caches them
+/// for the life of the preview.
+///
+/// Rendering is synchronous, so the renderer can only draw what is already in
+/// hand: an image that has to be fetched renders as its alt text, and `onLoad`
+/// asks the view to render again once the bytes arrive.
+///
+/// Remote sources are fetched over the network — README badges are the usual
+/// case. That means opening a preview can tell the image's host that this file
+/// was viewed.
+@MainActor
+final class MarkdownImageLoader {
+    /// Called after an image finishes loading, so the preview can re-render.
+    /// May fire several times while a document's images arrive.
+    var onLoad: (() -> Void)?
+
+    private var cache: [URL: NSImage] = [:]
+    private var inFlight: Set<URL> = []
+    /// Sources that failed or were rejected. Kept so a broken link is asked for
+    /// once per document rather than on every re-render.
+    private var failed: Set<URL> = []
+
+    /// A decoded image, or nil while it loads (or after it failed). Starts the
+    /// load on the first miss.
+    func image(for url: URL) -> NSImage? {
+        if let cached = cache[url] { return cached }
+        guard !inFlight.contains(url), !failed.contains(url) else { return nil }
+
+        if url.isFileURL {
+            load(url) { await Self.readFile(url) }
+        } else if url.scheme == "http" || url.scheme == "https" {
+            load(url) { await Self.fetch(url) }
+        } else {
+            // data:, mailto:, anything else — nothing to draw.
+            failed.insert(url)
+        }
+        return nil
+    }
+
+    /// Drops everything so a re-opened or re-pointed document re-reads from
+    /// disk instead of showing the previous file's images.
+    func reset() {
+        cache.removeAll()
+        failed.removeAll()
+        // In-flight loads are left alone; their results are simply discarded
+        // when they land, because the cache they would populate is gone.
+        inFlight.removeAll()
+    }
+
+    private func load(_ url: URL, using work: @escaping () async -> NSImage?) {
+        inFlight.insert(url)
+        Task { [weak self] in
+            let image = await work()
+            guard let self else { return }
+            self.inFlight.remove(url)
+            guard let image else {
+                self.failed.insert(url)
+                return
+            }
+            self.cache[url] = image
+            self.onLoad?()
+        }
+    }
+
+    /// Ceiling on a single image, so a preview can't be made to buffer an
+    /// arbitrarily large download or read.
+    private nonisolated static let maxBytes = 20 << 20
+
+    private nonisolated static func readFile(_ url: URL) async -> NSImage? {
+        await Task.detached(priority: .userInitiated) {
+            guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+                  data.count <= maxBytes
+            else { return nil }
+            return NSImage(data: data)
+        }.value
+    }
+
+    private nonisolated static func fetch(_ url: URL) async -> NSImage? {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
+              data.count <= maxBytes
+        else { return nil }
+        return NSImage(data: data)
+    }
+}

--- a/kero/MarkdownModeChip.swift
+++ b/kero/MarkdownModeChip.swift
@@ -1,0 +1,152 @@
+//
+//  MarkdownModeChip.swift
+//  kero
+//
+
+import AppKit
+import Combine
+
+/// Whether markdown tabs open rendered or as source. Sticky across tabs and
+/// launches, like the diff viewer's review/edit choice: pick source once and
+/// the next `.md` file opens there too.
+@MainActor
+final class MarkdownViewPreferences: ObservableObject {
+    static let shared = MarkdownViewPreferences()
+
+    private static let modeKey = "markdownView.mode"
+
+    @Published var showsSource: Bool {
+        didSet {
+            UserDefaults.standard.set(showsSource ? "source" : "preview", forKey: Self.modeKey)
+        }
+    }
+
+    private init() {
+        showsSource = UserDefaults.standard.string(forKey: Self.modeKey) == "source"
+    }
+}
+
+/// The floating pill in the top-right of a markdown pane that swaps between the
+/// rendered document and its source.
+///
+/// It names the *action*, not the current state — "Edit" while reading, "Preview"
+/// while editing — so one glance says what the click will do. It stays visible
+/// in both modes: hiding it in source mode would leave the way back invisible.
+@MainActor
+final class MarkdownModeChipView: NSView {
+    var onToggle: (() -> Void)?
+
+    private let icon = NSImageView()
+    private let label = NSTextField(labelWithString: "")
+    private var showsSource = false
+    private var hovering = false
+
+    /// Clears the vertical scroller (~15pt) plus a margin, so the chip and the
+    /// scroll thumb never overlap when the pointer brings the scroller out.
+    static let trailingInset: CGFloat = 22
+    static let topInset: CGFloat = 8
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.imageScaling = .scaleProportionallyDown
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 11, weight: .medium)
+        addSubview(icon)
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 11),
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 4),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            heightAnchor.constraint(equalToConstant: 22),
+        ])
+        updateAppearanceColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(showsSource: Bool) {
+        guard self.showsSource != showsSource || label.stringValue.isEmpty else { return }
+        self.showsSource = showsSource
+        if showsSource {
+            label.stringValue = String(
+                localized: "Preview",
+                comment: "Switches a markdown file from its source back to the rendered document."
+            )
+            icon.image = NSImage(systemSymbolName: "eye", accessibilityDescription: nil)
+        } else {
+            label.stringValue = String(
+                localized: "Edit",
+                comment: "Switches a rendered markdown file to its editable source."
+            )
+            icon.image = NSImage(systemSymbolName: "pencil", accessibilityDescription: nil)
+        }
+        setAccessibilityLabel(label.stringValue)
+        updateAlpha()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas { removeTrackingArea(area) }
+        addTrackingArea(
+            NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow],
+                owner: self
+            )
+        )
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        hovering = true
+        updateAlpha()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        hovering = false
+        updateAlpha()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onToggle?()
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearanceColors()
+    }
+
+    /// Full strength over the rendered document, where the chip is the only way
+    /// back to the source; dimmed over the editor, which is a work surface the
+    /// chip should stay out of until it is wanted.
+    private func updateAlpha() {
+        alphaValue = (showsSource && !hovering) ? 0.4 : 1
+    }
+
+    private func updateAppearanceColors() {
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let theme = Theme.terminal(dark: isDark)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = theme.surfaceNSColor(elevation: 0.08).cgColor
+            layer?.borderColor = theme.surfaceNSColor(elevation: 0.18).cgColor
+        }
+        let foreground = theme.surfaceNSColor(elevation: 0.6)
+        label.textColor = foreground
+        icon.contentTintColor = foreground
+    }
+}

--- a/kero/MarkdownPreviewView.swift
+++ b/kero/MarkdownPreviewView.swift
@@ -1,0 +1,257 @@
+//
+//  MarkdownPreviewView.swift
+//  kero
+//
+
+import AppKit
+
+/// The rendered half of a markdown file tab: a read-only text view showing the
+/// document as formatted content, with the source one click away on the mode
+/// chip.
+///
+/// Deliberately TextKit 1. `MarkdownRenderer` expresses blockquote bars, code
+/// backgrounds and GFM tables as `NSTextBlock`/`NSTextTable`, which TextKit 2
+/// does not lay out at all. The editor beside it stays TextKit 2 (STTextView) —
+/// only the preview drops back, and only because a preview is a short,
+/// read-only, immutable document where TextKit 2's incremental editing wins
+/// buy nothing.
+///
+/// Re-rendering is whole-document rather than incremental: markdown files are
+/// small, and a full re-render keeps image arrival, grammar compilation,
+/// appearance changes and width changes on one obvious path.
+@MainActor
+final class MarkdownPreviewView: NSView {
+    private let file: FileTab
+    private let scrollView = NSScrollView()
+    private let textView: PreviewTextView
+    private let images = MarkdownImageLoader()
+
+    /// Text width the current render was laid out for. A resize past this
+    /// re-renders, because image scaling and table columns depend on it.
+    private var renderedWidth: CGFloat = 0
+    /// Source the current render was built from, so a re-render triggered by an
+    /// unrelated event (an image arriving) can skip re-parsing unchanged text.
+    private var renderedSource: String?
+    private var renderedDark: Bool?
+    private var renderScheduled = false
+
+    var onFocused: (() -> Void)?
+    var onSplit: ((PaneDropEdge) -> Void)? {
+        didSet { textView.splitTarget.onSplit = onSplit }
+    }
+
+    private static let contentInset = NSSize(width: 26, height: 22)
+
+    init(file: FileTab) {
+        self.file = file
+
+        // TextKit 1 stack, built explicitly: a programmatically created
+        // NSTextView is TextKit 2 by default, and text blocks would silently
+        // not draw.
+        let storage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(
+            size: CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        )
+        container.widthTracksTextView = true
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        textView = PreviewTextView(frame: .zero, textContainer: container)
+
+        super.init(frame: .zero)
+
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = true
+        textView.drawsBackground = true
+        textView.textContainerInset = Self.contentInset
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        // A document view grows vertically with its text and tracks the scroll
+        // view's width; without an unbounded max size it would stop laying out
+        // past its initial frame height.
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        // Same find bar the editor gets, so ⌘F works in both modes.
+        textView.usesFindBar = true
+        textView.isIncrementalSearchingEnabled = true
+        textView.onBecomeFirstResponder = { [weak self] in self?.onFocused?() }
+
+        scrollView.documentView = textView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = true
+        // Matches the editor: the window uses a full-size content view, so
+        // automatic insets would push the content down by a titlebar height.
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentInsets = NSEdgeInsets()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        // The source is unchanged when an image lands, so the render guard has
+        // to be cleared explicitly or the new bytes would never be drawn.
+        images.onLoad = { [weak self] in
+            self?.renderedSource = nil
+            self?.setNeedsRender()
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(grammarBecameReady),
+            name: MarkdownCodeHighlighter.grammarReadyNotification,
+            object: nil
+        )
+        applyColors()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// A fence's grammar finished compiling, so the document can be drawn again
+    /// with that block colored.
+    @objc private func grammarBecameReady() {
+        renderedSource = nil
+        setNeedsRender()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// The text view, so the tab can route Find menu actions at it.
+    var findTarget: NSTextView { textView }
+
+    func takeFocus() {
+        window?.makeFirstResponder(textView)
+    }
+
+    /// Re-reads `file.text`, keeping the image cache and the scroll position.
+    /// Called when the tab switches back from the source editor, so edits made
+    /// there show up without refetching every remote image.
+    func refresh() {
+        renderedSource = nil
+        setNeedsRender()
+    }
+
+    /// The document moved on disk, so every relative link and image resolves
+    /// against a different directory now.
+    func reloadForPathChange() {
+        images.reset()
+        refresh()
+    }
+
+    override func layout() {
+        super.layout()
+        // Width drives image scaling and table columns, so a resize past the
+        // width the document was laid out for needs a fresh render — but a
+        // sub-point jitter during live resize should not.
+        if abs(availableWidth - renderedWidth) > 0.5 {
+            setNeedsRender()
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+        setNeedsRender()
+    }
+
+    private var availableWidth: CGFloat {
+        max(bounds.width - Self.contentInset.width * 2, 1)
+    }
+
+    /// Coalesces the several things that can invalidate a render — an image
+    /// landing, a grammar finishing its compile, a resize, an appearance change
+    /// — into one pass per turn of the run loop.
+    private func setNeedsRender() {
+        guard !renderScheduled else { return }
+        renderScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.renderScheduled = false
+            self.render()
+        }
+    }
+
+    private func render() {
+        guard bounds.width > 0 else { return }
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let source = file.text
+        let width = availableWidth
+        guard source != renderedSource || width != renderedWidth || isDark != renderedDark
+        else {
+            return
+        }
+        renderedSource = source
+        renderedWidth = width
+        renderedDark = isDark
+
+        let rendered = MarkdownRenderer.render(
+            source,
+            style: .theme(dark: isDark),
+            baseURL: URL(fileURLWithPath: file.path).deletingLastPathComponent(),
+            contentWidth: width,
+            images: images
+        )
+
+        // Re-rendering replaces the whole document, which would otherwise snap
+        // the reader back to the top on every image that arrives.
+        let offset = scrollView.contentView.bounds.origin
+        textView.textStorage?.setAttributedString(rendered)
+        textView.scroll(offset)
+    }
+
+    private func applyColors() {
+        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let palette = EditorPalette.theme(dark: isDark)
+        textView.backgroundColor = palette.background
+        scrollView.backgroundColor = palette.background
+        textView.linkTextAttributes = [
+            .foregroundColor: palette.insertionPoint,
+            .cursor: NSCursor.pointingHand,
+        ]
+    }
+}
+
+/// Read-only text view that reports focus and carries the pane-split context
+/// menu, so a preview pane behaves like the editor pane it replaces.
+private final class PreviewTextView: NSTextView {
+    var onBecomeFirstResponder: (() -> Void)?
+    /// Owns the split menu items, kept off the text view so its own menu
+    /// validation doesn't disable them. Same arrangement as the editor's
+    /// `FocusReportingTextView`.
+    let splitTarget = SplitMenuTarget()
+
+    override func becomeFirstResponder() -> Bool {
+        let became = super.becomeFirstResponder()
+        if became { onBecomeFirstResponder?() }
+        return became
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = super.menu(for: event) ?? NSMenu()
+        menu.addItem(.separator())
+        for item in splitTarget.menuItems() { menu.addItem(item) }
+        return menu
+    }
+
+    /// Opens links in the user's browser (or the default app for a local file)
+    /// rather than trying to navigate inside a text view.
+    override func clicked(onLink link: Any, at charIndex: Int) {
+        guard let url = link as? URL ?? (link as? String).flatMap(URL.init(string:)) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/kero/MarkdownRenderer.swift
+++ b/kero/MarkdownRenderer.swift
@@ -1,0 +1,729 @@
+//
+//  MarkdownRenderer.swift
+//  kero
+//
+
+import AppKit
+import Markdown
+
+/// Fonts and colors the markdown preview draws with, derived from the selected
+/// ghostty theme so a rendered README sits in the same palette as the source
+/// editor it toggles against.
+@MainActor
+struct MarkdownStyle {
+    var bodyFont: NSFont
+    var codeFont: NSFont
+    var text: NSColor
+    var secondary: NSColor
+    var link: NSColor
+    var codeBackground: NSColor
+    var rule: NSColor
+    var quoteBar: NSColor
+    var tableBorder: NSColor
+    var tableHeaderBackground: NSColor
+
+    /// Prose is proportional (a rendered document is for reading, not for
+    /// column alignment) while code keeps the terminal font, so a fenced block
+    /// in the preview matches the same block in the editor.
+    static func theme(dark: Bool) -> MarkdownStyle {
+        let theme = Theme.terminal(dark: dark)
+        let bodySize: CGFloat = 14
+        let terminal = TerminalFont.current()
+        return MarkdownStyle(
+            bodyFont: .systemFont(ofSize: bodySize),
+            codeFont: NSFont(descriptor: terminal.fontDescriptor, size: bodySize * 0.92) ?? terminal,
+            text: theme.foregroundNSColor,
+            secondary: theme.surfaceNSColor(elevation: 0.45),
+            link: theme.accentNSColor,
+            codeBackground: theme.surfaceNSColor(elevation: 0.06),
+            rule: theme.surfaceNSColor(elevation: 0.18),
+            quoteBar: theme.surfaceNSColor(elevation: 0.3),
+            tableBorder: theme.surfaceNSColor(elevation: 0.22),
+            tableHeaderBackground: theme.surfaceNSColor(elevation: 0.04)
+        )
+    }
+}
+
+/// Turns a parsed markdown document into an `NSAttributedString` for the
+/// preview's text view.
+///
+/// Block structure — blockquote bars, fenced-code backgrounds, GFM table grids
+/// — is expressed with `NSTextBlock`/`NSTextTable`, which is why the preview
+/// runs on TextKit 1 (see `MarkdownPreviewView`). TextKit 2 ignores text blocks
+/// entirely, and hand-rolling table layout to avoid them would cost far more
+/// code than the preview is worth.
+///
+/// The visitor keeps a `blockStack` rather than folding indentation into each
+/// paragraph style: nesting (a table inside a blockquote, a fence inside a list)
+/// then composes by construction instead of by arithmetic.
+/// The conformance is main-actor isolated because the walk reaches the image
+/// cache and the shared code highlighter, both of which live on the main actor.
+/// Rendering runs there anyway — its output goes straight into a text view.
+@MainActor
+struct MarkdownRenderer: @MainActor MarkupVisitor {
+    typealias Result = NSAttributedString
+
+    let style: MarkdownStyle
+    /// Directory the document was loaded from, so relative image sources
+    /// resolve the way they do on disk.
+    let baseURL: URL
+    /// Width available to the text, used to size images down to fit.
+    let contentWidth: CGFloat
+    /// Supplies images already in hand and starts fetching the ones that are
+    /// not; the view re-renders when they land.
+    let images: MarkdownImageLoader
+
+    /// Enclosing text blocks, outermost first. Every paragraph style built
+    /// during the walk carries the current stack.
+    private var blockStack: [NSTextBlock] = []
+    /// Extra head indent from enclosing lists, in points.
+    private var listIndent: CGFloat = 0
+
+    init(
+        style: MarkdownStyle,
+        baseURL: URL,
+        contentWidth: CGFloat,
+        images: MarkdownImageLoader
+    ) {
+        self.style = style
+        self.baseURL = baseURL
+        self.contentWidth = contentWidth
+        self.images = images
+    }
+
+    static func render(
+        _ source: String,
+        style: MarkdownStyle,
+        baseURL: URL,
+        contentWidth: CGFloat,
+        images: MarkdownImageLoader
+    ) -> NSAttributedString {
+        let document = Document(parsing: source)
+        var renderer = MarkdownRenderer(
+            style: style,
+            baseURL: baseURL,
+            contentWidth: contentWidth,
+            images: images
+        )
+        return renderer.visit(document)
+    }
+
+    // MARK: - Container defaults
+
+    mutating func defaultVisit(_ markup: any Markup) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in markup.children {
+            result.append(visit(child))
+        }
+        return result
+    }
+
+    mutating func visitDocument(_ document: Document) -> NSAttributedString {
+        defaultVisit(document)
+    }
+
+    // MARK: - Blocks
+
+    mutating func visitParagraph(_ paragraph: Paragraph) -> NSAttributedString {
+        // Items in a list sit closer together than free-standing paragraphs, or
+        // a short list reads as a stack of unrelated lines.
+        block(defaultVisit(paragraph), spacingAfter: listIndent > 0 ? 4 : 10)
+    }
+
+    mutating func visitHeading(_ heading: Heading) -> NSAttributedString {
+        // Descending scale with a floor at body size; h6 drops to the secondary
+        // color instead of shrinking below the prose it labels.
+        let scales: [CGFloat] = [1.75, 1.45, 1.22, 1.08, 1.0, 1.0]
+        let scale = scales[min(max(heading.level, 1), 6) - 1]
+        let size = style.bodyFont.pointSize * scale
+        let font = NSFont.systemFont(ofSize: size, weight: .semibold)
+
+        let content = NSMutableAttributedString(attributedString: defaultVisit(heading))
+        content.addAttribute(
+            .font,
+            value: font,
+            range: NSRange(location: 0, length: content.length)
+        )
+        if heading.level >= 6 {
+            content.addAttribute(
+                .foregroundColor,
+                value: style.secondary,
+                range: NSRange(location: 0, length: content.length)
+            )
+        }
+        // A heading that opens the document needs no space above it.
+        let isFirst = heading.indexInParent == 0 && heading.parent is Document
+        return block(content, spacingBefore: isFirst ? 0 : 18, spacingAfter: 8)
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> NSAttributedString {
+        let rule = NSTextBlock()
+        // A text block defaults to zero content width, which collapses its text
+        // to one character per line; every block kero builds has to claim the
+        // width it was given.
+        rule.setContentWidth(100, type: .percentageValueType)
+        rule.setWidth(1, type: .absoluteValueType, for: .border, edge: .minY)
+        rule.setBorderColor(style.rule, for: .minY)
+        rule.setWidth(0, type: .absoluteValueType, for: .padding)
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = blockStack + [rule]
+        paragraph.paragraphSpacingBefore = 10
+        paragraph.paragraphSpacing = 10
+        // A non-breaking space keeps the paragraph from collapsing to nothing,
+        // which would take the border with it.
+        return NSAttributedString(
+            string: "\u{00A0}\n",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 1),
+                .paragraphStyle: paragraph,
+                .foregroundColor: NSColor.clear,
+            ]
+        )
+    }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> NSAttributedString {
+        let bar = NSTextBlock()
+        bar.setContentWidth(100, type: .percentageValueType)
+        bar.setWidth(3, type: .absoluteValueType, for: .border, edge: .minX)
+        bar.setBorderColor(style.quoteBar, for: .minX)
+        bar.setWidth(14, type: .absoluteValueType, for: .padding, edge: .minX)
+        bar.setWidth(6, type: .absoluteValueType, for: .padding, edge: .minY)
+        bar.setWidth(6, type: .absoluteValueType, for: .padding, edge: .maxY)
+
+        // The block owns the inset, so list indent restarts inside it.
+        let outerIndent = listIndent
+        listIndent = 0
+        blockStack.append(bar)
+        let content = NSMutableAttributedString(attributedString: defaultVisit(blockQuote))
+        blockStack.removeLast()
+        listIndent = outerIndent
+
+        content.addAttribute(
+            .foregroundColor,
+            value: style.secondary,
+            range: NSRange(location: 0, length: content.length)
+        )
+        return content
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> NSAttributedString {
+        let background = NSTextBlock()
+        background.setContentWidth(100, type: .percentageValueType)
+        background.backgroundColor = style.codeBackground
+        background.setWidth(10, type: .absoluteValueType, for: .padding)
+
+        // Trailing newline is the fence's own terminator, not a blank code line.
+        var code = codeBlock.code
+        if code.hasSuffix("\n") { code.removeLast() }
+
+        let highlighted = MarkdownCodeHighlighter.shared.attributedCode(
+            code,
+            language: codeBlock.language,
+            font: style.codeFont,
+            color: style.text
+        )
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = blockStack + [background]
+        paragraph.paragraphSpacingBefore = 8
+        paragraph.paragraphSpacing = 12
+        paragraph.lineHeightMultiple = 1.2
+        // Long lines wrap rather than clipping: the preview has no horizontal
+        // scroller, unlike the editor.
+        paragraph.lineBreakMode = .byWordWrapping
+
+        let result = NSMutableAttributedString(attributedString: highlighted)
+        result.append(NSAttributedString(string: "\n"))
+        result.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: result.length)
+        )
+        return result
+    }
+
+    mutating func visitHTMLBlock(_ html: HTMLBlock) -> NSAttributedString {
+        // Raw HTML is shown as its source, never interpreted — the preview is a
+        // text view, and rendering embedded markup would mean a web engine.
+        var source = html.rawHTML
+        if source.hasSuffix("\n") { source.removeLast() }
+        return block(
+            NSAttributedString(
+                string: source,
+                attributes: [.font: style.codeFont, .foregroundColor: style.secondary]
+            ),
+            spacingAfter: 10
+        )
+    }
+
+    // MARK: - Lists
+
+    mutating func visitUnorderedList(_ list: UnorderedList) -> NSAttributedString {
+        // Depth drives both the bullet glyph and the indent, so nested lists
+        // read as nested without needing a different renderer path.
+        let depth = Self.listDepth(of: list)
+        let bullets = ["•", "◦", "▪"]
+        let bullet = bullets[depth % bullets.count]
+        return renderList(list) { item, _ in
+            switch item.checkbox {
+            case .checked: return "☑"
+            case .unchecked: return "☐"
+            case .none: return bullet
+            }
+        }
+    }
+
+    mutating func visitOrderedList(_ list: OrderedList) -> NSAttributedString {
+        let start = Int(list.startIndex)
+        return renderList(list) { item, offset in
+            switch item.checkbox {
+            case .checked: return "☑"
+            case .unchecked: return "☐"
+            case .none: return "\(start + offset)."
+            }
+        }
+    }
+
+    /// Shared list body: each item is laid out as `marker \t content`, with a
+    /// tab stop at the item's text indent so wrapped lines and nested blocks
+    /// line up under the first character rather than under the marker.
+    private mutating func renderList(
+        _ list: any ListItemContainer,
+        marker: (ListItem, Int) -> String
+    ) -> NSAttributedString {
+        let indentStep: CGFloat = 22
+        let outerIndent = listIndent
+        let textIndent = outerIndent + indentStep
+
+        let result = NSMutableAttributedString()
+        for (offset, item) in list.listItems.enumerated() {
+            listIndent = textIndent
+            let content = NSMutableAttributedString(attributedString: defaultVisit(item))
+            listIndent = outerIndent
+
+            // Only the paragraph the marker joins is rewritten. Anything deeper
+            // in the item — a nested list, a fence, a quote — was rendered with
+            // its own absolute indent already, and reindenting it here is what
+            // would flatten every nesting level onto the first.
+            let ownStyle = content.length > 0
+                ? content.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+                : nil
+            let hanging = (ownStyle?.mutableCopy() as? NSMutableParagraphStyle)
+                ?? NSMutableParagraphStyle()
+            hanging.headIndent = textIndent
+            hanging.firstLineHeadIndent = outerIndent
+            hanging.tabStops = [NSTextTab(textAlignment: .left, location: textIndent)]
+
+            content.insert(
+                NSAttributedString(
+                    string: "\(marker(item, offset))\t",
+                    attributes: [
+                        .font: style.bodyFont,
+                        .foregroundColor: item.checkbox == nil ? style.secondary : style.text,
+                    ]
+                ),
+                at: 0
+            )
+            // Applied across the marker too: a paragraph takes its style from
+            // its first character, so leaving the marker unstyled would drop
+            // the whole line back to the default indent.
+            content.addAttribute(
+                .paragraphStyle,
+                value: hanging,
+                range: NSRange(location: 0, length: Self.firstParagraphEnd(of: content))
+            )
+            result.append(content)
+        }
+        return result
+    }
+
+    /// End of the run of text that carries the item's marker, so only that
+    /// paragraph gets the hanging first line.
+    private static func firstParagraphEnd(of string: NSAttributedString) -> Int {
+        let newline = (string.string as NSString).range(of: "\n")
+        return newline.location == NSNotFound ? string.length : newline.location + 1
+    }
+
+    /// How many lists enclose this one, counted through the AST rather than
+    /// tracked in visitor state so it stays right regardless of visit order.
+    private static func listDepth(of list: any Markup) -> Int {
+        var depth = 0
+        var parent = list.parent
+        while let current = parent {
+            if current is UnorderedList || current is OrderedList { depth += 1 }
+            parent = current.parent
+        }
+        return depth
+    }
+
+    // MARK: - Tables
+
+    mutating func visitTable(_ table: Markdown.Table) -> NSAttributedString {
+        let columnCount = max(table.maxColumnCount, 1)
+        let textTable = NSTextTable()
+        textTable.numberOfColumns = columnCount
+        textTable.setContentWidth(100, type: .percentageValueType)
+        textTable.layoutAlgorithm = .automaticLayoutAlgorithm
+        textTable.collapsesBorders = true
+        textTable.hidesEmptyCells = false
+
+        let rows = Array(table.body.rows)
+        let lastRow = rows.count
+        let result = NSMutableAttributedString()
+        result.append(
+            renderRow(
+                table.head.cells,
+                table: textTable,
+                row: 0,
+                columnCount: columnCount,
+                alignments: table.columnAlignments,
+                isHeader: true,
+                // Spacing lives on the outermost row of the grid, so the table
+                // is separated from the prose around it rather than butting
+                // straight against the paragraph above.
+                spacingBefore: 10,
+                spacingAfter: lastRow == 0 ? 12 : 0
+            )
+        )
+        for (offset, bodyRow) in rows.enumerated() {
+            result.append(
+                renderRow(
+                    bodyRow.cells,
+                    table: textTable,
+                    row: offset + 1,
+                    columnCount: columnCount,
+                    alignments: table.columnAlignments,
+                    isHeader: false,
+                    spacingBefore: 0,
+                    spacingAfter: offset == lastRow - 1 ? 12 : 0
+                )
+            )
+        }
+        return result
+    }
+
+    private mutating func renderRow(
+        _ cells: some Sequence<Markdown.Table.Cell>,
+        table: NSTextTable,
+        row: Int,
+        columnCount: Int,
+        alignments: [Markdown.Table.ColumnAlignment?],
+        isHeader: Bool,
+        spacingBefore: CGFloat,
+        spacingAfter: CGFloat
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        var column = 0
+        for cell in cells {
+            guard column < columnCount else { break }
+            let span = max(Int(cell.colspan), 1)
+            result.append(
+                renderCell(
+                    cell,
+                    table: table,
+                    row: row,
+                    column: column,
+                    span: min(span, columnCount - column),
+                    alignment: column < alignments.count ? alignments[column] : nil,
+                    isHeader: isHeader,
+                    spacingBefore: spacingBefore,
+                    spacingAfter: spacingAfter
+                )
+            )
+            column += span
+        }
+        // A short row still has to close every column, or the table's remaining
+        // cells shift up into it.
+        while column < columnCount {
+            result.append(
+                renderEmptyCell(
+                    table: table,
+                    row: row,
+                    column: column,
+                    isHeader: isHeader,
+                    spacingBefore: spacingBefore,
+                    spacingAfter: spacingAfter
+                )
+            )
+            column += 1
+        }
+        return result
+    }
+
+    private mutating func renderCell(
+        _ cell: Markdown.Table.Cell,
+        table: NSTextTable,
+        row: Int,
+        column: Int,
+        span: Int,
+        alignment: Markdown.Table.ColumnAlignment?,
+        isHeader: Bool,
+        spacingBefore: CGFloat,
+        spacingAfter: CGFloat
+    ) -> NSAttributedString {
+        let block = cellBlock(
+            table: table,
+            row: row,
+            column: column,
+            span: span,
+            isHeader: isHeader
+        )
+
+        // Cell contents are inline-only, and the enclosing list indent must not
+        // follow them into the table's own coordinate space.
+        let outerIndent = listIndent
+        let outerStack = blockStack
+        listIndent = 0
+        blockStack = blockStack + [block]
+        let content = NSMutableAttributedString(attributedString: defaultVisit(cell))
+        blockStack = outerStack
+        listIndent = outerIndent
+
+        if isHeader {
+            content.enumerateAttribute(
+                .font,
+                in: NSRange(location: 0, length: content.length)
+            ) { value, range, _ in
+                let font = (value as? NSFont) ?? style.bodyFont
+                content.addAttribute(
+                    .font,
+                    value: NSFont.systemFont(ofSize: font.pointSize, weight: .semibold),
+                    range: range
+                )
+            }
+        }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = outerStack + [block]
+        paragraph.alignment = Self.textAlignment(alignment)
+        paragraph.paragraphSpacingBefore = spacingBefore
+        paragraph.paragraphSpacing = spacingAfter
+        content.append(NSAttributedString(string: "\n"))
+        content.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: content.length)
+        )
+        return content
+    }
+
+    private func renderEmptyCell(
+        table: NSTextTable,
+        row: Int,
+        column: Int,
+        isHeader: Bool,
+        spacingBefore: CGFloat,
+        spacingAfter: CGFloat
+    ) -> NSAttributedString {
+        let block = cellBlock(table: table, row: row, column: column, span: 1, isHeader: isHeader)
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = blockStack + [block]
+        paragraph.paragraphSpacingBefore = spacingBefore
+        paragraph.paragraphSpacing = spacingAfter
+        return NSAttributedString(
+            string: "\n",
+            attributes: [.font: style.bodyFont, .paragraphStyle: paragraph]
+        )
+    }
+
+    private func cellBlock(
+        table: NSTextTable,
+        row: Int,
+        column: Int,
+        span: Int,
+        isHeader: Bool
+    ) -> NSTextTableBlock {
+        let block = NSTextTableBlock(
+            table: table,
+            startingRow: row,
+            rowSpan: 1,
+            startingColumn: column,
+            columnSpan: span
+        )
+        block.setWidth(1, type: .absoluteValueType, for: .border)
+        block.setBorderColor(style.tableBorder)
+        block.setWidth(7, type: .absoluteValueType, for: .padding)
+        if isHeader {
+            block.backgroundColor = style.tableHeaderBackground
+        }
+        return block
+    }
+
+    private static func textAlignment(
+        _ alignment: Markdown.Table.ColumnAlignment?
+    ) -> NSTextAlignment {
+        switch alignment {
+        case .left: .left
+        case .right: .right
+        case .center: .center
+        case nil: .natural
+        }
+    }
+
+    // MARK: - Inline
+
+    mutating func visitText(_ text: Markdown.Text) -> NSAttributedString {
+        NSAttributedString(string: text.string, attributes: baseAttributes)
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
+        Self.applying(.italic, to: defaultVisit(emphasis))
+    }
+
+    mutating func visitStrong(_ strong: Strong) -> NSAttributedString {
+        Self.applying(.bold, to: defaultVisit(strong))
+    }
+
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> NSAttributedString {
+        let content = NSMutableAttributedString(attributedString: defaultVisit(strikethrough))
+        content.addAttribute(
+            .strikethroughStyle,
+            value: NSUnderlineStyle.single.rawValue,
+            range: NSRange(location: 0, length: content.length)
+        )
+        return content
+    }
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
+        NSAttributedString(
+            string: inlineCode.code,
+            attributes: [
+                .font: style.codeFont,
+                .foregroundColor: style.text,
+                .backgroundColor: style.codeBackground,
+            ]
+        )
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> NSAttributedString {
+        NSAttributedString(
+            string: inlineHTML.rawHTML,
+            attributes: [.font: style.codeFont, .foregroundColor: style.secondary]
+        )
+    }
+
+    mutating func visitLink(_ link: Markdown.Link) -> NSAttributedString {
+        let content = NSMutableAttributedString(attributedString: defaultVisit(link))
+        let range = NSRange(location: 0, length: content.length)
+        content.addAttribute(.foregroundColor, value: style.link, range: range)
+        content.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        content.addAttribute(.underlineColor, value: style.link.withAlphaComponent(0.4), range: range)
+        if let destination = link.destination, let url = resolve(destination) {
+            content.addAttribute(.link, value: url, range: range)
+        }
+        return content
+    }
+
+    mutating func visitImage(_ image: Markdown.Image) -> NSAttributedString {
+        let alternate = image.plainText.isEmpty ? "image" : image.plainText
+        guard let source = image.source, let url = resolve(source) else {
+            return placeholder(for: alternate)
+        }
+        guard let loaded = images.image(for: url) else {
+            return placeholder(for: alternate)
+        }
+
+        let attachment = NSTextAttachment()
+        attachment.image = loaded
+        // Never upscale past the image's own size, and never overflow the text
+        // column — a full-width screenshot in a narrow pane would otherwise
+        // stretch the table view's content width and enable horizontal scroll.
+        let available = max(contentWidth - listIndent, 32)
+        let scale = min(1, available / max(loaded.size.width, 1))
+        attachment.bounds = CGRect(
+            origin: .zero,
+            size: CGSize(width: loaded.size.width * scale, height: loaded.size.height * scale)
+        )
+        return NSAttributedString(attachment: attachment)
+    }
+
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> NSAttributedString {
+        NSAttributedString(string: " ", attributes: baseAttributes)
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> NSAttributedString {
+        NSAttributedString(string: "\u{2028}", attributes: baseAttributes)
+    }
+
+    // MARK: - Helpers
+
+    private var baseAttributes: [NSAttributedString.Key: Any] {
+        [.font: style.bodyFont, .foregroundColor: style.text]
+    }
+
+    /// An unresolved or not-yet-loaded image renders as its alt text, so the
+    /// document still reads while a remote fetch is in flight or has failed.
+    private func placeholder(for alternate: String) -> NSAttributedString {
+        NSAttributedString(
+            string: "🖼 \(alternate)",
+            attributes: [.font: style.bodyFont, .foregroundColor: style.secondary]
+        )
+    }
+
+    /// Resolves a link or image destination against the document's directory,
+    /// so `./docs/x.png` points where it does on disk.
+    private func resolve(_ destination: String) -> URL? {
+        let trimmed = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let url = URL(string: trimmed), url.scheme != nil { return url }
+        // `[Usage](#usage)` points inside this document. The preview has no
+        // anchor navigation, so it stays styled but inert — turning it into a
+        // file path would open something named "#usage" that does not exist.
+        guard !trimmed.hasPrefix("#") else { return nil }
+        // A fragment on a path (`README.md#usage`) is not part of the filename.
+        let path = trimmed.split(separator: "#", maxSplits: 1).first.map(String.init) ?? trimmed
+        guard !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path, relativeTo: baseURL).standardizedFileURL
+    }
+
+    /// Wraps block content in a paragraph style carrying the current block
+    /// stack and list indent, and terminates the paragraph.
+    private func block(
+        _ content: NSAttributedString,
+        spacingBefore: CGFloat = 0,
+        spacingAfter: CGFloat = 0
+    ) -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = blockStack
+        paragraph.headIndent = listIndent
+        paragraph.firstLineHeadIndent = listIndent
+        paragraph.paragraphSpacingBefore = spacingBefore
+        paragraph.paragraphSpacing = spacingAfter
+        paragraph.lineHeightMultiple = 1.3
+        paragraph.lineBreakMode = .byWordWrapping
+
+        let result = NSMutableAttributedString(attributedString: content)
+        result.append(NSAttributedString(string: "\n", attributes: baseAttributes))
+        result.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: result.length)
+        )
+        return result
+    }
+
+    /// Adds a symbolic trait to every font in a run, so nesting composes —
+    /// `**bold _and italic_**` ends up both rather than only the inner one.
+    private static func applying(
+        _ traits: NSFontDescriptor.SymbolicTraits,
+        to string: NSAttributedString
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString(attributedString: string)
+        result.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, range, _ in
+            guard let font = value as? NSFont else { return }
+            let descriptor = font.fontDescriptor.withSymbolicTraits(
+                font.fontDescriptor.symbolicTraits.union(traits)
+            )
+            result.addAttribute(
+                .font,
+                value: NSFont(descriptor: descriptor, size: font.pointSize) ?? font,
+                range: range
+            )
+        }
+        return result
+    }
+}

--- a/kero/MarkdownRenderer.swift
+++ b/kero/MarkdownRenderer.swift
@@ -136,14 +136,34 @@ struct MarkdownRenderer: @MainActor MarkupVisitor {
         let scales: [CGFloat] = [1.75, 1.45, 1.22, 1.08, 1.0, 1.0]
         let scale = scales[min(max(heading.level, 1), 6) - 1]
         let size = style.bodyFont.pointSize * scale
-        let font = NSFont.systemFont(ofSize: size, weight: .semibold)
 
         let content = NSMutableAttributedString(attributedString: defaultVisit(heading))
-        content.addAttribute(
+        // Per-run rather than one font across the range: `# an *italic* title`
+        // and inline code in a heading carry their own fonts, which a blanket
+        // assignment would erase. Mono runs keep their face at the heading
+        // size; everything else becomes semibold system with its italic and
+        // bold traits carried over.
+        content.enumerateAttribute(
             .font,
-            value: font,
-            range: NSRange(location: 0, length: content.length)
-        )
+            in: NSRange(location: 0, length: content.length)
+        ) { value, range, _ in
+            let existing = (value as? NSFont) ?? style.bodyFont
+            let existingTraits = existing.fontDescriptor.symbolicTraits
+            var replacement: NSFont
+            if existingTraits.contains(.monoSpace) {
+                replacement = NSFont(descriptor: existing.fontDescriptor, size: size) ?? existing
+            } else {
+                replacement = .systemFont(ofSize: size, weight: .semibold)
+                let carried = existingTraits.intersection([.italic, .bold])
+                if !carried.isEmpty {
+                    let descriptor = replacement.fontDescriptor.withSymbolicTraits(
+                        replacement.fontDescriptor.symbolicTraits.union(carried)
+                    )
+                    replacement = NSFont(descriptor: descriptor, size: size) ?? replacement
+                }
+            }
+            content.addAttribute(.font, value: replacement, range: range)
+        }
         if heading.level >= 6 {
             content.addAttribute(
                 .foregroundColor,
@@ -674,6 +694,13 @@ struct MarkdownRenderer: @MainActor MarkupVisitor {
         // A fragment on a path (`README.md#usage`) is not part of the filename.
         let path = trimmed.split(separator: "#", maxSplits: 1).first.map(String.init) ?? trimmed
         guard !path.isEmpty else { return nil }
+        // A markdown destination is a URI reference, so percent-escapes decode
+        // into the real filename (`My%20Guide.md` names "My Guide.md"). Only a
+        // destination that is not a valid URI — a raw space, usually — falls
+        // back to being taken as a literal path.
+        if let uri = URL(string: path, relativeTo: baseURL), uri.isFileURL {
+            return uri.standardizedFileURL
+        }
         return URL(fileURLWithPath: path, relativeTo: baseURL).standardizedFileURL
     }
 

--- a/kero/SourceTextEditor.swift
+++ b/kero/SourceTextEditor.swift
@@ -6,7 +6,6 @@
 import AppKit
 import STPluginNeon
 import STTextView
-import SwiftUI
 
 /// Scroll offset and cursor position of a file tab's editor, kept on the
 /// `FileTab` so it survives tab switches, and in the session snapshot so it
@@ -41,28 +40,43 @@ struct EditorPalette: Equatable {
     }
 }
 
-/// STTextView wrapped for SwiftUI: plain-text editing with line numbers and
-/// the system search-and-replace find bar (⌘F / ⌥⌘F via the Edit ▸ Find menu,
-/// routed here by `FileTab.performFindAction`). Text edits are written
-/// straight back to `FileTab.text`; scroll/cursor state is written back to
-/// `FileTab.editorState` as it changes and restored when the view is
-/// recreated on tab switch or relaunch.
-struct SourceTextEditor: NSViewRepresentable {
-    let file: FileTab
-    let font: NSFont
-    let palette: EditorPalette
-    let wrapLines: Bool
-    var isFocused: Bool = true
-    var onFocused: () -> Void = {}
-    var onSplit: (PaneDropEdge) -> Void = { _ in }
+/// STTextView driven directly from AppKit: plain-text editing with line
+/// numbers and the system search-and-replace find bar (⌘F / ⌥⌘F via the Edit ▸
+/// Find menu, routed here by `FileTab.performFindAction`). Text edits are
+/// written straight back to `FileTab.text`; scroll/cursor state is written back
+/// to `FileTab.editorState` as it changes and restored when the editor is
+/// rebuilt on tab switch or relaunch.
+///
+/// Owned by `FileViewerContainerView`, which mounts and discards it as the tab
+/// switches between source and rendered markdown.
+@MainActor
+final class SourceEditorController: NSObject, STTextViewDelegate {
+    /// The editor's scroll view, for the container to install.
+    let scrollView: NSScrollView
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(file: file)
-    }
+    private let file: FileTab
+    private weak var textView: STTextView?
+    private var scrollObserver: (any NSObjectProtocol)?
+    /// Last-applied focus state, so `update` acts only on the unfocused→focused
+    /// edge rather than stealing the caret on every settings change.
+    private var wasFocused = false
 
-    func makeNSView(context: Context) -> NSScrollView {
+    init(
+        file: FileTab,
+        font: NSFont,
+        palette: EditorPalette,
+        wrapLines: Bool,
+        isFocused: Bool,
+        onFocused: @escaping () -> Void,
+        onSplit: @escaping (PaneDropEdge) -> Void
+    ) {
+        self.file = file
         let scrollView = RestorableScrollView()
+        self.scrollView = scrollView
+        super.init()
+
         let textView = FocusReportingTextView()
+        self.textView = textView
         textView.onBecomeFirstResponder = onFocused
         textView.splitTarget.onSplit = onSplit
         scrollView.wantsLayer = true
@@ -93,7 +107,7 @@ struct SourceTextEditor: NSViewRepresentable {
         // the terminal's find bar searches as you type. Off by default in
         // STTextView.
         textView.isIncrementalSearchingEnabled = true
-        apply(to: textView, scrollView: scrollView)
+        apply(font: font, palette: palette, wrapLines: wrapLines)
         textView.text = file.text
 
         // Tree-sitter syntax highlighting (STPluginNeon), for file types with
@@ -106,8 +120,8 @@ struct SourceTextEditor: NSViewRepresentable {
             textView.addPlugin(plugin)
         }
 
-        // Captured before the coordinator attaches, because its scroll
-        // observer starts overwriting `editorState` immediately.
+        // Captured before the scroll observer attaches, because it starts
+        // overwriting `editorState` immediately.
         let state = file.editorState
         if let location = state.selectionLocation {
             let limit = (textView.text ?? "").utf16.count
@@ -116,7 +130,7 @@ struct SourceTextEditor: NSViewRepresentable {
             textView.textSelection = NSRange(location: start, length: length)
         }
 
-        context.coordinator.attach(textView: textView, scrollView: scrollView)
+        attach(textView: textView, scrollView: scrollView)
 
         // Restore the saved scroll offset during the first layout pass — while
         // the frame is finally known but before the first paint — so the file
@@ -144,51 +158,49 @@ struct SourceTextEditor: NSViewRepresentable {
                 textView.window?.makeFirstResponder(textView)
             }
         }
-        context.coordinator.wasFocused = isFocused
-        // Expose the view so a pane-move drag can snapshot it as a thumbnail.
+        wasFocused = isFocused
+        // Expose the view so a pane-move drag can snapshot it as a thumbnail,
+        // and so Find menu actions can reach the text view.
         file.editorView = scrollView
-        return scrollView
     }
 
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? STTextView else { return }
-        (textView as? FocusReportingTextView)?.onBecomeFirstResponder = onFocused
-        (textView as? FocusReportingTextView)?.splitTarget.onSplit = onSplit
-        apply(to: textView, scrollView: scrollView)
+    deinit {
+        if let scrollObserver {
+            NotificationCenter.default.removeObserver(scrollObserver)
+        }
+    }
+
+    func update(
+        font: NSFont,
+        palette: EditorPalette,
+        wrapLines: Bool,
+        isFocused: Bool,
+        onFocused: @escaping () -> Void,
+        onSplit: @escaping (PaneDropEdge) -> Void
+    ) {
+        guard let textView = textView as? FocusReportingTextView else { return }
+        textView.onBecomeFirstResponder = onFocused
+        textView.splitTarget.onSplit = onSplit
+        apply(font: font, palette: palette, wrapLines: wrapLines)
         // Take focus on the unfocused→focused edge (keyboard navigation moving
-        // focus here), never on every render.
-        if isFocused, !context.coordinator.wasFocused {
+        // focus here), never on every update.
+        if isFocused, !wasFocused {
             DispatchQueue.main.async {
                 textView.window?.makeFirstResponder(textView)
             }
         }
-        context.coordinator.wasFocused = isFocused
+        wasFocused = isFocused
     }
 
-    /// Take exactly the space SwiftUI offers. Without this, SwiftUI sizes the
-    /// editor from the scroll view's `fittingSize`, which STTextView derives
-    /// from the entire document — enormous for a large file, and degenerate
-    /// for an empty one. Because the main window tracks its content's ideal
-    /// size, that runaway measurement drives the window size and drops it into
-    /// an unbounded layout loop (a hard crash: "more Layout Window passes than
-    /// there are views"). Reporting the proposed size keeps the editor a
-    /// space-filling pane that never influences the window's size.
-    func sizeThatFits(
-        _ proposal: ProposedViewSize, nsView: NSScrollView, context: Context
-    ) -> CGSize? {
-        func resolve(_ value: CGFloat?, fallback: CGFloat) -> CGFloat {
-            guard let value, value.isFinite else { return fallback }
-            return value
-        }
-        return CGSize(
-            width: resolve(proposal.width, fallback: nsView.frame.width),
-            height: resolve(proposal.height, fallback: nsView.frame.height)
-        )
+    func takeFocus() {
+        guard let textView else { return }
+        textView.window?.makeFirstResponder(textView)
     }
 
-    /// Guarded assignments: the font/color setters restyle the whole
-    /// document, and this runs on every SwiftUI render.
-    private func apply(to textView: STTextView, scrollView: NSScrollView) {
+    /// Guarded assignments: the font/color setters restyle the whole document,
+    /// and this runs on every settings or appearance change.
+    private func apply(font: NSFont, palette: EditorPalette, wrapLines: Bool) {
+        guard let textView else { return }
         if textView.font != font {
             textView.font = font
         }
@@ -209,55 +221,34 @@ struct SourceTextEditor: NSViewRepresentable {
         }
     }
 
-    @MainActor
-    final class Coordinator: NSObject, STTextViewDelegate {
-        private let file: FileTab
-        private weak var textView: STTextView?
-        private var scrollObserver: (any NSObjectProtocol)?
-        /// Last-applied focus state, so `updateNSView` can act only on the
-        /// unfocused→focused edge.
-        var wasFocused = false
-
-        init(file: FileTab) {
-            self.file = file
-        }
-
-        func attach(textView: STTextView, scrollView: NSScrollView) {
-            self.textView = textView
-            textView.textDelegate = self
-            scrollObserver = NotificationCenter.default.addObserver(
-                forName: NSView.boundsDidChangeNotification,
-                object: scrollView.contentView,
-                queue: .main
-            ) { [weak self, weak scrollView] _ in
-                MainActor.assumeIsolated {
-                    guard let self, let clipView = scrollView?.contentView else { return }
-                    self.file.editorState.scrollX = clipView.bounds.origin.x
-                    self.file.editorState.scrollY = clipView.bounds.origin.y
-                }
+    private func attach(textView: STTextView, scrollView: NSScrollView) {
+        textView.textDelegate = self
+        scrollObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self, weak scrollView] _ in
+            MainActor.assumeIsolated {
+                guard let self, let clipView = scrollView?.contentView else { return }
+                self.file.editorState.scrollX = clipView.bounds.origin.x
+                self.file.editorState.scrollY = clipView.bounds.origin.y
             }
         }
+    }
 
-        deinit {
-            if let scrollObserver {
-                NotificationCenter.default.removeObserver(scrollObserver)
-            }
-        }
+    func textViewDidChangeText(_ notification: Notification) {
+        guard let textView else { return }
+        let newText = textView.text ?? ""
+        guard newText != file.text else { return }
+        file.text = newText
+        file.refreshDirtyState()
+    }
 
-        func textViewDidChangeText(_ notification: Notification) {
-            guard let textView else { return }
-            let newText = textView.text ?? ""
-            guard newText != file.text else { return }
-            file.text = newText
-            file.refreshDirtyState()
-        }
-
-        func textViewDidChangeSelection(_ notification: Notification) {
-            guard let textView else { return }
-            let selection = textView.textSelection
-            file.editorState.selectionLocation = selection.location
-            file.editorState.selectionLength = selection.length
-        }
+    func textViewDidChangeSelection(_ notification: Notification) {
+        guard let textView else { return }
+        let selection = textView.textSelection
+        file.editorState.selectionLocation = selection.location
+        file.editorState.selectionLength = selection.length
     }
 }
 

--- a/kero/SyntaxHighlightPlugin.swift
+++ b/kero/SyntaxHighlightPlugin.swift
@@ -208,14 +208,16 @@ final class SyntaxHighlightCoordinator {
     /// concealment, and the explicit "no highlight" marker. Grammars attach
     /// these alongside real captures (e.g. Swift's `@comment @spell`), so they
     /// must be dropped rather than resolved to a color.
-    private static let ignoredCaptures: Set<String> = ["spell", "nospell", "conceal", "none"]
+    /// Also read by `MarkdownCodeHighlighter`, which colors preview code
+    /// fences through the same capture-name rules.
+    static let ignoredCaptures: Set<String> = ["spell", "nospell", "conceal", "none"]
 
     /// The theme color for a tree-sitter capture name, trying the most specific
     /// name first and shortening on each dot (`variable.parameter` → `variable`),
     /// then the theme's `plain` default. The merged queries carry finer-grained
     /// capture names than the theme enumerates, so exact-match alone would leave
     /// many tokens uncolored.
-    private static func themeColor(for name: String, theme: STPluginNeonAppKit.Theme) -> NSColor? {
+    static func themeColor(for name: String, theme: STPluginNeonAppKit.Theme) -> NSColor? {
         var key = name
         while true {
             if let color = theme.color(forToken: TokenName(key)) {

--- a/kero/SyntaxHighlighting.swift
+++ b/kero/SyntaxHighlighting.swift
@@ -49,7 +49,7 @@ enum SyntaxLanguage: Hashable {
     }
 }
 
-/// Tree-sitter syntax highlighting for the source editor. `SourceTextEditor`
+/// Tree-sitter syntax highlighting for the source editor. `SourceEditorController`
 /// asks for a plugin per file; unsupported file types get `nil` and render as
 /// plain text. The highlighter itself lives in `SyntaxHighlightPlugin`.
 enum SyntaxHighlighting {

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -508,6 +508,22 @@ final class TerminalManager: nonisolated ObservableObject {
         }
     }
 
+    /// Swaps the focused markdown file between its rendered form and its
+    /// source. The choice is global (see `MarkdownViewPreferences`), so every
+    /// markdown tab follows — the same way the diff viewer's review/edit
+    /// choice carries across diffs.
+    func toggleMarkdownPreview() {
+        guard canToggleMarkdownPreview else { return }
+        MarkdownViewPreferences.shared.showsSource.toggle()
+    }
+
+    /// Whether the focused pane is a markdown file, the only kind with a
+    /// rendered form to toggle to.
+    var canToggleMarkdownPreview: Bool {
+        guard case .file(let file)? = selectedProject?.focusedContent else { return false }
+        return FileViewerContainerView.isMarkdown(file.path)
+    }
+
     /// Whether the Find menu has something searchable on screen right now.
     /// Diffs render their own views rather than a searchable text view.
     var canFind: Bool {
@@ -518,10 +534,12 @@ final class TerminalManager: nonisolated ObservableObject {
     }
 
     /// Whether Find and Replace has an editable pane to act on: terminal
-    /// output and diffs are read-only, so replace is only offered for a file.
+    /// output and diffs are read-only, so replace is only offered for a file —
+    /// and not for a markdown file showing its rendered form, which is a
+    /// read-only projection with nothing to replace into.
     var canReplace: Bool {
-        if case .file? = selectedProject?.focusedContent { return true }
-        return false
+        guard case .file(let file)? = selectedProject?.focusedContent else { return false }
+        return !file.showsRenderedMarkdown
     }
 
     /// Closes the focused pane (⌘W). When it's the last pane in its tab the

--- a/kero/keroApp.swift
+++ b/kero/keroApp.swift
@@ -205,6 +205,14 @@ private struct KeroCommands: Commands {
             }
             .keyboardShortcut("i", modifiers: [.command, .shift])
             .disabled(manager?.selectedProject == nil)
+
+            Divider()
+
+            Button("Toggle Markdown Preview") {
+                manager?.toggleMarkdownPreview()
+            }
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            .disabled(manager?.canToggleMarkdownPreview != true)
         }
 
         CommandMenu("Projects") {


### PR DESCRIPTION
Closes #84.

Selecting a `.md` file showed its raw source. This renders it instead, with a chip in the corner of the pane that switches to the source and back.

## Render samples

Renderer output through the preview's own TextKit stack (standalone harness, neutral light palette — in-app it follows the terminal theme):

<img width="720" alt="CONTRIBUTING.md rendered" src="https://raw.githubusercontent.com/markxiong0122/kero/md-preview-assets/preview-contributing.png" />

<img width="680" alt="Tables with per-column alignment, blockquote, nested lists, task boxes, rule, code fence" src="https://raw.githubusercontent.com/markxiong0122/kero/md-preview-assets/preview-blocks.png" />

## What renders

Headings, paragraphs, emphasis/strong/strikethrough, links, inline code, nested lists with task checkboxes, blockquotes, thematic breaks, GFM tables, local and remote images, and fenced code blocks.

Fenced code reuses the editor's own tree-sitter grammars and palette through the shared `HighlightQueryCache`, so a ` ```swift ` block in a preview looks like the same block open in a tab beside it. The editor's highlighter itself can't be reused — it drives Neon incrementally against a live TextKit 2 content manager — so `MarkdownCodeHighlighter` takes the same path the editor uses for *injected* regions: parse once, run the highlights query, color the ranges.

## Two decisions worth flagging

**The preview runs on TextKit 1.** `MarkdownRenderer` expresses blockquote bars, code backgrounds and table grids as `NSTextBlock`/`NSTextTable`, which TextKit 2 does not lay out at all. Hand-rolling table layout to avoid them would have cost far more code than the preview is worth. The editor stays TextKit 2 (STTextView); only the preview drops back, and only because it is a short, read-only, immutable document where TextKit 2's incremental editing wins buy nothing.

**Remote images are fetched.** README badges are the common case, so opening a preview can tell an image's host that the file was viewed. Flagging it explicitly in case that trade isn't wanted — it is easy to gate behind a setting or drop to local-only.

## Mode switching

The rendered view is a projection of `FileTab.text`, not a second buffer, so dirty tracking and saving are untouched and edits made in the source appear on switching back. Both views stay alive across a toggle — rebuilding the editor would hand it a fresh `STTextView` and with it a fresh undo manager, silently discarding everything ⌘Z could have undone.

The choice is global and persisted in `UserDefaults`, mirroring how `DiffViewPreferences` already carries the diff viewer's review/edit choice across diffs. ⇧⌘V and a command palette entry drive the same toggle.

## AppKit migration

Adding a second way to view a file tab materially changes its UI, so per CLAUDE.md the container moved off SwiftUI: `FileViewerContainerView` now owns the editor, preview, image and placeholder views and the switching between them, and `SourceTextEditor`'s `NSViewRepresentable` became `SourceEditorController`. `FileViewerView` is a thin representable over it, keeping the `sizeThatFits` guard that stops the window from measuring the whole document.

## Scope

`.md` only. `.markdown`/`.mdown`/`.mkd` still open as source — a one-line change if wanted. Local file links open in the default app rather than as a new tab. Task checkboxes render but are not interactive, and there is no in-document anchor navigation, so `[Usage](#usage)` renders styled but inert rather than opening a bogus path.

## Verification

Built and run on macOS. The renderer was additionally exercised outside the app target against real documents, asserting structure rather than eyeballing it: table cells carry `NSTextTableBlock`, blockquotes carry a left-border block, nested lists produce distinct indents, `**bold _and italic_**` composes into one font with both traits, oversized images scale into the column, and link destinations resolve as expected.

Two pre-existing warnings are mirrored in `MarkdownCodeHighlighter.swift:97-98` (non-Sendable `OpaquePointer` capture, weak/strong capture mismatch); they match `SyntaxHighlightPlugin.swift:413-414`, the code that path was adapted from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XPTmUZMoJF16npJz5jnzM
