### PR TITLE
Add Cmd-click to open files in their default app

### DIFF
--- a/kero/RightSidebarView.swift
+++ b/kero/RightSidebarView.swift
@@ -471,7 +471,9 @@ private struct FileTreeRow: View {
 
     private var rowButton: some View {
         Button {
-            if item.isDirectory {
+            if !item.isDirectory && NSEvent.modifierFlags.contains(.command) {
+                NSWorkspace.shared.open(URL(fileURLWithPath: item.path))
+            } else if item.isDirectory {
                 model.toggle(item)
             } else {
                 openFile(item.path)


### PR DESCRIPTION
## What changed

- Cmd-click on a file row in the file tree opens it with `NSWorkspace.shared.open`, which is already available in the row's context menu item as "Open in Default App".
- Directories are unaffected — Cmd-click still toggles expand/collapse.
- A plain click still opens the file in Kero as before.

## Why

The file tree already exposes "Open in Default App" via right-click, but reaching it takes two steps. Cmd-click is the standard Finder/VS Code convention for "open outside the app" and gives the same result in one gesture.

## Verification

- I ran the app and command clicked away in the UI. it was an incredible experience. so good you'll want it too.