### PR TITLE
Add guarded pane and agent automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Automate project-scoped panes and coding agents from Kero terminals with guarded `+pane` and `+agent` commands, one-click AI setup, semantic status badges, completion notifications, and attention navigation
+
 ## [0.1.44]
 
 - Prevent a rare crash while using the Ctrl-Tab switcher

--- a/kero/AgentAutomation.swift
+++ b/kero/AgentAutomation.swift
@@ -1,0 +1,1015 @@
+//
+//  AgentAutomation.swift
+//  kero
+//
+
+import AppKit
+import Foundation
+
+enum KeroAgentKind: String, CaseIterable, Codable, Sendable {
+    case codex
+    case claude
+    case gemini
+    case opencode
+    case cursor = "cursor-agent"
+    case aider
+    case amp
+    case pi
+
+    var displayName: String {
+        switch self {
+        case .codex: return "Codex"
+        case .claude: return "Claude Code"
+        case .gemini: return "Gemini CLI"
+        case .opencode: return "OpenCode"
+        case .cursor: return "Cursor Agent"
+        case .aider: return "Aider"
+        case .amp: return "Amp"
+        case .pi: return "Pi"
+        }
+    }
+
+    var executable: String { rawValue }
+
+    static func recognize(processID: pid_t) -> Self? {
+        recognize(
+            executablePath: processExecutablePath(pid: processID),
+            arguments: processArguments(pid: processID) ?? []
+        )
+    }
+
+    static func recognize(
+        executablePath: String?,
+        arguments: [String] = []
+    ) -> Self? {
+        // argv[0] preserves the invoked symlink for versioned native installs
+        // such as Claude and `exec -a` wrappers such as Cursor Agent.
+        for value in [arguments.first, executablePath].compactMap({ $0 }) {
+            if let kind = recognizeCommandName(value) { return kind }
+        }
+
+        guard let executablePath,
+              isScriptInterpreter((executablePath as NSString).lastPathComponent)
+        else { return nil }
+
+        let tail = Array(arguments.dropFirst().prefix(8))
+        if let moduleFlag = tail.firstIndex(of: "-m"),
+           tail.indices.contains(moduleFlag + 1),
+           let kind = recognizeScriptIdentity(tail[moduleFlag + 1]) {
+            return kind
+        }
+
+        // For the supported wrappers the first non-option operand identifies
+        // the script. Stop there rather than scanning prompts or user paths,
+        // which would make ordinary interpreter jobs look like agents.
+        for value in tail {
+            if value.hasPrefix("-") || value == "run" { continue }
+            return recognizeScriptIdentity(value)
+        }
+        return nil
+    }
+
+    private static func recognizeCommandName(_ value: String) -> Self? {
+        var name = (value as NSString).lastPathComponent.lowercased()
+        for suffix in [".exe", ".js", ".mjs", ".cjs", ".py"] where name.hasSuffix(suffix) {
+            name.removeLast(suffix.count)
+            break
+        }
+        switch name {
+        case "codex": return .codex
+        case "claude": return .claude
+        case "gemini": return .gemini
+        case "opencode": return .opencode
+        case "cursor-agent": return .cursor
+        case "aider", "aider-chat": return .aider
+        case "amp": return .amp
+        case "pi": return .pi
+        default: return nil
+        }
+    }
+
+    private static func isScriptInterpreter(_ value: String) -> Bool {
+        let name = value.lowercased()
+        return name == "node" || name == "nodejs" || name == "bun"
+            || name == "deno" || name == "python" || name.hasPrefix("python3")
+            || name == "ruby" || name == "bash" || name == "sh" || name == "zsh"
+    }
+
+    private static func recognizeScriptIdentity(_ value: String) -> Self? {
+        if let kind = recognizeCommandName(value) { return kind }
+        let normalized = value.lowercased().replacingOccurrences(of: "\\", with: "/")
+        if normalized.contains("/@openai/codex/") { return .codex }
+        if normalized.contains("/@anthropic-ai/claude-code/") { return .claude }
+        if normalized.contains("/gemini-cli/") { return .gemini }
+        if normalized.contains("/opencode-ai/") { return .opencode }
+        if normalized.contains("/cursor-agent/") { return .cursor }
+        if normalized.contains("/aider-chat/") || normalized.contains("/aider_chat/") {
+            return .aider
+        }
+        if normalized.contains("/sourcegraph/amp/") { return .amp }
+        if normalized.contains("/pi-coding-agent/") { return .pi }
+        return nil
+    }
+}
+
+enum KeroAgentPhase: String, Codable, CaseIterable, Sendable {
+    case created
+    case working
+    case blocked
+    case done
+    case idle
+    case unknown
+
+    fileprivate var rollupPriority: Int {
+        switch self {
+        case .blocked: return 6
+        case .done: return 5
+        case .working: return 4
+        case .unknown: return 3
+        case .created: return 2
+        case .idle: return 1
+        }
+    }
+}
+
+enum KeroAgentStateAuthority: String, Codable, Sendable {
+    /// A native agent hook or plugin reported a complete lifecycle event.
+    case integration
+    /// Kero classified the live terminal UI after repeated observations.
+    case screen
+    /// Kero recognized the foreground executable.
+    case process
+    /// Kero just launched or prompted the agent and is awaiting observation.
+    case command
+}
+
+private enum KeroAgentScreenDisposition {
+    case working
+    case blocked
+    case idle
+    case hold
+}
+
+private struct KeroAgentScreenSnapshot {
+    let fingerprint: Int
+    let disposition: KeroAgentScreenDisposition
+}
+
+/// A compact, deliberately conservative subset of Herdr's terminal-manifest
+/// model. The process identity selects the rules; terminal text never decides
+/// which agent is running. Agents without a specific working rule still use
+/// the debounced, post-activity idle fallback instead of model self-reporting.
+private nonisolated enum KeroAgentScreenClassifier {
+    static func snapshot(
+        kind: KeroAgentKind,
+        title: String,
+        visibleText: String
+    ) -> KeroAgentScreenSnapshot {
+        var hasher = Hasher()
+        hasher.combine(title)
+        hasher.combine(visibleText)
+
+        let lowerTitle = title.lowercased()
+        let recentLines = visibleText
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .suffix(12)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+        let recent = recentLines.joined(separator: "\n").lowercased()
+        let evidence = lowerTitle + "\n" + recent
+
+        let disposition: KeroAgentScreenDisposition
+        if isTranscriptOrPicker(kind: kind, recent: recent) {
+            disposition = .hold
+        } else if isBlocked(evidence) {
+            disposition = .blocked
+        } else if isWorking(
+            kind: kind,
+            lowerTitle: lowerTitle,
+            recent: recent,
+            recentLines: recentLines
+        ) {
+            disposition = .working
+        } else {
+            // This is Herdr's known-agent idle fallback: once task activity
+            // has actually been observed, no working/blocker rule means the
+            // interactive agent has settled. The caller debounces publication.
+            disposition = .idle
+        }
+
+        return KeroAgentScreenSnapshot(
+            fingerprint: hasher.finalize(), disposition: disposition
+        )
+    }
+
+    private static func isTranscriptOrPicker(
+        kind: KeroAgentKind,
+        recent: String
+    ) -> Bool {
+        if recent.contains("showing detailed transcript") { return true }
+        if recent.contains("select model")
+            && recent.contains("esc to cancel") { return true }
+        guard kind == .codex else { return false }
+        let scrolling = recent.contains("↑/↓ to scroll")
+            || recent.contains("pgup/pgdn")
+            || recent.contains("home/end to jump")
+        return scrolling && recent.contains("q to quit")
+    }
+
+    private static func isBlocked(_ recent: String) -> Bool {
+        let strongSignals = [
+            "action required",
+            "permission required",
+            "plugin confirmation needed",
+            "waiting for approval",
+            "waiting for user confirmation",
+            "waiting for permission",
+            "allow command?",
+            "allow execution",
+            "apply this change",
+            "run this command?",
+            "write to this file?",
+            "reject & propose changes",
+            "skip (esc or n)",
+            "keep (n)",
+            "invoke tool",
+            "allow editing file:",
+            "allow creating file:",
+            "confirm tool call",
+            "deny with feedback",
+            "enter to submit answer",
+            "enter to submit all",
+            "do you want to allow this connection?",
+            "tab to amend",
+            "ctrl+e to explain",
+            "review your answers",
+            "skip interview and plan immediately",
+            "(y) (enter)",
+            "[y/n]",
+        ]
+        if strongSignals.contains(where: recent.contains) { return true }
+        if recent.contains("do you want to proceed")
+            && (recent.contains("yes") || recent.contains("esc to cancel")) {
+            return true
+        }
+        if recent.contains("would you like to")
+            && (recent.contains("yes") || recent.contains("❯")) {
+            return true
+        }
+        return recent.contains("enter to confirm")
+            && recent.contains("esc to cancel")
+    }
+
+    private static func isWorking(
+        kind: KeroAgentKind,
+        lowerTitle: String,
+        recent: String,
+        recentLines: [String]
+    ) -> Bool {
+        switch kind {
+        case .pi:
+            return recent.contains("working...")
+        case .codex:
+            return hasBraillePrefix(lowerTitle)
+                || (recent.contains("working (")
+                    && recent.contains("esc to interrupt"))
+        case .claude:
+            return hasBraillePrefix(lowerTitle)
+                || (recent.contains("/btw") && recent.contains("esc to close"))
+        case .gemini:
+            return recent.contains("esc to cancel")
+        case .opencode:
+            return recent.contains("esc to interrupt")
+                || recent.contains("ctrl+c to interrupt")
+                || recent.contains("■■■■")
+                || recent.contains("⬝⬝⬝⬝")
+        case .cursor:
+            return recent.contains("ctrl+c to stop")
+                || recentLines.contains(where: hasCursorBackgroundTaskLine)
+                || recentLines.contains(where: hasSpinnerVerbPrefix)
+        case .amp:
+            return hasBraillePrefix(lowerTitle)
+                || recent.contains("esc to cancel")
+                || recentLines.contains(where: hasAmpStatusLine)
+        case .aider:
+            return false
+        }
+    }
+
+    private static func hasBraillePrefix(_ value: String) -> Bool {
+        guard let scalar = value.unicodeScalars.first else { return false }
+        return (0x2800...0x28ff).contains(Int(scalar.value))
+    }
+
+    private static func hasSpinnerVerbPrefix(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard let first = trimmed.unicodeScalars.first else { return false }
+        let spinner = first.value == 0x2b21 || first.value == 0x2b22
+            || (0x2800...0x28ff).contains(Int(first.value))
+        guard spinner else { return false }
+        let words = trimmed.lowercased().split(whereSeparator: { !$0.isLetter })
+        guard let verb = words.dropFirst().first else { return false }
+        return verb.hasSuffix("ing")
+    }
+
+    private static func hasCursorBackgroundTaskLine(_ line: String) -> Bool {
+        let words = line.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        guard let count = words.first, Int(count) != nil else { return false }
+        return words.dropFirst().first == "background"
+            && words.dropFirst(2).first?.hasPrefix("task") == true
+    }
+
+    private static func hasAmpStatusLine(_ line: String) -> Bool {
+        let lower = line.lowercased().trimmingCharacters(in: .whitespaces)
+        guard lower.hasPrefix("╰"), lower.contains("─") else { return false }
+        return [" thinking ", " streaming ", " running tools ", " waiting "]
+            .contains(where: lower.contains)
+    }
+}
+
+struct KeroAgentStatus: Equatable, Sendable {
+    let alias: String
+    let kind: KeroAgentKind
+    let phase: KeroAgentPhase
+    let authority: KeroAgentStateAuthority
+    let reason: String
+    let updatedAt: Date
+    let processID: pid_t?
+    /// Completion remains unseen until the pane itself receives focus. Reads
+    /// through the automation API deliberately do not mutate this bit.
+    let unseen: Bool
+}
+
+struct KeroAgentRollup: Equatable {
+    let phase: KeroAgentPhase
+    let count: Int
+}
+
+enum KeroAutomationReadError: Error {
+    case agentNotIdle
+}
+
+/// Mutable evidence kept beside a `TerminalSession`. It is separate from the
+/// published status so unchanged polling never invalidates AppKit/SwiftUI view
+/// trees.
+@MainActor
+final class KeroAgentObservationState {
+    var declaredKind: KeroAgentKind?
+    var alias: String?
+    var lastForegroundPID: pid_t?
+    var integrationPhase: KeroAgentPhase?
+    var integrationReason: String?
+    var screenPromptedAt: Date?
+    var lastScreenFingerprint: Int?
+    var screenChangeCount = 0
+    var screenObservedWorking = false
+    var screenIdleConfirmations = 0
+    var isCollectingAlternateScreenHistory = false
+    /// A Kero-launched process is `created` until its first guarded prompt.
+    /// This lifecycle fact does not require guessing how the CLI renders UI.
+    var awaitingInitialPrompt = false
+    /// Shell input is asynchronous. Keep a freshly declared launch working
+    /// briefly so the monitor cannot mistake the still-foreground shell for
+    /// an agent that already exited before it has consumed the command.
+    var commandGraceDeadline: Date?
+
+    func beginScreenObservation(fingerprint: Int, at date: Date = Date()) {
+        screenPromptedAt = date
+        lastScreenFingerprint = fingerprint
+        screenChangeCount = 0
+        screenObservedWorking = false
+        screenIdleConfirmations = 0
+    }
+
+    func resetScreenObservation() {
+        screenPromptedAt = nil
+        lastScreenFingerprint = nil
+        screenChangeCount = 0
+        screenObservedWorking = false
+        screenIdleConfirmations = 0
+    }
+}
+
+@MainActor
+final class AgentAutomationMonitor {
+    static let shared = AgentAutomationMonitor()
+
+    private let sessions = NSHashTable<TerminalSession>.weakObjects()
+    private var timer: Timer?
+
+    private init() {}
+
+    func register(_ session: TerminalSession) {
+        sessions.add(session)
+        guard timer == nil else { return }
+        let timer = Timer(timeInterval: 0.75, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func refresh() {
+        let liveSessions = sessions.allObjects.filter { !$0.hasExited }
+        for session in liveSessions {
+            session.refreshAutomationAgentState(
+                isFocused: TerminalManager.automationIsSessionFocused(session.id)
+            )
+        }
+        if liveSessions.isEmpty {
+            timer?.invalidate()
+            timer = nil
+        }
+    }
+}
+
+extension TerminalSession {
+    var isShellAvailableForAutomation: Bool {
+        guard !hasExited, let shellPid, shellPid > 0 else { return false }
+        return surface.foregroundPid == shellPid
+            && commandLifecycle.phase != .executing
+    }
+
+    func isAutomationAgentRunning(kind: KeroAgentKind) -> Bool {
+        guard let foreground = surface.foregroundPid,
+              foreground != shellPid else { return false }
+        return KeroAgentKind.recognize(processID: foreground) == kind
+    }
+
+    /// Bounded viewport text for automation reads and diagnostics. Reading
+    /// does not call `markAutomationAgentSeen()`.
+    func automationVisibleText(maxLines: Int, maxColumns: Int) -> String {
+        let boundedLines = min(max(maxLines, 1), 500)
+        let boundedColumns = min(max(maxColumns, 1), 2_000)
+        guard let text = surface.readVisibleText(
+            maxLines: boundedLines, maxColumns: boundedColumns
+        ) else { return "" }
+        var lines = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0.prefix(boundedColumns)) }
+        while lines.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            lines.removeLast()
+        }
+        return lines.suffix(boundedLines).joined(separator: "\n")
+    }
+
+    /// Recent host history for automation result reads. Unlike lifecycle
+    /// detection, this deliberately asks the backend for bounded scrollback.
+    func automationRecentText(maxLines: Int, maxColumns: Int) -> String {
+        let boundedLines = min(max(maxLines, 1), 500)
+        let boundedColumns = min(max(maxColumns, 1), 2_000)
+        return TerminalHistorySerializer.previewText(
+            from: surface,
+            maxLines: boundedLines,
+            maxColumns: boundedColumns
+        ) ?? automationVisibleText(
+            maxLines: boundedLines,
+            maxColumns: boundedColumns
+        )
+    }
+
+    /// Collects older transcript pages from an idle full-screen agent when its
+    /// alternate buffer has no host scrollback. Every page overlaps the prior
+    /// page, and the same wheel interface is driven back to the live bottom
+    /// before the read completes. Unsupported applications simply return the
+    /// passive recent snapshot after the first wheel event changes nothing.
+    func automationReadText(
+        maxLines: Int,
+        maxColumns: Int,
+        requireIdleAgentForHistory: Bool
+    ) async throws -> String {
+        let boundedLines = min(max(maxLines, 1), 500)
+        let boundedColumns = min(max(maxColumns, 1), 2_000)
+        let recent = automationRecentText(
+            maxLines: boundedLines,
+            maxColumns: boundedColumns
+        )
+        let recentLines = Self.automationLines(recent)
+        guard recentLines.count < boundedLines,
+              !TerminalHistorySerializer.hasPrimaryScrollback(surface),
+              terminalIsAtLiveBottom,
+              let status = agentStatus,
+              isAutomationAgentRunning(kind: status.kind),
+              !agentObservation.isCollectingAlternateScreenHistory
+        else { return recent }
+
+        guard status.phase == .idle || status.phase == .done else {
+            if requireIdleAgentForHistory { throw KeroAutomationReadError.agentNotIdle }
+            return recent
+        }
+
+        var latestPage = Self.automationLines(
+            automationVisibleText(
+                maxLines: boundedLines,
+                maxColumns: boundedColumns
+            )
+        )
+        guard !latestPage.isEmpty else { return recent }
+
+        var collected = latestPage
+        let pageStep = min(max(latestPage.count - 4, 4), 50)
+        var pagesMoved = 0
+        agentObservation.isCollectingAlternateScreenHistory = true
+        defer { agentObservation.isCollectingAlternateScreenHistory = false }
+
+        while collected.count < boundedLines, pagesMoved < 32 {
+            guard surface.sendApplicationScroll(lines: pageStep) else { break }
+            pagesMoved += 1
+            try? await Task.sleep(for: .milliseconds(90))
+
+            let olderPage = Self.automationLines(
+                automationVisibleText(
+                    maxLines: boundedLines,
+                    maxColumns: boundedColumns
+                )
+            )
+            guard !olderPage.isEmpty, olderPage != latestPage else { break }
+            let merged = Self.prependingAutomationPage(
+                olderPage,
+                previousPage: latestPage,
+                collected: collected
+            )
+            guard merged != collected else { break }
+            collected = merged
+            latestPage = olderPage
+        }
+
+        if pagesMoved > 0 {
+            // Each downward batch is at least as large as the upward page step;
+            // two extra batches cover applications that clamp one wheel burst.
+            for _ in 0..<(pagesMoved + 2) {
+                guard surface.sendApplicationScroll(lines: -50) else { break }
+            }
+            try? await Task.sleep(for: .milliseconds(120))
+        }
+
+        return collected.suffix(boundedLines).joined(separator: "\n")
+    }
+
+    private static func automationLines(_ text: String) -> [String] {
+        var lines = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        while lines.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func prependingAutomationPage(
+        _ olderPage: [String],
+        previousPage: [String],
+        collected: [String]
+    ) -> [String] {
+        var olderContent = olderPage
+
+        // Full-screen agents often pin an input/status footer while their
+        // transcript scrolls. Drop one copy before looking for page overlap.
+        let maximumFooter = min(8, min(olderPage.count, previousPage.count))
+        var sharedFooter = 0
+        if maximumFooter > 0 {
+            for count in stride(from: maximumFooter, through: 1, by: -1)
+            where Array(olderPage.suffix(count)) == Array(previousPage.suffix(count)) {
+                sharedFooter = count
+                break
+            }
+        }
+        if sharedFooter > 0 { olderContent.removeLast(sharedFooter) }
+        guard !olderContent.isEmpty else { return collected }
+
+        let maximumOverlap = min(olderContent.count, collected.count)
+        var overlap = 0
+        if maximumOverlap > 0 {
+            for count in stride(from: maximumOverlap, through: 1, by: -1)
+            where Array(olderContent.suffix(count)) == Array(collected.prefix(count)) {
+                overlap = count
+                break
+            }
+        }
+        return Array(olderContent.dropLast(overlap)) + collected
+    }
+
+    func declareAutomationAgent(alias: String, kind: KeroAgentKind) {
+        agentObservation.alias = alias
+        agentObservation.declaredKind = kind
+        agentObservation.integrationPhase = nil
+        agentObservation.integrationReason = nil
+        agentObservation.resetScreenObservation()
+        agentObservation.awaitingInitialPrompt = true
+        agentObservation.commandGraceDeadline = Date().addingTimeInterval(5)
+        updateAutomationAgentStatus(
+            alias: alias,
+            kind: kind,
+            phase: .working,
+            authority: .command,
+            reason: "Kero launched \(kind.displayName)",
+            processID: nil,
+            unseen: false
+        )
+    }
+
+    func markAutomationAgentPrompted() {
+        guard let status = agentStatus else { return }
+        agentObservation.integrationPhase = nil
+        agentObservation.integrationReason = nil
+        agentObservation.awaitingInitialPrompt = false
+        agentObservation.commandGraceDeadline = nil
+        agentObservation.beginScreenObservation(
+            fingerprint: automationAgentScreenSnapshot(kind: status.kind).fingerprint
+        )
+        updateAutomationAgentStatus(
+            alias: status.alias,
+            kind: status.kind,
+            phase: .working,
+            authority: .command,
+            reason: "Prompt submitted",
+            processID: surface.foregroundPid,
+            unseen: false
+        )
+    }
+
+    func reportAutomationAgent(
+        phase: KeroAgentPhase,
+        reason: String?
+    ) -> Bool {
+        let foreground = surface.foregroundPid
+        let rememberedProcess = agentStatus?.processID
+        let recognized = [rememberedProcess, foreground]
+            .compactMap { $0 }
+            .lazy
+            .compactMap { processID -> (pid_t, KeroAgentKind)? in
+                KeroAgentKind.recognize(processID: processID).map { (processID, $0) }
+            }
+            .first
+        guard let (processID, detected) = recognized else { return false }
+        let kind = agentStatus?.kind ?? agentObservation.declaredKind ?? detected
+        guard kind == detected else { return false }
+        let alias = agentStatus?.alias ?? agentObservation.alias ?? kind.rawValue
+        agentObservation.alias = alias
+        agentObservation.declaredKind = kind
+        let focused = TerminalManager.automationIsSessionFocused(id)
+        agentObservation.integrationPhase = phase
+        agentObservation.integrationReason = reason
+        agentObservation.commandGraceDeadline = nil
+        if phase == .working || phase == .blocked {
+            agentObservation.beginScreenObservation(
+                fingerprint: automationAgentScreenSnapshot(kind: kind).fingerprint
+            )
+        } else {
+            agentObservation.resetScreenObservation()
+        }
+
+        // A newly launched interactive CLI commonly publishes its initial idle
+        // event before Kero submits any task. Keep the deliberate `created`
+        // state; readiness is process recognition, not a disposable lifecycle
+        // turn that should appear as background completion.
+        if agentObservation.awaitingInitialPrompt, phase == .idle {
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: .created,
+                authority: .process,
+                reason: "Agent process created; no task has been submitted",
+                processID: processID,
+                unseen: false
+            )
+            return true
+        }
+
+        let presentedPhase = automationPresentedPhase(
+            integrationPhase: phase,
+            isFocused: focused
+        )
+        updateAutomationAgentStatus(
+            alias: alias,
+            kind: kind,
+            phase: presentedPhase,
+            authority: .integration,
+            reason: reason ?? "Reported by native agent integration",
+            processID: processID,
+            unseen: presentedPhase == .done
+        )
+        return true
+    }
+
+    func markAutomationAgentSeen() {
+        guard let status = agentStatus, status.phase == .done || status.unseen else { return }
+        guard isAutomationAgentRunning(kind: status.kind) else {
+            clearAutomationAgentStatus()
+            return
+        }
+        if status.authority == .screen {
+            agentObservation.integrationPhase = nil
+            agentObservation.integrationReason = nil
+        } else {
+            agentObservation.integrationPhase = .idle
+            agentObservation.integrationReason = "Completion viewed"
+        }
+        updateAutomationAgentStatus(
+            alias: status.alias,
+            kind: status.kind,
+            phase: .idle,
+            authority: status.authority,
+            reason: "Completion viewed",
+            processID: status.processID,
+            unseen: false
+        )
+    }
+
+    private func automationAgentScreenSnapshot(
+        kind: KeroAgentKind
+    ) -> KeroAgentScreenSnapshot {
+        KeroAgentScreenClassifier.snapshot(
+            kind: kind,
+            title: title,
+            visibleText: automationVisibleText(maxLines: 80, maxColumns: 500)
+        )
+    }
+
+    /// Integrations publish the semantic idle state. `done` is Kero's unseen
+    /// presentation of that same state, not something a model must announce.
+    private func automationPresentedPhase(
+        integrationPhase: KeroAgentPhase,
+        isFocused: Bool
+    ) -> KeroAgentPhase {
+        switch integrationPhase {
+        case .idle, .done:
+            return isFocused ? .idle : .done
+        default:
+            return integrationPhase
+        }
+    }
+
+    /// Herdr treats a known agent with no matching working/blocker rule as
+    /// idle, then publishes that idle state as done when it is unseen. Kero
+    /// adds a post-prompt activity gate because its terminal exports are
+    /// sampled less frequently than Herdr's in-memory bottom-buffer reader.
+    private func automationScreenFallback(
+        kind: KeroAgentKind,
+        isFocused: Bool,
+        now: Date = Date()
+    ) -> (phase: KeroAgentPhase, reason: String)? {
+        guard terminalIsAtLiveBottom,
+              let promptedAt = agentObservation.screenPromptedAt else { return nil }
+        let snapshot = automationAgentScreenSnapshot(kind: kind)
+        if snapshot.fingerprint != agentObservation.lastScreenFingerprint {
+            agentObservation.lastScreenFingerprint = snapshot.fingerprint
+            agentObservation.screenChangeCount += 1
+            agentObservation.screenIdleConfirmations = 0
+        }
+
+        switch snapshot.disposition {
+        case .hold:
+            agentObservation.screenIdleConfirmations = 0
+            return nil
+        case .working:
+            agentObservation.screenObservedWorking = true
+            agentObservation.screenIdleConfirmations = 0
+            return (.working, "Working terminal UI detected")
+        case .blocked:
+            agentObservation.screenObservedWorking = true
+            agentObservation.screenIdleConfirmations = 0
+            return (.blocked, "Terminal UI is waiting for input")
+        case .idle:
+            let elapsed = now.timeIntervalSince(promptedAt)
+            let activityObserved = agentObservation.screenObservedWorking
+                || agentObservation.screenChangeCount >= 2
+                || (agentObservation.screenChangeCount >= 1 && elapsed >= 3)
+            guard activityObserved else { return nil }
+            agentObservation.screenIdleConfirmations += 1
+            guard agentObservation.screenIdleConfirmations >= 3 else { return nil }
+            return (
+                isFocused ? .idle : .done,
+                "Terminal UI settled after task activity"
+            )
+        }
+    }
+
+    fileprivate func refreshAutomationAgentState(isFocused: Bool) {
+        if isFocused { markAutomationAgentSeen() }
+
+        // Collecting transcript pages deliberately moves a full-screen agent's
+        // own viewport. Those screen changes are reads, not lifecycle evidence.
+        if agentObservation.isCollectingAlternateScreenHistory { return }
+
+        let foreground = surface.foregroundPid
+        let shell = shellPid
+        let processIsAgent = foreground != nil && foreground != shell
+        let detectedKind = processIsAgent
+            ? foreground.flatMap(KeroAgentKind.recognize(processID:))
+            : nil
+        let kind = detectedKind
+        if detectedKind != nil {
+            agentObservation.commandGraceDeadline = nil
+        }
+
+        if foreground != agentObservation.lastForegroundPID {
+            agentObservation.lastForegroundPID = foreground
+            if !processIsAgent {
+                agentObservation.integrationPhase = nil
+                agentObservation.integrationReason = nil
+            }
+        }
+
+        guard let kind else {
+            guard let previous = agentStatus else { return }
+            if !processIsAgent {
+                if previous.phase == .working,
+                   previous.authority == .command,
+                   let deadline = agentObservation.commandGraceDeadline,
+                   Date() < deadline {
+                    return
+                }
+                clearAutomationAgentStatus()
+            }
+            return
+        }
+
+        let alias = agentObservation.alias ?? agentStatus?.alias ?? kind.rawValue
+        agentObservation.alias = alias
+        let declaredKind = agentObservation.declaredKind
+        agentObservation.declaredKind = kind
+
+        if let phase = agentObservation.integrationPhase,
+           phase != .working, phase != .blocked {
+            let normalized = automationPresentedPhase(
+                integrationPhase: phase,
+                isFocused: isFocused
+            )
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: normalized,
+                authority: .integration,
+                reason: agentObservation.integrationReason
+                    ?? "Reported by native agent integration",
+                processID: foreground,
+                unseen: normalized == .done
+            )
+            return
+        }
+
+        if agentObservation.awaitingInitialPrompt, declaredKind == kind {
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: .created,
+                authority: .process,
+                reason: "Agent process created; no task has been submitted",
+                processID: foreground,
+                unseen: false
+            )
+            return
+        }
+
+        let screenCanSettle = agentObservation.screenPromptedAt != nil
+            && agentObservation.integrationPhase == nil
+            && (agentStatus?.authority == .command
+                || agentStatus?.authority == .screen)
+        if screenCanSettle {
+            if let inferred = automationScreenFallback(kind: kind, isFocused: isFocused) {
+                updateAutomationAgentStatus(
+                    alias: alias,
+                    kind: kind,
+                    phase: inferred.phase,
+                    authority: .screen,
+                    reason: inferred.reason,
+                    processID: foreground,
+                    unseen: inferred.phase == .done
+                )
+                return
+            }
+            // Transcript viewers and an idle candidate still inside its
+            // confirmation window must not erase the last screen result.
+            if agentStatus?.authority == .screen { return }
+        }
+
+        if let phase = agentObservation.integrationPhase {
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: phase,
+                authority: .integration,
+                reason: agentObservation.integrationReason
+                    ?? "Reported by native agent integration",
+                processID: foreground,
+                unseen: false
+            )
+            return
+        }
+
+        if let current = agentStatus,
+           current.phase == .working,
+           current.authority == .command {
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: .working,
+                authority: .command,
+                reason: current.reason,
+                processID: foreground,
+                unseen: false
+            )
+            return
+        }
+
+        updateAutomationAgentStatus(
+            alias: alias,
+            kind: kind,
+            phase: .unknown,
+            authority: .process,
+            reason: "No prompted task is being observed",
+            processID: foreground,
+            unseen: false
+        )
+    }
+
+    private func clearAutomationAgentStatus() {
+        agentStatus = nil
+        agentObservation.alias = nil
+        agentObservation.declaredKind = nil
+        agentObservation.integrationPhase = nil
+        agentObservation.integrationReason = nil
+        agentObservation.awaitingInitialPrompt = false
+        agentObservation.commandGraceDeadline = nil
+        agentObservation.resetScreenObservation()
+    }
+
+    private func updateAutomationAgentStatus(
+        alias: String,
+        kind: KeroAgentKind,
+        phase: KeroAgentPhase,
+        authority: KeroAgentStateAuthority,
+        reason: String,
+        processID: pid_t?,
+        unseen: Bool
+    ) {
+        if let current = agentStatus,
+           current.alias == alias,
+           current.kind == kind,
+           current.phase == phase,
+           current.authority == authority,
+           current.reason == reason,
+           current.processID == processID,
+           current.unseen == unseen {
+            return
+        }
+
+        let previousPhase = agentStatus?.phase
+        agentStatus = KeroAgentStatus(
+            alias: alias,
+            kind: kind,
+            phase: phase,
+            authority: authority,
+            reason: reason,
+            updatedAt: Date(),
+            processID: processID,
+            unseen: unseen
+        )
+
+        guard phase != previousPhase,
+              phase == .blocked || phase == .done,
+              !TerminalManager.automationIsSessionFocused(id)
+        else { return }
+        TerminalNotificationService.shared.post(
+            message: phase == .blocked
+                ? String(localized: "\(alias) needs attention")
+                : String(localized: "\(alias) finished"),
+            sessionID: id
+        )
+    }
+}
+
+extension PaneTab {
+    var agentRollup: KeroAgentRollup? {
+        Self.rollup(sessions.compactMap(\.agentStatus))
+    }
+
+    fileprivate static func rollup(_ statuses: [KeroAgentStatus]) -> KeroAgentRollup? {
+        // Unknown is useful to automation clients diagnosing a recognized but
+        // unobserved process, but it gives people no actionable chrome state.
+        let visibleStatuses = statuses.filter { $0.phase != .unknown }
+        guard let phase = visibleStatuses.map(\.phase).max(by: {
+            $0.rollupPriority < $1.rollupPriority
+        }) else { return nil }
+        return KeroAgentRollup(
+            phase: phase,
+            count: visibleStatuses.filter { $0.phase == phase }.count
+        )
+    }
+}
+
+extension TerminalSession {
+    var agentRollup: KeroAgentRollup? {
+        PaneTab.rollup(agentStatus.map { [$0] } ?? [])
+    }
+}
+
+extension Project {
+    var agentRollup: KeroAgentRollup? {
+        PaneTab.rollup(sessions.compactMap(\.agentStatus))
+    }
+}

--- a/kero/AgentAutomation.swift
+++ b/kero/AgentAutomation.swift
@@ -358,6 +358,10 @@ final class KeroAgentObservationState {
     var lastForegroundPID: pid_t?
     var integrationPhase: KeroAgentPhase?
     var integrationReason: String?
+    /// Native integrations publish semantic idle, not whether that idle ended
+    /// a turn. Track active-turn evidence so launching an already-idle CLI in
+    /// the background never looks like a newly finished task.
+    var integrationTurnActive = false
     var screenPromptedAt: Date?
     var lastScreenFingerprint: Int?
     var screenChangeCount = 0
@@ -597,6 +601,7 @@ extension TerminalSession {
         agentObservation.declaredKind = kind
         agentObservation.integrationPhase = nil
         agentObservation.integrationReason = nil
+        agentObservation.integrationTurnActive = false
         agentObservation.resetScreenObservation()
         agentObservation.awaitingInitialPrompt = true
         agentObservation.commandGraceDeadline = Date().addingTimeInterval(5)
@@ -615,6 +620,7 @@ extension TerminalSession {
         guard let status = agentStatus else { return }
         agentObservation.integrationPhase = nil
         agentObservation.integrationReason = nil
+        agentObservation.integrationTurnActive = true
         agentObservation.awaitingInitialPrompt = false
         agentObservation.commandGraceDeadline = nil
         agentObservation.beginScreenObservation(
@@ -655,6 +661,7 @@ extension TerminalSession {
         agentObservation.integrationReason = reason
         agentObservation.commandGraceDeadline = nil
         if phase == .working || phase == .blocked {
+            agentObservation.integrationTurnActive = true
             agentObservation.beginScreenObservation(
                 fingerprint: automationAgentScreenSnapshot(kind: kind).fingerprint
             )
@@ -667,6 +674,8 @@ extension TerminalSession {
         // state; readiness is process recognition, not a disposable lifecycle
         // turn that should appear as background completion.
         if agentObservation.awaitingInitialPrompt, phase == .idle {
+            agentObservation.integrationPhase = nil
+            agentObservation.integrationReason = nil
             updateAutomationAgentStatus(
                 alias: alias,
                 kind: kind,
@@ -679,10 +688,17 @@ extension TerminalSession {
             return true
         }
 
-        let presentedPhase = automationPresentedPhase(
-            integrationPhase: phase,
-            isFocused: focused
-        )
+        let completedTurn = agentObservation.integrationTurnActive
+            || agentStatus?.phase == .working
+            || agentStatus?.phase == .blocked
+        let presentedPhase: KeroAgentPhase
+        switch phase {
+        case .idle, .done:
+            presentedPhase = completedTurn && !focused ? .done : .idle
+            agentObservation.integrationTurnActive = false
+        default:
+            presentedPhase = phase
+        }
         updateAutomationAgentStatus(
             alias: alias,
             kind: kind,
@@ -704,9 +720,13 @@ extension TerminalSession {
         if status.authority == .screen {
             agentObservation.integrationPhase = nil
             agentObservation.integrationReason = nil
+            agentObservation.beginScreenObservation(
+                fingerprint: automationAgentScreenSnapshot(kind: status.kind).fingerprint
+            )
         } else {
             agentObservation.integrationPhase = .idle
             agentObservation.integrationReason = "Completion viewed"
+            agentObservation.integrationTurnActive = false
         }
         updateAutomationAgentStatus(
             alias: status.alias,
@@ -727,20 +747,6 @@ extension TerminalSession {
             title: title,
             visibleText: automationVisibleText(maxLines: 80, maxColumns: 500)
         )
-    }
-
-    /// Integrations publish the semantic idle state. `done` is Kero's unseen
-    /// presentation of that same state, not something a model must announce.
-    private func automationPresentedPhase(
-        integrationPhase: KeroAgentPhase,
-        isFocused: Bool
-    ) -> KeroAgentPhase {
-        switch integrationPhase {
-        case .idle, .done:
-            return isFocused ? .idle : .done
-        default:
-            return integrationPhase
-        }
     }
 
     /// Herdr treats a known agent with no matching working/blocker rule as
@@ -781,10 +787,17 @@ extension TerminalSession {
             guard activityObserved else { return nil }
             agentObservation.screenIdleConfirmations += 1
             guard agentObservation.screenIdleConfirmations >= 3 else { return nil }
-            return (
-                isFocused ? .idle : .done,
-                "Terminal UI settled after task activity"
-            )
+            let phase: KeroAgentPhase = isFocused ? .idle : .done
+            if phase == .idle {
+                // A completion observed in its focused pane is already seen.
+                // Make the settled screen the next-turn baseline so merely
+                // moving focus away cannot manufacture a new completion.
+                agentObservation.beginScreenObservation(
+                    fingerprint: snapshot.fingerprint,
+                    at: now
+                )
+            }
+            return (phase, "Terminal UI settled after task activity")
         }
     }
 
@@ -833,12 +846,39 @@ extension TerminalSession {
         let declaredKind = agentObservation.declaredKind
         agentObservation.declaredKind = kind
 
+        // Directly launched CLIs have no `agent.start` declaration. Their
+        // recognized foreground process is enough to show an idle presence
+        // badge immediately, while this baseline lets later screen activity
+        // drive the same working/blocked/done lifecycle as guarded launches.
+        if agentStatus == nil,
+           agentObservation.integrationPhase == nil,
+           agentObservation.screenPromptedAt == nil {
+            agentObservation.beginScreenObservation(
+                fingerprint: automationAgentScreenSnapshot(kind: kind).fingerprint
+            )
+            updateAutomationAgentStatus(
+                alias: alias,
+                kind: kind,
+                phase: .idle,
+                authority: .process,
+                reason: "Directly launched \(kind.displayName) detected",
+                processID: foreground,
+                unseen: false
+            )
+        }
+
         if let phase = agentObservation.integrationPhase,
            phase != .working, phase != .blocked {
-            let normalized = automationPresentedPhase(
-                integrationPhase: phase,
-                isFocused: isFocused
-            )
+            // Presentation is decided when the native event arrives. Preserve
+            // it until a new event or explicit focus acknowledges completion;
+            // otherwise leaving an idle pane would turn it back into `done`.
+            let currentPresentation = agentStatus.flatMap { status in
+                status.authority == .integration
+                    && (status.phase == .idle || status.phase == .done)
+                    ? status : nil
+            }
+            let normalized = currentPresentation?.phase
+                ?? ((phase == .idle || phase == .done) ? .idle : phase)
             updateAutomationAgentStatus(
                 alias: alias,
                 kind: kind,
@@ -847,7 +887,7 @@ extension TerminalSession {
                 reason: agentObservation.integrationReason
                     ?? "Reported by native agent integration",
                 processID: foreground,
-                unseen: normalized == .done
+                unseen: currentPresentation?.unseen ?? (normalized == .done)
             )
             return
         }
@@ -868,7 +908,8 @@ extension TerminalSession {
         let screenCanSettle = agentObservation.screenPromptedAt != nil
             && agentObservation.integrationPhase == nil
             && (agentStatus?.authority == .command
-                || agentStatus?.authority == .screen)
+                || agentStatus?.authority == .screen
+                || agentStatus?.authority == .process)
         if screenCanSettle {
             if let inferred = automationScreenFallback(kind: kind, isFocused: isFocused) {
                 updateAutomationAgentStatus(
@@ -884,7 +925,8 @@ extension TerminalSession {
             }
             // Transcript viewers and an idle candidate still inside its
             // confirmation window must not erase the last screen result.
-            if agentStatus?.authority == .screen { return }
+            if agentStatus?.authority == .screen
+                || agentStatus?.authority == .process { return }
         }
 
         if let phase = agentObservation.integrationPhase {
@@ -919,9 +961,9 @@ extension TerminalSession {
         updateAutomationAgentStatus(
             alias: alias,
             kind: kind,
-            phase: .unknown,
+            phase: .idle,
             authority: .process,
-            reason: "No prompted task is being observed",
+            reason: "Directly launched \(kind.displayName) detected",
             processID: foreground,
             unseen: false
         )
@@ -933,6 +975,7 @@ extension TerminalSession {
         agentObservation.declaredKind = nil
         agentObservation.integrationPhase = nil
         agentObservation.integrationReason = nil
+        agentObservation.integrationTurnActive = false
         agentObservation.awaitingInitialPrompt = false
         agentObservation.commandGraceDeadline = nil
         agentObservation.resetScreenObservation()
@@ -989,9 +1032,11 @@ extension PaneTab {
     }
 
     fileprivate static func rollup(_ statuses: [KeroAgentStatus]) -> KeroAgentRollup? {
-        // Unknown is useful to automation clients diagnosing a recognized but
-        // unobserved process, but it gives people no actionable chrome state.
-        let visibleStatuses = statuses.filter { $0.phase != .unknown }
+        // Idle and unknown remain useful to automation clients, but neither is
+        // actionable enough to occupy persistent pane, tab, or project chrome.
+        let visibleStatuses = statuses.filter {
+            $0.phase != .idle && $0.phase != .unknown
+        }
         guard let phase = visibleStatuses.map(\.phase).max(by: {
             $0.rollupPriority < $1.rollupPriority
         }) else { return nil }

--- a/kero/AgentCLISupportSettingsView.swift
+++ b/kero/AgentCLISupportSettingsView.swift
@@ -1,0 +1,118 @@
+//
+//  AgentCLISupportSettingsView.swift
+//  kero
+//
+
+import AppKit
+import SwiftUI
+
+/// AppKit-owned Settings row for Kero's agent coordination integrations.
+/// The existing Settings screen remains the legacy SwiftUI mount point only.
+@MainActor
+final class AgentCLISupportSettingsView: NSView {
+    private let titleLabel = NSTextField(labelWithString: String(localized: "AI"))
+    private let detailLabel = NSTextField(
+        wrappingLabelWithString: String(
+            localized: "Installs Kero's coordination skill and lifecycle integrations"
+        )
+    )
+    private let errorLabel = NSTextField(wrappingLabelWithString: "")
+    private let toggle = NSSwitch(frame: .zero)
+    private let textStack = NSStackView()
+
+    private var appliedEnabled = false
+    var changeHandler: ((Bool) throws -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+        detailLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        detailLabel.textColor = .secondaryLabelColor
+        detailLabel.maximumNumberOfLines = 0
+        errorLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        errorLabel.textColor = .systemRed
+        errorLabel.maximumNumberOfLines = 0
+        errorLabel.isHidden = true
+
+        textStack.orientation = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 2
+        textStack.detachesHiddenViews = true
+        textStack.addArrangedSubview(titleLabel)
+        textStack.addArrangedSubview(detailLabel)
+        textStack.addArrangedSubview(errorLabel)
+        textStack.setCustomSpacing(5, after: detailLabel)
+
+        toggle.controlSize = .small
+        toggle.target = self
+        toggle.action = #selector(toggleChanged)
+        toggle.setAccessibilityLabel(String(localized: "AI"))
+        toggle.setAccessibilityHelp(detailLabel.stringValue)
+
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(textStack)
+        addSubview(toggle)
+
+        NSLayoutConstraint.activate([
+            textStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            textStack.topAnchor.constraint(equalTo: topAnchor),
+            textStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: toggle.leadingAnchor, constant: -16),
+            toggle.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toggle.topAnchor.constraint(equalTo: topAnchor),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(isEnabled: Bool) {
+        appliedEnabled = isEnabled
+        toggle.state = isEnabled ? .on : .off
+    }
+
+    @objc private func toggleChanged() {
+        let requested = toggle.state == .on
+        do {
+            try changeHandler?(requested)
+            appliedEnabled = requested
+            errorLabel.stringValue = ""
+            errorLabel.isHidden = true
+        } catch {
+            toggle.state = appliedEnabled ? .on : .off
+            errorLabel.stringValue = error.localizedDescription
+            errorLabel.isHidden = false
+        }
+        invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(
+            width: NSView.noIntrinsicMetric,
+            height: ceil(max(max(textStack.fittingSize.height, toggle.fittingSize.height), 44))
+        )
+    }
+}
+
+/// SwiftUI only mounts the native row inside the pre-existing Settings form.
+struct AgentCLISupportSettingsRow: NSViewRepresentable {
+    let isEnabled: Bool
+    let onChange: (Bool) throws -> Void
+
+    func makeNSView(context: Context) -> AgentCLISupportSettingsView {
+        let view = AgentCLISupportSettingsView(frame: .zero)
+        view.changeHandler = onChange
+        view.apply(isEnabled: isEnabled)
+        return view
+    }
+
+    func updateNSView(_ view: AgentCLISupportSettingsView, context: Context) {
+        view.changeHandler = onChange
+        view.apply(isEnabled: isEnabled)
+    }
+}

--- a/kero/AgentIntegrations/opencode/kero-agent-state.js
+++ b/kero/AgentIntegrations/opencode/kero-agent-state.js
@@ -1,0 +1,113 @@
+// Managed by Kero. Re-enabling AI replaces this integration.
+// KERO_INTEGRATION_ID=opencode
+// KERO_INTEGRATION_VERSION=1
+
+import net from "node:net";
+
+const socketPath = process.env.KERO_AUTOMATION_SOCKET;
+const token = process.env.KERO_AUTOMATION_TOKEN;
+const terminalID = process.env.KERO_TERMINAL_ID;
+let requestSequence = Date.now() * 1000;
+let requestChain = Promise.resolve();
+let lastState;
+
+function enabled() {
+  return process.env.KERO_AUTOMATION === "1"
+    && !!socketPath
+    && !!token
+    && !!terminalID;
+}
+
+function report(state, reason) {
+  if (state === lastState) return Promise.resolve();
+  lastState = state;
+  const pending = requestChain.then(() => reportOnce(state, reason));
+  requestChain = pending.catch(() => {});
+  return pending;
+}
+
+function reportOnce(state, reason) {
+  if (!enabled()) return Promise.resolve();
+
+  requestSequence += 1;
+  const request = {
+    version: 1,
+    id: `kero:opencode:${requestSequence}`,
+    method: "agent.report",
+    token,
+    terminalID,
+    params: {
+      state,
+      reason: reason ?? `OpenCode lifecycle: ${state}`,
+    },
+  };
+
+  return new Promise((resolve) => {
+    const socket = net.createConnection(socketPath);
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      socket.destroy();
+      resolve();
+    };
+    socket.setTimeout(750, finish);
+    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+    socket.on("data", finish);
+    socket.on("error", finish);
+    socket.on("end", finish);
+    socket.on("close", finish);
+  });
+}
+
+function stateFromStatus(status) {
+  const value = typeof status === "string" ? status : status?.type;
+  switch (value?.toLowerCase()) {
+    case "idle": return "idle";
+    case "active":
+    case "busy":
+    case "pending":
+    case "retry":
+    case "running":
+    case "streaming":
+    case "working": return "working";
+    default: return undefined;
+  }
+}
+
+export const KeroAgentStatePlugin = async () => {
+  if (!enabled()) return {};
+
+  return {
+    "chat.message": async () => report("working"),
+    event: async ({ event }) => {
+      const type = event?.type;
+      const properties = event?.properties ?? {};
+      switch (type) {
+        case "session.status": {
+          const state = stateFromStatus(properties.status);
+          if (state) await report(state);
+          break;
+        }
+        case "tool.execute.before":
+        case "tool.execute.after":
+        case "permission.replied":
+        case "question.replied":
+        case "question.rejected":
+        case "session.compacted":
+          await report("working");
+          break;
+        case "permission.asked":
+        case "question.asked":
+        case "session.error":
+          await report("blocked");
+          break;
+        case "session.idle":
+          await report("idle");
+          break;
+        default:
+          break;
+      }
+    },
+  };
+};

--- a/kero/AgentIntegrations/pi/kero-agent-state.pi.txt
+++ b/kero/AgentIntegrations/pi/kero-agent-state.pi.txt
@@ -1,0 +1,97 @@
+// Managed by Kero. Re-enabling AI replaces this integration.
+// KERO_INTEGRATION_ID=pi
+// KERO_INTEGRATION_VERSION=1
+// @ts-nocheck
+
+import net from "node:net";
+
+type AgentState = "working" | "blocked" | "idle";
+
+const socketPath = process.env.KERO_AUTOMATION_SOCKET;
+const token = process.env.KERO_AUTOMATION_TOKEN;
+const terminalID = process.env.KERO_TERMINAL_ID;
+let requestSequence = Date.now() * 1000;
+let requestChain = Promise.resolve();
+
+function enabled(): boolean {
+  return process.env.KERO_AUTOMATION === "1"
+    && !!socketPath
+    && !!token
+    && !!terminalID;
+}
+
+function report(state: AgentState, reason?: string): Promise<void> {
+  const pending = requestChain.then(() => reportOnce(state, reason));
+  requestChain = pending.catch(() => {});
+  return pending;
+}
+
+function reportOnce(state: AgentState, reason?: string): Promise<void> {
+  if (!enabled()) return Promise.resolve();
+
+  requestSequence += 1;
+  const request = {
+    version: 1,
+    id: `kero:pi:${requestSequence}`,
+    method: "agent.report",
+    token,
+    terminalID,
+    params: {
+      state,
+      reason: reason ?? `Pi lifecycle: ${state}`,
+    },
+  };
+
+  return new Promise((resolve) => {
+    const socket = net.createConnection(socketPath!);
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      socket.destroy();
+      resolve();
+    };
+    socket.setTimeout(750, finish);
+    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+    socket.on("data", finish);
+    socket.on("error", finish);
+    socket.on("end", finish);
+    socket.on("close", finish);
+  });
+}
+
+export default function keroAgentState(pi) {
+  if (!enabled()) return;
+
+  let rootSession = false;
+  let active = false;
+  let lastState: AgentState | undefined;
+
+  function publish(state: AgentState) {
+    if (state === lastState) return;
+    lastState = state;
+    void report(state);
+  }
+
+  pi.on("session_start", (_event, context) => {
+    if (context?.mode !== "tui") return;
+    rootSession = true;
+    active = context?.isIdle?.() === false;
+    publish(active ? "working" : "idle");
+  });
+
+  pi.on("agent_start", () => {
+    if (!rootSession) return;
+    active = true;
+    publish("working");
+  });
+
+  const settle = (_event, context) => {
+    if (!rootSession || context?.isIdle?.() === false) return;
+    active = false;
+    publish("idle");
+  };
+  pi.on("agent_settled", settle);
+  // Older Pi releases expose agent_end but not agent_settled.
+  pi.on("agent_end", settle);
+}

--- a/kero/AgentStatusBadge.swift
+++ b/kero/AgentStatusBadge.swift
@@ -1,0 +1,121 @@
+//
+//  AgentStatusBadge.swift
+//  kero
+//
+
+import AppKit
+import SwiftUI
+
+/// Native, allocation-light agent status chrome reused by panes, tabs, and
+/// project rows. Shape, color, tooltip, and accessibility label all encode the
+/// state, so status never depends on color alone.
+final class AgentStatusBadgeView: NSView {
+    private let imageView = NSImageView(frame: .zero)
+    private let countLabel = NSTextField(labelWithString: "")
+    private var phase: KeroAgentPhase?
+    private var count = 0
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.imageScaling = .scaleProportionallyDown
+        imageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: 10.5, weight: .semibold
+        )
+        countLabel.translatesAutoresizingMaskIntoConstraints = false
+        countLabel.font = .systemFont(ofSize: 9, weight: .semibold)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        addSubview(imageView)
+        addSubview(countLabel)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 13),
+            imageView.heightAnchor.constraint(equalToConstant: 13),
+            countLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 2),
+            countLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            countLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            heightAnchor.constraint(equalToConstant: 15),
+        ])
+        setAccessibilityElement(true)
+        setAccessibilityRole(.staticText)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(phase: KeroAgentPhase, count: Int) {
+        guard self.phase != phase || self.count != count else { return }
+        self.phase = phase
+        self.count = count
+        imageView.image = NSImage(systemSymbolName: symbolName(for: phase), accessibilityDescription: nil)
+        imageView.contentTintColor = color(for: phase)
+        countLabel.stringValue = count > 1 ? "\(count)" : ""
+        countLabel.isHidden = count <= 1
+        let description = statusDescription(phase: phase, count: count)
+        toolTip = description
+        setAccessibilityLabel(description)
+        invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: count > 1 ? 26 : 13, height: 15)
+    }
+
+    private func symbolName(for phase: KeroAgentPhase) -> String {
+        switch phase {
+        case .created: return "plus.circle"
+        case .working: return "bolt.circle.fill"
+        case .blocked: return "exclamationmark.triangle.fill"
+        case .done: return "checkmark.circle.fill"
+        case .idle: return "pause.circle"
+        case .unknown: return "questionmark.circle"
+        }
+    }
+
+    private func color(for phase: KeroAgentPhase) -> NSColor {
+        switch phase {
+        case .created: return .secondaryLabelColor
+        case .working: return .systemBlue
+        case .blocked: return .systemOrange
+        case .done: return .systemGreen
+        case .idle: return .secondaryLabelColor
+        case .unknown: return .tertiaryLabelColor
+        }
+    }
+
+    private func statusDescription(phase: KeroAgentPhase, count: Int) -> String {
+        let state: String = switch phase {
+        case .created: String(localized: "created")
+        case .working: String(localized: "working")
+        case .blocked: String(localized: "blocked")
+        case .done: String(localized: "done")
+        case .idle: String(localized: "idle")
+        case .unknown: String(localized: "unknown")
+        }
+        return count == 1
+            ? String(localized: "Agent \(state)")
+            : String(localized: "\(count) agents \(state)")
+    }
+}
+
+/// Existing screen composition is still SwiftUI; this representable is only
+/// the mount point for the AppKit view above. No status rendering or layout is
+/// implemented in SwiftUI.
+struct AgentStatusBadgeRepresentable: NSViewRepresentable {
+    let rollup: KeroAgentRollup
+
+    func makeNSView(context: Context) -> AgentStatusBadgeView {
+        let view = AgentStatusBadgeView(frame: .zero)
+        view.apply(phase: rollup.phase, count: rollup.count)
+        return view
+    }
+
+    func updateNSView(_ view: AgentStatusBadgeView, context: Context) {
+        view.apply(phase: rollup.phase, count: rollup.count)
+    }
+}

--- a/kero/AgentStatusBadge.swift
+++ b/kero/AgentStatusBadge.swift
@@ -7,40 +7,127 @@ import AppKit
 import SwiftUI
 
 /// Native, allocation-light agent status chrome reused by panes, tabs, and
-/// project rows. Shape, color, tooltip, and accessibility label all encode the
-/// state, so status never depends on color alone.
+/// project rows.
+///
+/// The badge is the agent's presence lamp, with two deliberate tiers. Ring
+/// shapes carry the ambient lifecycle — a dotted ring while starting, a live
+/// spinner while working, a plain ring at rest — and stay quiet so a wall of
+/// running agents never shouts. Blocked and done, the only two states that
+/// also post a notification, are the only ones that earn a tinted capsule:
+/// chrome weight always means "this wants you". Shape, color, motion,
+/// tooltip, and accessibility label all encode the state, so status never
+/// depends on color alone.
+///
+/// The spinner is a Core Animation transform loop, so continuous motion costs
+/// no main-thread time; Reduce Motion swaps it for a static partial ring.
 final class AgentStatusBadgeView: NSView {
+    private enum Metrics {
+        static let height: CGFloat = 15
+        static let glyphBox: CGFloat = 13
+        static let ringRadius: CGFloat = 4.6
+        static let ringWidth: CGFloat = 1.5
+        static let capsulePad: CGFloat = 3.5
+        static let capsuleCountGap: CGFloat = 1.5
+        static let capsuleCountTrailingPad: CGFloat = 4.5
+        static let bareCountGap: CGFloat = 2.5
+    }
+
+    private static let spinKey = "kero.agentBadge.spin"
+
+    private let capsuleLayer = CALayer()
+    private let ringLayer = CAShapeLayer()
+    private let arcLayer = CAShapeLayer()
     private let imageView = NSImageView(frame: .zero)
     private let countLabel = NSTextField(labelWithString: "")
+    private var accessibilityObserver: NSObjectProtocol?
+    private var occlusionObserver: NSObjectProtocol?
+
     private var phase: KeroAgentPhase?
     private var count = 0
+    private var countSize = NSSize.zero
+    private var reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+
+    /// Ring geometry lives in the shape layers' own 13×13 coordinate space.
+    private static let ringPath: CGPath = {
+        let center = Metrics.glyphBox / 2
+        return CGPath(
+            ellipseIn: CGRect(
+                x: center - Metrics.ringRadius,
+                y: center - Metrics.ringRadius,
+                width: Metrics.ringRadius * 2,
+                height: Metrics.ringRadius * 2
+            ),
+            transform: nil
+        )
+    }()
+
+    /// 270° arc with its gap at the top, so the static Reduce Motion rendering
+    /// still reads as "in progress" next to idle's closed ring.
+    private static let arcPath: CGPath = {
+        let center = Metrics.glyphBox / 2
+        let path = CGMutablePath()
+        path.addArc(
+            center: CGPoint(x: center, y: center),
+            radius: Metrics.ringRadius,
+            startAngle: .pi / 2,
+            endAngle: -.pi,
+            clockwise: true
+        )
+        return path
+    }()
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         translatesAutoresizingMaskIntoConstraints = false
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        capsuleLayer.cornerRadius = Metrics.height / 2
+        capsuleLayer.cornerCurve = .continuous
+        capsuleLayer.isHidden = true
+
+        for ring in [ringLayer, arcLayer] {
+            ring.fillColor = nil
+            ring.lineWidth = Metrics.ringWidth
+            ring.lineCap = .round
+            ring.isHidden = true
+            ring.bounds = CGRect(x: 0, y: 0, width: Metrics.glyphBox, height: Metrics.glyphBox)
+        }
+        ringLayer.path = Self.ringPath
+        arcLayer.path = Self.arcPath
+
         imageView.imageScaling = .scaleProportionallyDown
-        imageView.symbolConfiguration = NSImage.SymbolConfiguration(
-            pointSize: 10.5, weight: .semibold
-        )
-        countLabel.translatesAutoresizingMaskIntoConstraints = false
-        countLabel.font = .systemFont(ofSize: 9, weight: .semibold)
-        countLabel.textColor = .secondaryLabelColor
-        countLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        imageView.isHidden = true
+
+        // The label convenience initializer opts into Auto Layout; this view
+        // lays out manually, so opt back out before AppKit engages the engine.
+        countLabel.translatesAutoresizingMaskIntoConstraints = true
+        countLabel.font = .monospacedDigitSystemFont(ofSize: 9, weight: .semibold)
+        countLabel.isHidden = true
+
+        layer?.addSublayer(capsuleLayer)
+        layer?.addSublayer(ringLayer)
+        layer?.addSublayer(arcLayer)
         addSubview(imageView)
         addSubview(countLabel)
-        NSLayoutConstraint.activate([
-            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            imageView.widthAnchor.constraint(equalToConstant: 13),
-            imageView.heightAnchor.constraint(equalToConstant: 13),
-            countLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 2),
-            countLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            countLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            heightAnchor.constraint(equalToConstant: 15),
-        ])
+
         setAccessibilityElement(true)
         setAccessibilityRole(.staticText)
+
+        accessibilityObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Bind the weak self to an immutable local first: the @Sendable
+            // observer block and the forwarded actor closure must not capture
+            // the mutable `weak var` itself.
+            let badge = self
+            assumeMainActor {
+                guard let badge else { return }
+                badge.reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                badge.updateSpinner()
+            }
+        }
     }
 
     @available(*, unavailable)
@@ -48,58 +135,244 @@ final class AgentStatusBadgeView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        if let accessibilityObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(accessibilityObserver)
+        }
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+        }
+    }
+
     func apply(phase: KeroAgentPhase, count: Int) {
         guard self.phase != phase || self.count != count else { return }
+        let previous = self.phase
         self.phase = phase
         self.count = count
-        imageView.image = NSImage(systemSymbolName: symbolName(for: phase), accessibilityDescription: nil)
-        imageView.contentTintColor = color(for: phase)
-        countLabel.stringValue = count > 1 ? "\(count)" : ""
-        countLabel.isHidden = count <= 1
+
+        if count > 1 {
+            countLabel.stringValue = "\(count)"
+            let measured = countLabel.attributedStringValue.size()
+            countSize = NSSize(width: ceil(measured.width), height: ceil(measured.height))
+            countLabel.isHidden = false
+        } else {
+            countLabel.stringValue = ""
+            countSize = .zero
+            countLabel.isHidden = true
+        }
+
         let description = statusDescription(phase: phase, count: count)
         toolTip = description
         setAccessibilityLabel(description)
+
+        refreshStateAppearance()
+        updateSpinner()
         invalidateIntrinsicContentSize()
+        needsLayout = true
+
+        // Pop only on a live transition into an attention state, mirroring the
+        // moment the notification fires; a freshly mounted badge stays still.
+        if let previous, previous != phase, isCapsule {
+            popIn()
+        }
     }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: count > 1 ? 26 : 13, height: 15)
+        NSSize(width: badgeWidth, height: Metrics.height)
     }
 
-    private func symbolName(for phase: KeroAgentPhase) -> String {
-        switch phase {
-        case .created: return "plus.circle"
-        case .working: return "bolt.circle.fill"
-        case .blocked: return "exclamationmark.triangle.fill"
-        case .done: return "checkmark.circle.fill"
-        case .idle: return "pause.circle"
-        case .unknown: return "questionmark.circle"
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        let glyphX: CGFloat = isCapsule ? Metrics.capsulePad : 0
+        let glyphY = (Metrics.height - Metrics.glyphBox) / 2
+        let glyphFrame = NSRect(
+            x: glyphX, y: glyphY, width: Metrics.glyphBox, height: Metrics.glyphBox
+        )
+        let glyphCenter = CGPoint(x: glyphFrame.midX, y: glyphFrame.midY)
+
+        capsuleLayer.frame = CGRect(x: 0, y: 0, width: badgeWidth, height: Metrics.height)
+        ringLayer.position = glyphCenter
+        arcLayer.position = glyphCenter
+        imageView.frame = glyphFrame
+
+        if count > 1 {
+            let gap = isCapsule ? Metrics.capsuleCountGap : Metrics.bareCountGap
+            countLabel.frame = NSRect(
+                x: glyphFrame.maxX + gap,
+                y: (Metrics.height - countSize.height) / 2,
+                width: countSize.width,
+                height: countSize.height
+            )
         }
     }
 
-    private func color(for phase: KeroAgentPhase) -> NSColor {
-        switch phase {
-        case .created: return .secondaryLabelColor
-        case .working: return .systemBlue
-        case .blocked: return .systemOrange
-        case .done: return .systemGreen
-        case .idle: return .secondaryLabelColor
-        case .unknown: return .tertiaryLabelColor
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Core Animation drops repeating animations when the layer leaves its
+        // window, and can shed them while a window is occluded or the machine
+        // sleeps; reinstall on arrival and whenever the window becomes visible
+        // again so a days-old working badge never freezes mid-rotation.
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+            self.occlusionObserver = nil
         }
+        if let window {
+            occlusionObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                let badge = self
+                assumeMainActor { badge?.updateSpinner() }
+            }
+        }
+        updateSpinner()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        refreshStateAppearance()
+    }
+
+    private var isCapsule: Bool { phase == .blocked || phase == .done }
+
+    private var badgeWidth: CGFloat {
+        let hasCount = count > 1
+        if isCapsule {
+            return Metrics.capsulePad + Metrics.glyphBox + (
+                hasCount
+                    ? Metrics.capsuleCountGap + countSize.width + Metrics.capsuleCountTrailingPad
+                    : Metrics.capsulePad
+            )
+        }
+        return Metrics.glyphBox + (hasCount ? Metrics.bareCountGap + countSize.width : 0)
+    }
+
+    /// Applies the current phase's shape, color, and capsule chrome, resolving
+    /// colors against the effective appearance so layer CGColors track light
+    /// and dark mode.
+    private func refreshStateAppearance() {
+        guard let phase else { return }
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            defer { CATransaction.commit() }
+
+            let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            capsuleLayer.isHidden = true
+            ringLayer.isHidden = true
+            arcLayer.isHidden = true
+            imageView.isHidden = true
+
+            switch phase {
+            case .created:
+                ringLayer.isHidden = false
+                ringLayer.lineDashPattern = [0.1, 3.51]
+                ringLayer.lineWidth = Metrics.ringWidth
+                ringLayer.strokeColor = NSColor.secondaryLabelColor.cgColor
+                countLabel.textColor = .secondaryLabelColor
+            case .working:
+                ringLayer.isHidden = false
+                ringLayer.lineDashPattern = nil
+                ringLayer.lineWidth = Metrics.ringWidth
+                ringLayer.strokeColor = NSColor.systemBlue
+                    .withAlphaComponent(isDark ? 0.32 : 0.25).cgColor
+                arcLayer.isHidden = false
+                arcLayer.strokeColor = NSColor.systemBlue.cgColor
+                countLabel.textColor = .systemBlue
+            case .blocked:
+                capsuleLayer.isHidden = false
+                capsuleLayer.backgroundColor = NSColor.systemOrange
+                    .withAlphaComponent(isDark ? 0.27 : 0.17).cgColor
+                showSymbol(
+                    "exclamationmark.triangle.fill",
+                    pointSize: 10, weight: .semibold, tint: .systemOrange
+                )
+                countLabel.textColor = .systemOrange
+            case .done:
+                capsuleLayer.isHidden = false
+                capsuleLayer.backgroundColor = NSColor.systemGreen
+                    .withAlphaComponent(isDark ? 0.24 : 0.17).cgColor
+                showSymbol("checkmark", pointSize: 9, weight: .bold, tint: .systemGreen)
+                countLabel.textColor = .systemGreen
+            case .idle:
+                ringLayer.isHidden = false
+                ringLayer.lineDashPattern = nil
+                // Thinner than the active states, so a resting ring never
+                // reads as a radio control next to the tab title.
+                ringLayer.lineWidth = 1.3
+                ringLayer.strokeColor = NSColor.tertiaryLabelColor.cgColor
+                countLabel.textColor = .secondaryLabelColor
+            case .unknown:
+                showSymbol("questionmark", pointSize: 9, weight: .semibold, tint: .tertiaryLabelColor)
+                countLabel.textColor = .secondaryLabelColor
+            }
+        }
+    }
+
+    private func showSymbol(
+        _ name: String, pointSize: CGFloat, weight: NSFont.Weight, tint: NSColor
+    ) {
+        imageView.isHidden = false
+        imageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: pointSize, weight: weight
+        )
+        imageView.image = NSImage(systemSymbolName: name, accessibilityDescription: nil)
+        imageView.contentTintColor = tint
+    }
+
+    private func updateSpinner() {
+        if phase == .working, !reduceMotion, window != nil {
+            guard arcLayer.animation(forKey: Self.spinKey) == nil else { return }
+            let spin = CABasicAnimation(keyPath: "transform.rotation.z")
+            spin.fromValue = 0
+            spin.toValue = -2 * Double.pi
+            spin.duration = 1.2
+            spin.repeatCount = .infinity
+            arcLayer.add(spin, forKey: Self.spinKey)
+        } else {
+            arcLayer.removeAnimation(forKey: Self.spinKey)
+        }
+    }
+
+    private func popIn() {
+        guard !reduceMotion, let layer, bounds.width > 0 else { return }
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        var from = CATransform3DMakeTranslation(center.x, center.y, 0)
+        from = CATransform3DScale(from, 0.55, 0.55, 1)
+        from = CATransform3DTranslate(from, -center.x, -center.y, 0)
+        let spring = CASpringAnimation(keyPath: "transform")
+        spring.fromValue = NSValue(caTransform3D: from)
+        spring.toValue = NSValue(caTransform3D: CATransform3DIdentity)
+        spring.stiffness = 520
+        spring.damping = 15
+        spring.duration = spring.settlingDuration
+        layer.add(spring, forKey: "kero.agentBadge.pop")
     }
 
     private func statusDescription(phase: KeroAgentPhase, count: Int) -> String {
-        let state: String = switch phase {
-        case .created: String(localized: "created")
-        case .working: String(localized: "working")
-        case .blocked: String(localized: "blocked")
-        case .done: String(localized: "done")
-        case .idle: String(localized: "idle")
-        case .unknown: String(localized: "unknown")
+        if count <= 1 {
+            return switch phase {
+            case .created: String(localized: "Agent starting")
+            case .working: String(localized: "Agent working")
+            case .blocked: String(localized: "Agent needs attention")
+            case .done: String(localized: "Agent finished")
+            case .idle: String(localized: "Agent idle")
+            case .unknown: String(localized: "Agent state unknown")
+            }
         }
-        return count == 1
-            ? String(localized: "Agent \(state)")
-            : String(localized: "\(count) agents \(state)")
+        return switch phase {
+        case .created: String(localized: "\(count) agents starting")
+        case .working: String(localized: "\(count) agents working")
+        case .blocked: String(localized: "\(count) agents need attention")
+        case .done: String(localized: "\(count) agents finished")
+        case .idle: String(localized: "\(count) agents idle")
+        case .unknown: String(localized: "\(count) agents in an unknown state")
+        }
     }
 }
 

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -1045,6 +1045,32 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         write(Array(text.utf8))
     }
 
+    func sendApplicationScroll(lines: Int) -> Bool {
+        guard lines != 0 else { return false }
+        let mode = terminalMode
+        if mode.contains(.mouseReporting) {
+            let code = lines > 0 ? 64 : 65
+            let column = max(gridSize.columns / 2, 0)
+            let row = max(gridSize.rows / 2, 0)
+            for _ in 0..<min(abs(lines), 50) {
+                sendMouse(
+                    code: code,
+                    column: column,
+                    row: row,
+                    modifiers: 0,
+                    released: false
+                )
+            }
+            return true
+        }
+        if mode.contains(.alternateScreen), mode.contains(.alternateScroll) {
+            let sequence = AlacrittyKeyMap.cursor(up: lines > 0, mode: mode)
+            for _ in 0..<min(abs(lines), 50) { writeControl(sequence) }
+            return true
+        }
+        return false
+    }
+
     func clearScreen() {
         guard let handle else { return }
         kero_alacritty_clear(handle)
@@ -1111,6 +1137,55 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     func exportScrollbackFile() -> String? {
         exportFile(scrollbackOnly: true)
+    }
+
+    /// Reads only the already-materialized viewport snapshot. This is bounded
+    /// by rows × columns and avoids serializing the 10,000-line scrollback for
+    /// status observation or a CLI read.
+    func readVisibleText(maxLines: Int, maxColumns: Int) -> String? {
+        guard let handle else { return nil }
+        var snapshot = KeroSnapshot()
+        kero_alacritty_snapshot(handle, &snapshot)
+        guard snapshot.columns > 0, snapshot.rows > 0,
+              let cells = snapshot.cells
+        else { return "" }
+
+        let boundedRows = min(snapshot.rows, max(maxLines, 1))
+        let boundedColumns = min(snapshot.columns, max(maxColumns, 1))
+        let firstRow = snapshot.rows - boundedRows
+        var lines: [String] = []
+        lines.reserveCapacity(boundedRows)
+        for row in firstRow..<snapshot.rows {
+            var line = ""
+            line.reserveCapacity(boundedColumns)
+            for column in 0..<boundedColumns {
+                let cell = cells[row * snapshot.columns + column]
+                if cell.flags & UInt16(KERO_CELL_WIDE_SPACER) != 0 { continue }
+                if cell.flags & UInt16(KERO_CELL_HIDDEN) != 0 {
+                    line.append(" ")
+                    continue
+                }
+                if cell.text_len > 0, let text = snapshot.text {
+                    let offset = Int(cell.text_offset)
+                    let length = Int(cell.text_len)
+                    guard offset >= 0, length >= 0,
+                          offset + length <= snapshot.text_len
+                    else { continue }
+                    line += String(
+                        decoding: UnsafeBufferPointer(
+                            start: text.advanced(by: offset), count: length
+                        ),
+                        as: UTF8.self
+                    )
+                } else if let scalar = UnicodeScalar(cell.ch) {
+                    line.unicodeScalars.append(scalar)
+                }
+            }
+            while line.last == " " || line.last == "\t" { line.removeLast() }
+            lines.append(line)
+        }
+        while lines.last?.isEmpty == true { lines.removeLast() }
+        return lines.joined(separator: "\n")
     }
 
     /// Writes the bridge's styled VT stream to its own directory under the
@@ -1548,12 +1623,30 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         let mode = terminalMode
         guard mode.contains(.mouseReporting) else { return }
         let point = gridPoint(for: event)
-        let x = point.column + 1
-        let y = point.line + 1
         let modifiers =
             (event.modifierFlags.contains(.shift) ? 4 : 0)
             + (event.modifierFlags.contains(.option) ? 8 : 0)
             + (event.modifierFlags.contains(.control) ? 16 : 0)
+        sendMouse(
+            code: code,
+            column: point.column,
+            row: point.line,
+            modifiers: modifiers,
+            released: released
+        )
+    }
+
+    private func sendMouse(
+        code: Int,
+        column: Int,
+        row: Int,
+        modifiers: Int,
+        released: Bool
+    ) {
+        let mode = terminalMode
+        guard mode.contains(.mouseReporting) else { return }
+        let x = column + 1
+        let y = row + 1
 
         if mode.contains(.sgrMouse) {
             let suffix = released ? "m" : "M"

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -204,6 +204,13 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Install Kero's shared coordination skill plus the native lifecycle
+    /// integrations whose provider APIs cover a complete interactive turn.
+    /// Every other agent continues to use passive process/screen observation.
+    @Published private(set) var aiEnabled: Bool {
+        didSet { save() }
+    }
+
     /// Which emulator drives terminal panes. Only ever holds a backend this
     /// build ships a surface for — see `TerminalBackend` — and a session binds
     /// its backend at creation, so a change here reaches terminals opened
@@ -247,6 +254,7 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = toml["terminal.macos-option-as-alt"]?.bool ?? false
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
+        aiEnabled = toml["ai.enabled"]?.bool ?? false
         terminalBackend = TerminalBackend(persisted: toml["terminal.backend"]?.string)
         applyAppearance()
         reloadThemeSelection()
@@ -295,7 +303,51 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = false
         wrapLines = false
         restoreTerminalHistory = false
+        if aiEnabled {
+            do {
+                try setAIEnabled(false)
+            } catch {
+                NSLog("kero: failed to disable AI support: \(error)")
+            }
+        }
         terminalBackend = .fallback
+    }
+
+    /// Persist the setting only after every requested destination operation
+    /// returns successfully.
+    func setAIEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try KeroAgentIntegrations.preflightInstallAvailable()
+            _ = try KeroAutomationSkill.install(
+                destinations: KeroAutomationSkill.Destination.allCases,
+                force: false
+            )
+            try KeroAgentIntegrations.installAvailable()
+        } else {
+            try KeroAgentIntegrations.preflightUninstallManaged()
+            _ = try KeroAutomationSkill.uninstall(
+                destinations: KeroAutomationSkill.Destination.allCases,
+                force: false
+            )
+            try KeroAgentIntegrations.uninstallManaged()
+        }
+        aiEnabled = enabled
+    }
+
+    /// App updates normally preserve the bundle path targeted by the links.
+    /// Reconcile at launch as well so moving the app or changing Debug build
+    /// products repairs only installations the user explicitly enabled.
+    func reconcileAIEnabled() {
+        guard aiEnabled else { return }
+        do {
+            _ = try KeroAutomationSkill.install(
+                destinations: KeroAutomationSkill.Destination.allCases,
+                force: false
+            )
+            try KeroAgentIntegrations.installAvailable()
+        } catch {
+            NSLog("kero: failed to refresh AI support: \(error)")
+        }
     }
 
     private func save() {
@@ -332,6 +384,9 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if restoreTerminalHistory {
             lines.append("terminal.restore-history = true")
+        }
+        if aiEnabled {
+            lines.append("ai.enabled = true")
         }
         if terminalBackend != .fallback {
             lines.append("terminal.backend = \(TOML.quote(terminalBackend.rawValue))")

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -1348,16 +1348,17 @@ private struct PaneTabItem: View {
         } else {
             switch tab.focusedContent {
             case .session(let session):
-                SessionTabLabel(session: session, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                SessionTabLabel(session: session, customTitle: tab.customName, paneCount: paneCount, agentRollup: tab.agentRollup, isSelected: isSelected, select: select, close: close)
             case .file(let file):
-                FileTabLabel(file: file, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                FileTabLabel(file: file, customTitle: tab.customName, paneCount: paneCount, agentRollup: tab.agentRollup, isSelected: isSelected, select: select, close: close)
             case .browser(let browser):
-                BrowserTabLabel(browser: browser, customTitle: tab.customName, paneCount: paneCount, isSelected: isSelected, select: select, close: close)
+                BrowserTabLabel(browser: browser, customTitle: tab.customName, paneCount: paneCount, agentRollup: tab.agentRollup, isSelected: isSelected, select: select, close: close)
             case .diff(let diff):
                 DiffTabLabel(
                     diff: diff,
                     customTitle: tab.customName,
                     paneCount: paneCount,
+                    agentRollup: tab.agentRollup,
                     isSelected: isSelected,
                     select: select,
                     close: close
@@ -1463,6 +1464,7 @@ private struct SessionTabLabel: View {
     /// User-assigned tab name overriding the live terminal title.
     var customTitle: String?
     let paneCount: Int
+    let agentRollup: KeroAgentRollup?
     let isSelected: Bool
     let select: () -> Void
     let close: () -> Void
@@ -1472,6 +1474,7 @@ private struct SessionTabLabel: View {
             systemImage: "terminal",
             title: customTitle ?? session.title,
             paneCount: paneCount,
+            agentRollup: agentRollup,
             isSelected: isSelected,
             select: select,
             close: close
@@ -1484,6 +1487,7 @@ private struct FileTabLabel: View {
     /// User-assigned tab name overriding the file name.
     var customTitle: String?
     let paneCount: Int
+    let agentRollup: KeroAgentRollup?
     let isSelected: Bool
     let select: () -> Void
     let close: () -> Void
@@ -1494,6 +1498,7 @@ private struct FileTabLabel: View {
             fileIconPath: file.path,
             title: customTitle ?? file.name,
             paneCount: paneCount,
+            agentRollup: agentRollup,
             isSelected: isSelected,
             isDirty: file.isDirty,
             select: select,
@@ -1508,6 +1513,7 @@ private struct BrowserTabLabel: View {
     /// User-assigned tab name overriding the webpage title.
     var customTitle: String?
     let paneCount: Int
+    let agentRollup: KeroAgentRollup?
     let isSelected: Bool
     let select: () -> Void
     let close: () -> Void
@@ -1518,6 +1524,7 @@ private struct BrowserTabLabel: View {
             browserIcon: browser,
             title: customTitle ?? browser.title,
             paneCount: paneCount,
+            agentRollup: agentRollup,
             isSelected: isSelected,
             select: select,
             close: close
@@ -1530,6 +1537,7 @@ private struct DiffTabLabel: View {
     @ObservedObject var diff: DiffTab
     var customTitle: String?
     let paneCount: Int
+    let agentRollup: KeroAgentRollup?
     let isSelected: Bool
     let select: () -> Void
     let close: () -> Void
@@ -1540,6 +1548,7 @@ private struct DiffTabLabel: View {
             fileIconPath: diff.path,
             title: customTitle ?? diff.title,
             paneCount: paneCount,
+            agentRollup: agentRollup,
             isSelected: isSelected,
             isDirty: diff.isDirty,
             select: select,
@@ -1556,6 +1565,7 @@ private struct TabItemChrome: View {
     var fileIconPath: String? = nil
     let title: String
     var paneCount: Int = 1
+    var agentRollup: KeroAgentRollup? = nil
     let isSelected: Bool
     var isDirty = false
     let select: () -> Void
@@ -1602,6 +1612,10 @@ private struct TabItemChrome: View {
                             .font(.system(size: 9, weight: .semibold))
                     }
                     .foregroundStyle(.tertiary)
+                }
+                if let agentRollup {
+                    AgentStatusBadgeRepresentable(rollup: agentRollup)
+                        .fixedSize()
                 }
                 if isHovering {
                     Button(action: close) {

--- a/kero/KeroAgentIntegrations.swift
+++ b/kero/KeroAgentIntegrations.swift
@@ -1,0 +1,213 @@
+//
+//  KeroAgentIntegrations.swift
+//  kero
+//
+
+import Foundation
+
+/// Native lifecycle integrations for agent CLIs whose public event surfaces
+/// cover a full interactive turn. Other supported agents continue to use
+/// process identity plus screen detection; partial hooks must never override
+/// that more complete lifecycle source.
+enum KeroAgentIntegrations {
+    enum Kind: String, CaseIterable {
+        case pi
+        case opencode
+
+        var marker: String { "KERO_INTEGRATION_ID=\(rawValue)" }
+
+        var resource: (name: String, extension: String, directories: [String?]) {
+            switch self {
+            case .pi:
+                return (
+                    "kero-agent-state.pi", "txt",
+                    ["AgentIntegrations/pi", "pi", nil]
+                )
+            case .opencode:
+                return (
+                    "kero-agent-state", "js",
+                    ["AgentIntegrations/opencode", "opencode", nil]
+                )
+            }
+        }
+
+        func installationRoot(
+            homeURL: URL,
+            environment: [String: String]
+        ) -> URL {
+            switch self {
+            case .pi:
+                if let configured = environment["PI_CODING_AGENT_DIR"],
+                   !configured.isEmpty {
+                    return expandedURL(configured, homeURL: homeURL)
+                }
+                return homeURL.appendingPathComponent(".pi/agent", isDirectory: true)
+            case .opencode:
+                return homeURL.appendingPathComponent(
+                    ".config/opencode",
+                    isDirectory: true
+                )
+            }
+        }
+
+        func destinationURL(
+            homeURL: URL,
+            environment: [String: String]
+        ) -> URL {
+            let root = installationRoot(homeURL: homeURL, environment: environment)
+            switch self {
+            case .pi:
+                return root.appendingPathComponent(
+                    "extensions/kero-agent-state.ts",
+                    isDirectory: false
+                )
+            case .opencode:
+                return root.appendingPathComponent(
+                    "plugins/kero-agent-state.js",
+                    isDirectory: false
+                )
+            }
+        }
+    }
+
+    enum IntegrationError: Error, LocalizedError {
+        case message(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .message(let message): message
+            }
+        }
+    }
+
+    /// Validates every integration whose agent config already exists. Missing
+    /// agents are intentionally skipped so enabling AI never creates unrelated
+    /// provider configuration in the user's home directory.
+    static func preflightInstallAvailable(
+        bundle: Bundle = .main,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        for kind in Kind.allCases {
+            let root = kind.installationRoot(homeURL: homeURL, environment: environment)
+            guard isDirectory(root) else { continue }
+            _ = try source(for: kind, bundle: bundle)
+            let destination = kind.destinationURL(
+                homeURL: homeURL,
+                environment: environment
+            )
+            if FileManager.default.fileExists(atPath: destination.path),
+               !isManaged(destination, kind: kind) {
+                throw IntegrationError.message(
+                    "The \(kind.rawValue) integration at \(destination.path) is not managed by Kero."
+                )
+            }
+        }
+    }
+
+    static func installAvailable(
+        bundle: Bundle = .main,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        try preflightInstallAvailable(
+            bundle: bundle,
+            homeURL: homeURL,
+            environment: environment
+        )
+        for kind in Kind.allCases {
+            let root = kind.installationRoot(homeURL: homeURL, environment: environment)
+            guard isDirectory(root) else { continue }
+            let source = try source(for: kind, bundle: bundle)
+            let destination = kind.destinationURL(
+                homeURL: homeURL,
+                environment: environment
+            )
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try source.data.write(to: destination, options: .atomic)
+        }
+    }
+
+    static func preflightUninstallManaged(
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        for kind in Kind.allCases {
+            let destination = kind.destinationURL(
+                homeURL: homeURL,
+                environment: environment
+            )
+            guard FileManager.default.fileExists(atPath: destination.path) else { continue }
+            guard isManaged(destination, kind: kind) else {
+                throw IntegrationError.message(
+                    "The \(kind.rawValue) integration at \(destination.path) has local changes."
+                )
+            }
+        }
+    }
+
+    static func uninstallManaged(
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        try preflightUninstallManaged(homeURL: homeURL, environment: environment)
+        for kind in Kind.allCases {
+            let destination = kind.destinationURL(
+                homeURL: homeURL,
+                environment: environment
+            )
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+        }
+    }
+
+    private struct Source {
+        let data: Data
+    }
+
+    private static func source(for kind: Kind, bundle: Bundle) throws -> Source {
+        let resource = kind.resource
+        for directory in resource.directories {
+            guard let url = bundle.url(
+                forResource: resource.name,
+                withExtension: resource.extension,
+                subdirectory: directory
+            ) else { continue }
+            let data = try Data(contentsOf: url)
+            guard let text = String(data: data, encoding: .utf8),
+                  text.contains(kind.marker) else { continue }
+            return Source(data: data)
+        }
+        throw IntegrationError.message(
+            "Kero's bundled \(kind.rawValue) lifecycle integration is missing."
+        )
+    }
+
+    private static func isManaged(_ url: URL, kind: Kind) -> Bool {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+              data.count <= 256 * 1_024,
+              let text = String(data: data, encoding: .utf8)
+        else { return false }
+        return text.contains(kind.marker)
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(
+            atPath: url.path,
+            isDirectory: &isDirectory
+        ) && isDirectory.boolValue
+    }
+
+    private static func expandedURL(_ path: String, homeURL: URL) -> URL {
+        if path == "~" { return homeURL }
+        if path.hasPrefix("~/") {
+            return homeURL.appendingPathComponent(String(path.dropFirst(2)))
+        }
+        return URL(fileURLWithPath: path)
+    }
+}

--- a/kero/KeroAutomationCommandLine.swift
+++ b/kero/KeroAutomationCommandLine.swift
@@ -1,0 +1,993 @@
+//
+//  KeroAutomationCommandLine.swift
+//  kero
+//
+
+import Foundation
+
+/// Script-facing wrappers for Kero's local automation protocol. Pane and agent
+/// operations return JSON so scripts can compose stable IDs and state. Skill
+/// management is human-readable by default and offers explicit `--json` output.
+enum KeroAutomationCommandLine {
+    static func run(namespace: String, arguments: [String]) throws {
+        if arguments.isEmpty || arguments == ["--help"] || arguments == ["-h"] {
+            namespace == "+pane" ? printPaneHelp() : printAgentHelp()
+            return
+        }
+        if namespace == "+agent", arguments == ["explain"] {
+            printAgentContract()
+            return
+        }
+        if namespace == "+agent", arguments.first == "skill" {
+            try runAgentSkill(Array(arguments.dropFirst()))
+            return
+        }
+
+        let connection = try AppConnection()
+        let result: KeroJSONValue
+        switch namespace {
+        case "+pane":
+            result = try runPane(arguments, connection: connection)
+        case "+agent":
+            result = try runAgent(arguments, connection: connection)
+        default:
+            throw CLIError.message("Unknown automation namespace \(namespace).")
+        }
+        try printJSON(result)
+    }
+
+    // MARK: - Pane commands
+
+    private static func runPane(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        let command = arguments[0]
+        let tail = Array(arguments.dropFirst())
+        switch command {
+        case "current":
+            try requireNoArguments(tail, command: "+pane current")
+            return try connection.automationRequest(method: "pane.current")
+        case "list":
+            try requireNoArguments(tail, command: "+pane list")
+            return try connection.automationRequest(method: "pane.list")
+        case "protocol":
+            try requireNoArguments(tail, command: "+pane protocol")
+            return try connection.automationRequest(method: "protocol.info")
+        case "get":
+            let pane = try parsePaneOnly(tail, command: "+pane get")
+            return try connection.automationRequest(
+                method: "pane.get",
+                params: targetParams(paneID: pane)
+            )
+        case "split":
+            return try splitPane(tail, connection: connection)
+        case "run":
+            return try runInPane(tail, connection: connection)
+        case "send":
+            return try sendToPane(tail, connection: connection)
+        case "read":
+            return try readPane(tail, connection: connection)
+        case "wait-output":
+            return try waitForOutput(tail, connection: connection)
+        case "help", "--help", "-h":
+            printPaneHelp()
+            return .object(["help": .bool(true)])
+        default:
+            throw CLIError.message(
+                "Unknown +pane command \(command). Run `kero +pane --help`."
+            )
+        }
+    }
+
+    private static func splitPane(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var paneID: String?
+        var edge = "right"
+        var cwd: String?
+        var focus = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": paneID = nil
+            case "--left": edge = "left"
+            case "--right": edge = "right"
+            case "--up", "--top": edge = "top"
+            case "--down", "--bottom": edge = "bottom"
+            case "--cwd": cwd = try value(after: &index, in: arguments, option: "--cwd")
+            case "--focus": focus = true
+            case "--no-focus": focus = false
+            default:
+                throw unknownOption(arguments[index], command: "+pane split")
+            }
+            index += 1
+        }
+        var params = targetParams(paneID: paneID)
+        params["edge"] = .string(edge)
+        params["focus"] = .bool(focus)
+        if let cwd { params["cwd"] = .string(cwd) }
+        return try connection.automationRequest(method: "pane.split", params: params)
+    }
+
+    private static func runInPane(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var paneID: String?
+        var index = 0
+        while index < arguments.count, arguments[index] != "--" {
+            switch arguments[index] {
+            case "--pane": paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": paneID = nil
+            default: throw unknownOption(arguments[index], command: "+pane run")
+            }
+            index += 1
+        }
+        guard index < arguments.count, arguments[index] == "--" else {
+            throw CLIError.message("`kero +pane run` requires `-- command [arguments...]`.")
+        }
+        let argv = Array(arguments.dropFirst(index + 1))
+        guard !argv.isEmpty else {
+            throw CLIError.message("No command was provided after `--`.")
+        }
+        var params = targetParams(paneID: paneID)
+        params["argv"] = .array(argv.map(KeroJSONValue.string))
+        return try connection.automationRequest(method: "pane.run", params: params)
+    }
+
+    private static func sendToPane(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var paneID: String?
+        var text: String?
+        var enter = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": paneID = nil
+            case "--text": text = try value(after: &index, in: arguments, option: "--text")
+            case "--enter": enter = true
+            default: throw unknownOption(arguments[index], command: "+pane send")
+            }
+            index += 1
+        }
+        guard let text else {
+            throw CLIError.message("`kero +pane send` requires --text.")
+        }
+        var params = targetParams(paneID: paneID)
+        params["text"] = .string(text)
+        params["enter"] = .bool(enter)
+        return try connection.automationRequest(method: "pane.send", params: params)
+    }
+
+    private static func readPane(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        let options = try parseReadOptions(arguments, command: "+pane read")
+        return try connection.automationRequest(
+            method: "pane.read",
+            params: readParams(options)
+        )
+    }
+
+    private static func waitForOutput(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var read = ReadOptions()
+        var needle: String?
+        var timeoutMS = 30_000
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": read.paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": read.paneID = nil
+            case "--lines": read.lines = try integerValue(after: &index, in: arguments, option: "--lines")
+            case "--columns": read.columns = try integerValue(after: &index, in: arguments, option: "--columns")
+            case "--contains": needle = try value(after: &index, in: arguments, option: "--contains")
+            case "--timeout": timeoutMS = try integerValue(after: &index, in: arguments, option: "--timeout")
+            default: throw unknownOption(arguments[index], command: "+pane wait-output")
+            }
+            index += 1
+        }
+        guard let needle, !needle.isEmpty else {
+            throw CLIError.message("`kero +pane wait-output` requires --contains.")
+        }
+        try validateTimeout(timeoutMS)
+        let deadline = Date().addingTimeInterval(Double(timeoutMS) / 1_000)
+        repeat {
+            let result = try connection.automationRequest(
+                method: "pane.read", params: readParams(read)
+            )
+            if result.objectValue?["text"]?.stringValue?.contains(needle) == true {
+                return result
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        } while Date() < deadline
+        throw CLIError.message("Timed out waiting for terminal output containing \(needle.debugDescription).")
+    }
+
+    // MARK: - Agent commands
+
+    private static func runAgentSkill(_ arguments: [String]) throws {
+        guard let command = arguments.first else {
+            printAgentSkillHelp()
+            return
+        }
+        let tail = Array(arguments.dropFirst())
+        switch command {
+        case "path":
+            try requireNoArguments(tail, command: "+agent skill path")
+            print(try KeroAutomationSkill.bundledSkillURL().path)
+
+        case "print":
+            try requireNoArguments(tail, command: "+agent skill print")
+            let contents = try KeroAutomationSkill.bundledSkillText()
+            print(contents, terminator: contents.hasSuffix("\n") ? "" : "\n")
+
+        case "status":
+            let options = try parseSkillOptions(
+                tail,
+                command: "+agent skill status",
+                allowsForce: false
+            )
+            let destinations = try KeroAutomationSkill.destinations(for: options.provider)
+            let snapshots = try KeroAutomationSkill.status(destinations: destinations)
+            if options.json {
+                var values: [KeroJSONValue] = []
+                for snapshot in snapshots { values.append(skillSnapshot(snapshot)) }
+                try printJSON(skillResult(
+                    action: "status",
+                    provider: options.provider,
+                    destinations: values,
+                    changed: false
+                ))
+            } else {
+                printSkillStatus(snapshots)
+            }
+
+        case "install":
+            let options = try parseSkillOptions(
+                tail,
+                command: "+agent skill install",
+                allowsForce: true
+            )
+            let destinations = try KeroAutomationSkill.destinations(for: options.provider)
+            let results = try KeroAutomationSkill.install(
+                destinations: destinations,
+                force: options.force
+            )
+            let changed = results.contains { $0.previousState != .current }
+            if options.json {
+                var values: [KeroJSONValue] = []
+                for result in results { values.append(skillMutation(result)) }
+                try printJSON(skillResult(
+                    action: "install",
+                    provider: options.provider,
+                    destinations: values,
+                    changed: changed,
+                    reloadRecommended: changed
+                ))
+            } else {
+                printSkillInstall(results, changed: changed)
+            }
+
+        case "uninstall":
+            let options = try parseSkillOptions(
+                tail,
+                command: "+agent skill uninstall",
+                allowsForce: true
+            )
+            let destinations = try KeroAutomationSkill.destinations(for: options.provider)
+            let results = try KeroAutomationSkill.uninstall(
+                destinations: destinations,
+                force: options.force
+            )
+            let changed = results.contains { $0.previousState != .missing }
+            if options.json {
+                var values: [KeroJSONValue] = []
+                for result in results { values.append(skillMutation(result)) }
+                try printJSON(skillResult(
+                    action: "uninstall",
+                    provider: options.provider,
+                    destinations: values,
+                    changed: changed,
+                    reloadRecommended: changed
+                ))
+            } else {
+                printSkillUninstall(results, changed: changed)
+            }
+
+        case "help", "--help", "-h":
+            printAgentSkillHelp()
+
+        default:
+            throw CLIError.message(
+                "Unknown +agent skill command \(command). Run `kero +agent skill --help`."
+            )
+        }
+    }
+
+    private struct SkillOptions {
+        var provider = "all"
+        var force = false
+        var json = false
+    }
+
+    private static func parseSkillOptions(
+        _ arguments: [String],
+        command: String,
+        allowsForce: Bool
+    ) throws -> SkillOptions {
+        var result = SkillOptions()
+        var didSetProvider = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--provider", "--for":
+                guard !didSetProvider else {
+                    throw CLIError.message("Choose only one --provider value.")
+                }
+                let option = arguments[index]
+                result.provider = try value(
+                    after: &index,
+                    in: arguments,
+                    option: option
+                )
+                didSetProvider = true
+            case "--force" where allowsForce:
+                result.force = true
+            case "--json":
+                result.json = true
+            default:
+                throw unknownOption(arguments[index], command: command)
+            }
+            index += 1
+        }
+        return result
+    }
+
+    private static func printSkillStatus(
+        _ snapshots: [KeroAutomationSkill.Snapshot]
+    ) {
+        print("Kero automation skill")
+        for snapshot in snapshots {
+            print("  \(agentNames(snapshot.destination)): \(skillStateLabel(snapshot.state))")
+            print("    \(abbreviatedHomePath(snapshot.url))")
+        }
+    }
+
+    private static func printSkillInstall(
+        _ results: [KeroAutomationSkill.MutationResult],
+        changed: Bool
+    ) {
+        if changed {
+            print("Installed Kero automation skill.")
+        } else {
+            print("Kero automation skill is already installed and current.")
+        }
+        for result in results {
+            let action = result.previousState == .current ? "Already linked" : "Linked"
+            print("  \(agentNames(result.destination)): \(action)")
+            print("    \(abbreviatedHomePath(result.url))")
+        }
+        if changed {
+            print("\nRestart running agents to load the skill.")
+        }
+    }
+
+    private static func printSkillUninstall(
+        _ results: [KeroAutomationSkill.MutationResult],
+        changed: Bool
+    ) {
+        if changed {
+            print("Uninstalled Kero automation skill.")
+        } else {
+            print("Kero automation skill is not installed.")
+        }
+        for result in results {
+            let action = result.previousState == .missing ? "Not installed" : "Removed"
+            print("  \(agentNames(result.destination)): \(action)")
+            print("    \(abbreviatedHomePath(result.url))")
+        }
+        if changed {
+            print("\nRestart running agents to refresh their available skills.")
+        }
+    }
+
+    private static func agentNames(_ destination: KeroAutomationSkill.Destination) -> String {
+        let displayNames = destination.agents.map { agent in
+            switch agent {
+            case "codex": "Codex"
+            case "gemini": "Gemini"
+            case "cursor": "Cursor"
+            case "opencode": "OpenCode"
+            case "claude": "Claude"
+            case "amp": "Amp"
+            case "pi": "Pi"
+            default: agent
+            }
+        }
+        return displayNames.joined(separator: ", ")
+    }
+
+    private static func skillStateLabel(
+        _ state: KeroAutomationSkill.InstallationState
+    ) -> String {
+        switch state {
+        case .missing: "Not installed"
+        case .current: "Installed and current"
+        case .updateAvailable: "Needs relinking"
+        case .unmanaged: "Present but not managed by Kero"
+        case .modified: "Locally modified"
+        }
+    }
+
+    private static func abbreviatedHomePath(_ url: URL) -> String {
+        let path = url.standardizedFileURL.path
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        guard path == home || path.hasPrefix(home + "/") else { return path }
+        return "~" + String(path.dropFirst(home.count))
+    }
+
+    private static func skillSnapshot(
+        _ item: KeroAutomationSkill.Snapshot
+    ) -> KeroJSONValue {
+        .object([
+            "destination": .string(item.destination.rawValue),
+            "agents": .array(item.destination.agents.map(KeroJSONValue.string)),
+            "path": .string(item.url.path),
+            "state": .string(item.state.rawValue),
+        ])
+    }
+
+    private static func skillMutation(
+        _ item: KeroAutomationSkill.MutationResult
+    ) -> KeroJSONValue {
+        .object([
+            "destination": .string(item.destination.rawValue),
+            "agents": .array(item.destination.agents.map(KeroJSONValue.string)),
+            "path": .string(item.url.path),
+            "previous_state": .string(item.previousState.rawValue),
+            "state": .string(item.state.rawValue),
+        ])
+    }
+
+    private static func skillResult(
+        action: String,
+        provider: String,
+        destinations: [KeroJSONValue],
+        changed: Bool,
+        reloadRecommended: Bool = false
+    ) throws -> KeroJSONValue {
+        .object([
+            "skill": .string(KeroAutomationSkill.name),
+            "action": .string(action),
+            "provider": .string(provider),
+            "source_path": .string(try KeroAutomationSkill.bundledSkillURL().path),
+            "destinations": .array(destinations),
+            "changed": .bool(changed),
+            "reload_or_restart_agents": .bool(reloadRecommended),
+        ])
+    }
+
+    private static func runAgent(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        let command = arguments[0]
+        let tail = Array(arguments.dropFirst())
+        switch command {
+        case "list":
+            try requireNoArguments(tail, command: "+agent list")
+            return try connection.automationRequest(method: "agent.list")
+        case "get":
+            let target = try parseAgentTarget(tail, command: "+agent get")
+            return try connection.automationRequest(
+                method: "agent.get", params: target.params
+            )
+        case "start":
+            return try startAgent(tail, connection: connection)
+        case "prompt":
+            return try promptAgent(tail, connection: connection)
+        case "read":
+            return try readAgent(tail, connection: connection)
+        case "wait":
+            return try waitForAgent(tail, connection: connection)
+        case "help", "--help", "-h":
+            printAgentHelp()
+            return .object(["help": .bool(true)])
+        default:
+            throw CLIError.message(
+                "Unknown +agent command \(command). Run `kero +agent --help`."
+            )
+        }
+    }
+
+    private static func startAgent(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        guard let alias = arguments.first, !alias.hasPrefix("--") else {
+            throw CLIError.message("`kero +agent start` requires an alias.")
+        }
+        var paneID: String?
+        var kind: String?
+        var focus = false
+        var timeoutMS = 30_000
+        var extra: [String] = []
+        var index = 1
+        while index < arguments.count {
+            if arguments[index] == "--" {
+                extra = Array(arguments.dropFirst(index + 1))
+                break
+            }
+            switch arguments[index] {
+            case "--pane": paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": paneID = nil
+            case "--kind": kind = try value(after: &index, in: arguments, option: "--kind")
+            case "--focus": focus = true
+            case "--no-focus": focus = false
+            case "--timeout": timeoutMS = try integerValue(
+                after: &index, in: arguments, option: "--timeout"
+            )
+            default: throw unknownOption(arguments[index], command: "+agent start")
+            }
+            index += 1
+        }
+        guard let kind else {
+            throw CLIError.message("`kero +agent start` requires --kind.")
+        }
+        guard (3_000...300_000).contains(timeoutMS) else {
+            throw CLIError.message("Agent start timeout must be between 3000 and 300000 milliseconds.")
+        }
+        var params = targetParams(paneID: paneID)
+        params["alias"] = .string(alias)
+        params["kind"] = .string(kind)
+        params["focus"] = .bool(focus)
+        params["argv"] = .array(extra.map(KeroJSONValue.string))
+        let launched = try connection.automationRequest(method: "agent.start", params: params)
+        return try pollAgentStarted(
+            target: stableTarget(
+                from: launched,
+                fallback: AgentTarget(alias: alias, paneID: paneID)
+            ),
+            timeoutMS: timeoutMS,
+            connection: connection
+        )
+    }
+
+    private static func promptAgent(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var target = AgentTarget()
+        var prompt: String?
+        var wait = false
+        var timeoutMS = 120_000
+        var positional: [String] = []
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": target.paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--text": prompt = try value(after: &index, in: arguments, option: "--text")
+            case "--wait": wait = true
+            case "--timeout": timeoutMS = try integerValue(after: &index, in: arguments, option: "--timeout")
+            default:
+                if arguments[index].hasPrefix("--") {
+                    throw unknownOption(arguments[index], command: "+agent prompt")
+                }
+                positional.append(arguments[index])
+            }
+            index += 1
+        }
+        if target.paneID == nil, !positional.isEmpty {
+            target.alias = positional.removeFirst()
+        }
+        if prompt == nil, !positional.isEmpty {
+            prompt = positional.joined(separator: " ")
+            positional.removeAll()
+        }
+        guard positional.isEmpty else {
+            throw CLIError.message("Unexpected positional arguments after --text.")
+        }
+        guard target.alias != nil || target.paneID != nil else {
+            throw CLIError.message("Name an agent alias or pass --pane.")
+        }
+        guard let prompt, !prompt.isEmpty else {
+            throw CLIError.message("Pass prompt text with --text or after the alias.")
+        }
+        var params = target.params
+        params["text"] = .string(prompt)
+        let submitted = try connection.automationRequest(method: "agent.prompt", params: params)
+        guard wait else { return submitted }
+        try validateTimeout(timeoutMS)
+        return try pollAgent(
+            target: stableTarget(from: submitted, fallback: target),
+            states: [.idle, .done, .blocked],
+            timeoutMS: timeoutMS,
+            connection: connection
+        )
+    }
+
+    private static func readAgent(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var targetArgs: [String] = []
+        var lines = 120
+        var columns = 400
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--lines": lines = try integerValue(after: &index, in: arguments, option: "--lines")
+            case "--columns": columns = try integerValue(after: &index, in: arguments, option: "--columns")
+            default: targetArgs.append(arguments[index])
+            }
+            index += 1
+        }
+        let target = try parseAgentTarget(targetArgs, command: "+agent read")
+        let agent = try connection.automationRequest(method: "agent.get", params: target.params)
+        guard let paneID = agent.objectValue?["pane_id"]?.stringValue else {
+            throw CLIError.message("Kero returned an agent without a pane ID.")
+        }
+        return try connection.automationRequest(method: "pane.read", params: [
+            "pane_id": .string(paneID),
+            "lines": .number(Double(lines)),
+            "columns": .number(Double(columns)),
+            "require_idle_agent": .bool(true),
+        ])
+    }
+
+    private static func waitForAgent(
+        _ arguments: [String],
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        var targetArgs: [String] = []
+        var stateNames = "idle,done,blocked"
+        var timeoutMS = 120_000
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--state": stateNames = try value(after: &index, in: arguments, option: "--state")
+            case "--timeout": timeoutMS = try integerValue(after: &index, in: arguments, option: "--timeout")
+            default: targetArgs.append(arguments[index])
+            }
+            index += 1
+        }
+        let target = try parseAgentTarget(targetArgs, command: "+agent wait")
+        let states = try parseAgentStates(stateNames)
+        try validateTimeout(timeoutMS)
+        return try pollAgent(
+            target: target,
+            states: states,
+            timeoutMS: timeoutMS,
+            connection: connection
+        )
+    }
+
+    private static func pollAgent(
+        target: AgentTarget,
+        states: Set<KeroAgentPhase>,
+        timeoutMS: Int,
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        let deadline = Date().addingTimeInterval(Double(timeoutMS) / 1_000)
+        repeat {
+            let result = try connection.automationRequest(
+                method: "agent.get", params: target.params
+            )
+            if let name = result.objectValue?["agent"]?.objectValue?["state"]?.stringValue,
+               let phase = KeroAgentPhase(rawValue: name), states.contains(phase) {
+                return result
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        } while Date() < deadline
+        throw CLIError.message(
+            "Timed out waiting for agent state \(states.map(\.rawValue).sorted().joined(separator: ", "))."
+        )
+    }
+
+    private static func pollAgentStarted(
+        target: AgentTarget,
+        timeoutMS: Int,
+        connection: AppConnection
+    ) throws -> KeroJSONValue {
+        let deadline = Date().addingTimeInterval(Double(timeoutMS) / 1_000)
+        repeat {
+            do {
+                let result = try connection.automationRequest(
+                    method: "agent.get", params: target.params
+                )
+                if let agent = result.objectValue?["agent"]?.objectValue,
+                   agent["authority"]?.stringValue != KeroAgentStateAuthority.command.rawValue,
+                   case .number? = agent["process_id"] {
+                    return result
+                }
+            } catch let error as CLIError {
+                guard case .message(let message) = error,
+                      message.hasPrefix("agent_not_found:") else {
+                    throw error
+                }
+                throw CLIError.message(
+                    "agent_not_running: The launched agent exited before Kero recognized it."
+                )
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        } while Date() < deadline
+        throw CLIError.message("Timed out waiting for Kero to recognize the launched agent.")
+    }
+
+    // MARK: - Parsing
+
+    private struct ReadOptions {
+        var paneID: String?
+        var lines = 80
+        var columns = 400
+    }
+
+    private struct AgentTarget {
+        var alias: String?
+        var paneID: String?
+
+        var params: [String: KeroJSONValue] {
+            if let paneID { return ["pane_id": .string(paneID)] }
+            if let alias { return ["alias": .string(alias)] }
+            return [:]
+        }
+    }
+
+    private static func parsePaneOnly(
+        _ arguments: [String], command: String
+    ) throws -> String? {
+        var paneID: String?
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": paneID = nil
+            default: throw unknownOption(arguments[index], command: command)
+            }
+            index += 1
+        }
+        return paneID
+    }
+
+    private static func parseReadOptions(
+        _ arguments: [String], command: String
+    ) throws -> ReadOptions {
+        var result = ReadOptions()
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane": result.paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current": result.paneID = nil
+            case "--lines": result.lines = try integerValue(after: &index, in: arguments, option: "--lines")
+            case "--columns": result.columns = try integerValue(after: &index, in: arguments, option: "--columns")
+            default: throw unknownOption(arguments[index], command: command)
+            }
+            index += 1
+        }
+        return result
+    }
+
+    private static func parseAgentTarget(
+        _ arguments: [String], command: String
+    ) throws -> AgentTarget {
+        var result = AgentTarget()
+        var current = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--pane":
+                guard result.paneID == nil, result.alias == nil, !current else {
+                    throw CLIError.message("Choose exactly one agent alias, --pane, or --current.")
+                }
+                result.paneID = try value(after: &index, in: arguments, option: "--pane")
+            case "--current":
+                guard result.paneID == nil, result.alias == nil, !current else {
+                    throw CLIError.message("Choose exactly one agent alias, --pane, or --current.")
+                }
+                current = true
+            default:
+                guard !arguments[index].hasPrefix("--"), result.alias == nil,
+                      result.paneID == nil, !current else {
+                    throw unknownOption(arguments[index], command: command)
+                }
+                result.alias = arguments[index]
+            }
+            index += 1
+        }
+        guard result.paneID != nil || result.alias != nil || current else {
+            throw CLIError.message("\(command) requires an agent alias, --pane, or --current.")
+        }
+        return result
+    }
+
+    private static func stableTarget(
+        from snapshot: KeroJSONValue,
+        fallback: AgentTarget
+    ) -> AgentTarget {
+        guard let paneID = snapshot.objectValue?["pane_id"]?.stringValue else {
+            return fallback
+        }
+        return AgentTarget(alias: nil, paneID: paneID)
+    }
+
+    private static func readParams(_ options: ReadOptions) -> [String: KeroJSONValue] {
+        var params = targetParams(paneID: options.paneID)
+        params["lines"] = .number(Double(options.lines))
+        params["columns"] = .number(Double(options.columns))
+        return params
+    }
+
+    private static func targetParams(paneID: String?) -> [String: KeroJSONValue] {
+        paneID.map { ["pane_id": .string($0)] } ?? [:]
+    }
+
+    private static func parseAgentStates(_ value: String) throws -> Set<KeroAgentPhase> {
+        let values = value.split(separator: ",").map(String.init)
+        let states = Set(values.compactMap(KeroAgentPhase.init(rawValue:)))
+        guard !values.isEmpty, states.count == values.count else {
+            throw CLIError.message(
+                "--state accepts comma-separated created, working, blocked, done, idle, or unknown."
+            )
+        }
+        return states
+    }
+
+    private static func value(
+        after index: inout Int,
+        in arguments: [String],
+        option: String
+    ) throws -> String {
+        index += 1
+        guard index < arguments.count else {
+            throw CLIError.message("\(option) requires a value.")
+        }
+        return arguments[index]
+    }
+
+    private static func integerValue(
+        after index: inout Int,
+        in arguments: [String],
+        option: String
+    ) throws -> Int {
+        let raw = try value(after: &index, in: arguments, option: option)
+        guard let result = Int(raw), result > 0 else {
+            throw CLIError.message("\(option) requires a positive integer.")
+        }
+        return result
+    }
+
+    private static func validateTimeout(_ milliseconds: Int) throws {
+        guard (100...3_600_000).contains(milliseconds) else {
+            throw CLIError.message("Timeout must be between 100 and 3600000 milliseconds.")
+        }
+    }
+
+    private static func requireNoArguments(
+        _ arguments: [String], command: String
+    ) throws {
+        guard arguments.isEmpty else { throw unknownOption(arguments[0], command: command) }
+    }
+
+    private static func unknownOption(_ value: String, command: String) -> CLIError {
+        .message("Unknown option \(value) for `kero \(command)`. Run `kero \(command.components(separatedBy: " ").first ?? command) --help`.")
+    }
+
+    private static func printJSON(_ value: KeroJSONValue) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        guard let output = String(data: data, encoding: .utf8) else {
+            throw CLIError.message("Could not encode Kero's automation response.")
+        }
+        print(output)
+    }
+
+    // MARK: - Help
+
+    private static func printPaneHelp() {
+        print("""
+        Usage:
+          kero +pane current
+          kero +pane list
+          kero +pane get [--pane ID | --current]
+          kero +pane split [--pane ID] [--left|--right|--up|--down] [--cwd PATH] [--focus]
+          kero +pane run [--pane ID] -- command [arguments...]
+          kero +pane send [--pane ID] --text TEXT [--enter]
+          kero +pane read [--pane ID] [--lines N] [--columns N]
+          kero +pane wait-output [--pane ID] --contains TEXT [--timeout MS]
+          kero +pane protocol
+
+        Targets default to the invoking terminal. Splits default to the right
+        and never steal focus unless --focus is explicit. `run` accepts argv
+        and quotes each argument for the target shell. `send` is raw input.
+        All successful results are JSON; reads do not mark agent output seen.
+        """)
+    }
+
+    private static func printAgentHelp() {
+        print("""
+        Usage:
+          kero +agent list
+          kero +agent get ALIAS | --pane ID | --current
+          kero +agent start ALIAS --kind KIND [--pane ID] [--focus] [--timeout MS] [-- agent-arguments...]
+          kero +agent prompt ALIAS --text TEXT [--wait] [--timeout MS]
+          kero +agent read ALIAS [--lines N] [--columns N]
+          kero +agent wait ALIAS [--state idle,done,blocked] [--timeout MS]
+          kero +agent skill <path|print|status|install|uninstall> [options]
+          kero +agent explain
+
+        Supported kinds: codex, claude, gemini, opencode, cursor-agent, aider,
+        amp, and pi. Agent start requires an existing available shell and never
+        creates layout; it returns after Kero recognizes the launched process.
+        Guarded prompts accept agents in created, working, idle, or done. While
+        an agent is working, its CLI decides whether input steers the active
+        turn or queues it. Use +pane send only when raw input is intentional.
+        Kero never asks a model to announce completion. Native lifecycle
+        hooks/plugins are authoritative when available; otherwise Kero
+        debounces the recognized agent's live terminal UI. A settled background
+        agent appears as done until its pane is focused. `skill install`
+        explicitly links Kero's bundled coordination skill into supported
+        agents; it never changes user files unless invoked.
+        """)
+    }
+
+    private static func printAgentSkillHelp() {
+        print("""
+        Usage:
+          kero +agent skill path
+          kero +agent skill print
+          kero +agent skill status [--provider PROVIDER] [--json]
+          kero +agent skill install [--provider PROVIDER] [--force] [--json]
+          kero +agent skill uninstall [--provider PROVIDER] [--force] [--json]
+
+        PROVIDER may be all, universal, codex, claude, gemini, cursor,
+        opencode, amp, or pi. The default is all. Codex, Gemini, Cursor,
+        OpenCode, Amp, and Pi share ~/.agents/skills; Claude uses
+        ~/.claude/skills. Existing local changes are never replaced or removed
+        without --force. Installation uses symlinks to Kero's app bundle, so
+        app updates update the skill without reinstalling it. Reload skills or
+        restart an already-running agent after first installation or a Kero
+        update.
+
+        path and print expose Kero's read-only bundled skill without installing
+        it. Management commands are human-readable by default; pass --json for
+        stable machine-readable output.
+        """)
+    }
+
+    private static func printAgentContract() {
+        print("""
+        Kero agent automation contract
+
+        1. A pane is layout. A terminal is raw I/O. An agent is a recognized
+           terminal occupant with semantic state. These IDs are not interchangeable.
+        2. Capabilities are scoped to the invoking terminal's project. Guessed
+           IDs in other projects and windows are never resolved.
+        3. Creation is explicit: split first, then start an agent in that shell.
+           Neither start nor prompt silently creates or closes layout.
+        4. Background operations default to no focus. Reading output never marks
+           a completion seen; focusing its pane does.
+        5. Agent prompts require both a live recognized process and an allowed
+           lifecycle state. Raw +pane send is a visibly separate escape hatch
+           and can interact with any terminal program.
+        6. A recognized process Kero launched is created until its first prompt.
+           The model is never asked to report lifecycle. Kero uses a complete
+           native hook/plugin when installed and repeated process-scoped live
+           terminal observations otherwise. Unseen idle is presented as done.
+        7. The optional kero-automation Agent Skill teaches this workflow to
+           compatible agents. Enable AI in Settings or install it explicitly
+           with `kero +agent skill install`. The AI setting also manages only
+           the provider integrations Kero can use as lifecycle authorities.
+        """)
+    }
+}

--- a/kero/KeroAutomationProtocol.swift
+++ b/kero/KeroAutomationProtocol.swift
@@ -1,0 +1,480 @@
+//
+//  KeroAutomationProtocol.swift
+//  kero
+//
+
+import Darwin
+import Foundation
+
+/// JSON values used by the local automation protocol. Keeping the wire model
+/// concrete avoids accepting arbitrary Foundation object graphs at the app
+/// boundary and lets both the app and bundled CLI share one Codable contract.
+enum KeroJSONValue: Codable, Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: KeroJSONValue])
+    case array([KeroJSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: KeroJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([KeroJSONValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    var intValue: Int? {
+        guard case .number(let value) = self,
+              value.rounded() == value,
+              value >= Double(Int.min), value <= Double(Int.max)
+        else { return nil }
+        return Int(value)
+    }
+
+    var arrayValue: [KeroJSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    var objectValue: [String: KeroJSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+}
+
+struct KeroAutomationRequest: Codable, Sendable {
+    let version: Int
+    let id: String
+    let method: String
+    let token: String
+    let terminalID: String
+    let params: [String: KeroJSONValue]
+}
+
+struct KeroAutomationErrorPayload: Codable, Sendable {
+    let code: String
+    let message: String
+}
+
+struct KeroAutomationResponse: Codable, Sendable {
+    let version: Int
+    let id: String
+    let ok: Bool
+    let result: KeroJSONValue?
+    let error: KeroAutomationErrorPayload?
+
+    static func success(id: String, result: KeroJSONValue) -> Self {
+        Self(version: 1, id: id, ok: true, result: result, error: nil)
+    }
+
+    static func failure(id: String, code: String, message: String) -> Self {
+        Self(
+            version: 1,
+            id: id,
+            ok: false,
+            result: nil,
+            error: KeroAutomationErrorPayload(code: code, message: message)
+        )
+    }
+}
+
+enum KeroAutomationWireError: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let message): return message
+        }
+    }
+}
+
+/// A versioned NDJSON request/response channel over a private Unix-domain
+/// socket. Each connection carries one request and one response. That keeps
+/// failure recovery simple for short-lived CLI processes and bounds memory
+/// before any request reaches Kero's main actor.
+final class KeroAutomationSocketServer: @unchecked Sendable {
+    typealias Handler = @Sendable (
+        KeroAutomationRequest,
+        @escaping @Sendable (KeroAutomationResponse) -> Void
+    ) -> Void
+
+    private static let maximumMessageBytes = 1_048_576
+
+    let path: String
+    private let listener: Int32
+    private let queue = DispatchQueue(label: "sh.kero.automation.socket")
+    private let workers = DispatchQueue(
+        label: "sh.kero.automation.clients",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private let handler: Handler
+    private var source: DispatchSourceRead?
+
+    init(path: String, handler: @escaping Handler) throws {
+        self.path = path
+        self.handler = handler
+
+        let listener = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listener >= 0 else {
+            throw KeroAutomationWireError.message("socket: \(String(cString: strerror(errno)))")
+        }
+        self.listener = listener
+
+        do {
+            try Self.configureSocket(listener)
+            var address = try Self.address(for: path)
+            unlink(path)
+            let result = withUnsafePointer(to: &address.value) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.bind(listener, $0, address.length)
+                }
+            }
+            guard result == 0 else {
+                throw KeroAutomationWireError.message(
+                    "bind: \(String(cString: strerror(errno)))"
+                )
+            }
+            guard Darwin.chmod(path, 0o600) == 0 else {
+                throw KeroAutomationWireError.message(
+                    "chmod: \(String(cString: strerror(errno)))"
+                )
+            }
+            guard Darwin.listen(listener, 16) == 0 else {
+                throw KeroAutomationWireError.message(
+                    "listen: \(String(cString: strerror(errno)))"
+                )
+            }
+            let flags = fcntl(listener, F_GETFL, 0)
+            guard flags >= 0, fcntl(listener, F_SETFL, flags | O_NONBLOCK) == 0 else {
+                throw KeroAutomationWireError.message(
+                    "fcntl: \(String(cString: strerror(errno)))"
+                )
+            }
+        } catch {
+            Darwin.close(listener)
+            unlink(path)
+            throw error
+        }
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: listener, queue: queue)
+        source.setEventHandler { [weak self] in self?.acceptAvailableClients() }
+        source.setCancelHandler { Darwin.close(listener) }
+        self.source = source
+        source.resume()
+    }
+
+    deinit {
+        source?.cancel()
+        unlink(path)
+    }
+
+    private func acceptAvailableClients() {
+        while true {
+            let client = Darwin.accept(listener, nil, nil)
+            if client < 0 {
+                if errno == EINTR { continue }
+                if errno != EAGAIN && errno != EWOULDBLOCK {
+                    NSLog("kero: automation accept failed: %s", strerror(errno))
+                }
+                return
+            }
+            do {
+                try Self.configureSocket(client)
+                // Darwin can propagate O_NONBLOCK from the listening socket
+                // to accepted descriptors. Client workers use a bounded,
+                // blocking request read; leaving this set races the writer
+                // and can close a healthy connection with EAGAIN.
+                let flags = fcntl(client, F_GETFL, 0)
+                guard flags >= 0,
+                      fcntl(client, F_SETFL, flags & ~O_NONBLOCK) == 0
+                else {
+                    throw KeroAutomationWireError.message(
+                        "fcntl: \(String(cString: strerror(errno)))"
+                    )
+                }
+            } catch {
+                Darwin.close(client)
+                continue
+            }
+            workers.async { [weak self] in
+                guard let self else {
+                    Darwin.close(client)
+                    return
+                }
+                self.readRequest(from: client)
+            }
+        }
+    }
+
+    private func readRequest(from client: Int32) {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 8_192)
+
+        while data.count <= Self.maximumMessageBytes {
+            let count = Darwin.read(client, &buffer, buffer.count)
+            if count > 0 {
+                data.append(buffer, count: count)
+                if data.contains(0x0A) { break }
+            } else if count == 0 {
+                break
+            } else if errno == EINTR {
+                continue
+            } else {
+                respond(
+                    .failure(
+                        id: "unknown", code: "transport_error",
+                        message: String(cString: strerror(errno))
+                    ),
+                    to: client
+                )
+                return
+            }
+        }
+
+        guard data.count <= Self.maximumMessageBytes else {
+            respond(
+                .failure(
+                    id: "unknown", code: "request_too_large",
+                    message: "Automation requests are limited to 1 MiB."
+                ),
+                to: client
+            )
+            return
+        }
+        if let newline = data.firstIndex(of: 0x0A) {
+            data = data[..<newline]
+        }
+
+        let request: KeroAutomationRequest
+        do {
+            request = try JSONDecoder().decode(KeroAutomationRequest.self, from: data)
+        } catch {
+            respond(
+                .failure(
+                    id: "unknown", code: "invalid_request",
+                    message: "Invalid automation request: \(error.localizedDescription)"
+                ),
+                to: client
+            )
+            return
+        }
+
+        handler(request) { [weak self] response in
+            guard let self else {
+                Darwin.close(client)
+                return
+            }
+            self.workers.async { self.respond(response, to: client) }
+        }
+    }
+
+    private func respond(_ response: KeroAutomationResponse, to client: Int32) {
+        defer { Darwin.close(client) }
+        guard var data = try? JSONEncoder.keroAutomation.encode(response) else { return }
+        data.append(0x0A)
+        data.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let written = Darwin.write(
+                    client,
+                    raw.baseAddress!.advanced(by: offset),
+                    raw.count - offset
+                )
+                if written > 0 {
+                    offset += written
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    static func exchange(
+        path: String,
+        request: KeroAutomationRequest,
+        timeout: TimeInterval = 5
+    ) throws -> KeroAutomationResponse {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw KeroAutomationWireError.message(
+                "Could not create the automation socket: \(String(cString: strerror(errno)))."
+            )
+        }
+        defer { Darwin.close(descriptor) }
+        try configureSocket(descriptor, timeout: timeout)
+
+        var address = try Self.address(for: path)
+        let connected = withUnsafePointer(to: &address.value) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, address.length)
+            }
+        }
+        guard connected == 0 else {
+            throw KeroAutomationWireError.message(
+                "Could not connect to Kero automation: \(String(cString: strerror(errno)))."
+            )
+        }
+
+        var encoded = try JSONEncoder.keroAutomation.encode(request)
+        encoded.append(0x0A)
+        try encoded.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let written = Darwin.write(
+                    descriptor,
+                    raw.baseAddress!.advanced(by: offset),
+                    raw.count - offset
+                )
+                if written > 0 {
+                    offset += written
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    throw KeroAutomationWireError.message(
+                        "Could not send the automation request: \(String(cString: strerror(errno)))."
+                    )
+                }
+            }
+        }
+        Darwin.shutdown(descriptor, SHUT_WR)
+
+        var responseData = Data()
+        var buffer = [UInt8](repeating: 0, count: 8_192)
+        while responseData.count <= maximumMessageBytes {
+            let count = Darwin.read(descriptor, &buffer, buffer.count)
+            if count > 0 {
+                responseData.append(buffer, count: count)
+                if responseData.contains(0x0A) { break }
+            } else if count == 0 {
+                break
+            } else if errno == EINTR {
+                continue
+            } else {
+                throw KeroAutomationWireError.message(
+                    "Could not read Kero's automation response: \(String(cString: strerror(errno)))."
+                )
+            }
+        }
+        guard responseData.count <= maximumMessageBytes else {
+            throw KeroAutomationWireError.message("Kero returned an oversized automation response.")
+        }
+        if let newline = responseData.firstIndex(of: 0x0A) {
+            responseData = responseData[..<newline]
+        }
+        guard !responseData.isEmpty else {
+            throw KeroAutomationWireError.message("Kero closed the automation connection without a response.")
+        }
+        return try JSONDecoder().decode(KeroAutomationResponse.self, from: responseData)
+    }
+
+    private static func configureSocket(
+        _ descriptor: Int32,
+        timeout: TimeInterval = 2
+    ) throws {
+        var enabled: Int32 = 1
+        guard setsockopt(
+            descriptor, SOL_SOCKET, SO_NOSIGPIPE,
+            &enabled, socklen_t(MemoryLayout<Int32>.size)
+        ) == 0 else {
+            throw KeroAutomationWireError.message(
+                "setsockopt: \(String(cString: strerror(errno)))"
+            )
+        }
+
+        let wholeSeconds = floor(timeout)
+        var value = timeval(
+            tv_sec: Int(wholeSeconds),
+            tv_usec: Int32((timeout - wholeSeconds) * 1_000_000)
+        )
+        guard setsockopt(
+            descriptor, SOL_SOCKET, SO_RCVTIMEO,
+            &value, socklen_t(MemoryLayout<timeval>.size)
+        ) == 0 else {
+            throw KeroAutomationWireError.message(
+                "setsockopt: \(String(cString: strerror(errno)))"
+            )
+        }
+        guard setsockopt(
+            descriptor, SOL_SOCKET, SO_SNDTIMEO,
+            &value, socklen_t(MemoryLayout<timeval>.size)
+        ) == 0 else {
+            throw KeroAutomationWireError.message(
+                "setsockopt: \(String(cString: strerror(errno)))"
+            )
+        }
+    }
+
+    private static func address(
+        for path: String
+    ) throws -> (value: sockaddr_un, length: socklen_t) {
+        let bytes = Array(path.utf8CString)
+        var value = sockaddr_un()
+        let capacity = MemoryLayout.size(ofValue: value.sun_path)
+        guard bytes.count <= capacity else {
+            throw KeroAutomationWireError.message(
+                "Automation socket path is too long for macOS: \(path)"
+            )
+        }
+
+        let length = MemoryLayout<sa_family_t>.size + bytes.count
+        value.sun_len = UInt8(length)
+        value.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutablePointer(to: &value.sun_path) { tuple in
+            tuple.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                for index in bytes.indices {
+                    destination[index] = bytes[index]
+                }
+            }
+        }
+        return (value, socklen_t(length))
+    }
+}
+
+extension JSONEncoder {
+    fileprivate static var keroAutomation: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+}

--- a/kero/KeroAutomationRouter.swift
+++ b/kero/KeroAutomationRouter.swift
@@ -1,0 +1,547 @@
+//
+//  KeroAutomationRouter.swift
+//  kero
+//
+
+import AppKit
+import Foundation
+
+/// Main-actor command router behind the authenticated Unix socket. A caller's
+/// capability resolves to one terminal and therefore one project. Targets are
+/// searched only inside that project; no request can reach another window or
+/// project by guessing a UUID.
+@MainActor
+enum KeroAutomationRouter {
+    private struct PaneContext {
+        let manager: TerminalManager
+        let project: Project
+        let tab: PaneTab
+        let pane: Pane
+
+        var session: TerminalSession? {
+            guard case .session(let session) = pane.content else { return nil }
+            return session
+        }
+    }
+
+    static func route(
+        _ request: KeroAutomationRequest,
+        callerTerminalID: UUID
+    ) async -> KeroAutomationResponse {
+        guard let caller = context(forSession: callerTerminalID) else {
+            return failure(
+                request, "caller_closed",
+                "The terminal that owned this capability is no longer open."
+            )
+        }
+
+        switch request.method {
+        case "protocol.info":
+            return success(request, .object([
+                "version": .number(1),
+                "scope": .string("project"),
+                "current_terminal_id": .string(callerTerminalID.uuidString),
+                "reads_mark_seen": .bool(false),
+                "split_focus_default": .bool(false),
+            ]))
+
+        case "pane.current":
+            return success(request, paneSnapshot(caller, caller: caller))
+
+        case "pane.list":
+            return success(
+                request,
+                .array(projectContexts(caller.project, manager: caller.manager).map {
+                    paneSnapshot($0, caller: caller)
+                })
+            )
+
+        case "pane.get":
+            guard let target = targetPane(request, caller: caller) else {
+                return failure(request, "pane_not_found", "No matching pane exists in this project.")
+            }
+            return success(request, paneSnapshot(target, caller: caller))
+
+        case "pane.split":
+            return splitPane(request, caller: caller)
+
+        case "pane.run":
+            return runInPane(request, caller: caller)
+
+        case "pane.send":
+            return sendToPane(request, caller: caller)
+
+        case "pane.read":
+            return await readPane(request, caller: caller)
+
+        case "agent.list":
+            let agents = projectContexts(caller.project, manager: caller.manager)
+                .compactMap { context -> KeroJSONValue? in
+                    guard context.session?.agentStatus != nil else { return nil }
+                    return paneSnapshot(context, caller: caller)
+                }
+            return success(request, .array(agents))
+
+        case "agent.get":
+            guard let target = targetAgent(request, caller: caller) else {
+                return failure(request, "agent_not_found", "No matching agent exists in this project.")
+            }
+            return success(request, paneSnapshot(target, caller: caller))
+
+        case "agent.start":
+            return startAgent(request, caller: caller)
+
+        case "agent.prompt":
+            return promptAgent(request, caller: caller)
+
+        case "agent.report":
+            return reportAgent(request, caller: caller)
+
+        default:
+            return failure(
+                request, "method_not_found",
+                "Unknown automation method \(request.method)."
+            )
+        }
+    }
+
+    private static func splitPane(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let target = targetPane(request, caller: caller) else {
+            return failure(request, "pane_not_found", "No matching pane exists in this project.")
+        }
+        guard !target.pane.content.isDiff else {
+            return failure(request, "pane_not_splittable", "Diff panes cannot be split.")
+        }
+        guard let edgeName = request.params["edge"]?.stringValue,
+              let edge = paneEdge(edgeName)
+        else {
+            return failure(
+                request, "invalid_params",
+                "edge must be one of left, right, top, or bottom."
+            )
+        }
+        let focus = request.params["focus"]?.boolValue ?? false
+        let directory = request.params["cwd"]?.stringValue
+        if let directory {
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(
+                atPath: directory, isDirectory: &isDirectory
+            ), isDirectory.boolValue else {
+                return failure(
+                    request, "invalid_directory",
+                    "The requested working directory does not exist."
+                )
+            }
+        }
+
+        guard let created = caller.project.automationSplitTerminal(
+            beside: target.pane.id,
+            toward: edge,
+            directory: directory,
+            focus: focus
+        ) else {
+            return failure(request, "pane_not_splittable", "The target pane could not be split.")
+        }
+        if focus { TerminalManager.revealSession(id: created.session.id) }
+        let context = PaneContext(
+            manager: caller.manager,
+            project: caller.project,
+            tab: created.tab,
+            pane: created.pane
+        )
+        return success(request, paneSnapshot(context, caller: caller))
+    }
+
+    private static func runInPane(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let target = targetPane(request, caller: caller),
+              let session = target.session else {
+            return failure(request, "terminal_required", "The target pane is not a terminal.")
+        }
+        guard session.isShellAvailableForAutomation else {
+            return failure(
+                request, "shell_busy",
+                "The target terminal does not have an available foreground shell."
+            )
+        }
+        guard let argv = stringArray(request.params["argv"]),
+              !argv.isEmpty, argv.count <= 256,
+              !argv[0].isEmpty,
+              argv.allSatisfy({
+                  $0.utf8.count <= 16_384 && isSafeShellArgument($0)
+              })
+        else {
+            return failure(
+                request, "invalid_params",
+                "argv must contain 1 to 256 control-free arguments with a non-empty executable."
+            )
+        }
+        let command = argv.map(shellQuote).joined(separator: " ")
+        session.sendCommand(command + "\r")
+        return success(request, paneSnapshot(target, caller: caller))
+    }
+
+    private static func sendToPane(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let target = targetPane(request, caller: caller),
+              let session = target.session else {
+            return failure(request, "terminal_required", "The target pane is not a terminal.")
+        }
+        guard let text = request.params["text"]?.stringValue,
+              text.utf8.count <= 262_144 else {
+            return failure(
+                request, "invalid_params",
+                "text is required and is limited to 256 KiB."
+            )
+        }
+        session.sendCommand(text)
+        if request.params["enter"]?.boolValue == true {
+            session.sendCommand("\r")
+        }
+        return success(request, paneSnapshot(target, caller: caller))
+    }
+
+    private static func readPane(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) async -> KeroAutomationResponse {
+        guard let target = targetPane(request, caller: caller),
+              let session = target.session else {
+            return failure(request, "terminal_required", "The target pane is not a terminal.")
+        }
+        let lines = min(max(request.params["lines"]?.intValue ?? 80, 1), 500)
+        let columns = min(max(request.params["columns"]?.intValue ?? 400, 1), 2_000)
+        do {
+            let text = try await session.automationReadText(
+                maxLines: lines,
+                maxColumns: columns,
+                requireIdleAgentForHistory:
+                    request.params["require_idle_agent"]?.boolValue == true
+            )
+            return success(request, .object([
+                "pane": paneSnapshot(target, caller: caller),
+                "text": .string(text),
+                "lines": .number(Double(lines)),
+                "columns": .number(Double(columns)),
+            ]))
+        } catch KeroAutomationReadError.agentNotIdle {
+            return failure(
+                request,
+                "agent_not_idle",
+                "Alternate-screen transcript history is available only after the agent settles. Wait for idle or done, then read again."
+            )
+        } catch {
+            return failure(
+                request,
+                "read_failed",
+                "Kero could not read the terminal transcript."
+            )
+        }
+    }
+
+    private static func startAgent(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let target = targetPane(request, caller: caller),
+              let session = target.session else {
+            return failure(request, "terminal_required", "The target pane is not a terminal.")
+        }
+        guard session.isShellAvailableForAutomation else {
+            return failure(
+                request, "shell_busy",
+                "Agents can start only in an existing terminal with an available shell."
+            )
+        }
+        guard session.agentStatus == nil else {
+            return failure(
+                request, "agent_already_declared",
+                "This terminal already has an active or pending agent."
+            )
+        }
+        guard let alias = request.params["alias"]?.stringValue,
+              isValidAlias(alias) else {
+            return failure(
+                request, "invalid_alias",
+                "alias must be 1 to 64 ASCII letters, numbers, dots, underscores, or hyphens."
+            )
+        }
+        guard let kindName = request.params["kind"]?.stringValue,
+              let kind = KeroAgentKind(rawValue: kindName) else {
+            return failure(
+                request, "invalid_agent_kind",
+                "Supported kinds: \(KeroAgentKind.allCases.map(\.rawValue).joined(separator: ", "))."
+            )
+        }
+        let duplicate = caller.project.sessions.contains {
+            $0.id != session.id && $0.agentStatus?.alias == alias
+        }
+        guard !duplicate else {
+            return failure(
+                request, "alias_in_use",
+                "Another agent in this project already uses alias \(alias)."
+            )
+        }
+        let extra = stringArray(request.params["argv"]) ?? []
+        guard extra.count <= 128,
+              extra.allSatisfy({
+                  $0.utf8.count <= 16_384 && isSafeShellArgument($0)
+              }) else {
+            return failure(
+                request, "invalid_params",
+                "Agent arguments exceed the protocol limits or contain terminal control characters."
+            )
+        }
+
+        session.declareAutomationAgent(alias: alias, kind: kind)
+        let command = ([kind.executable] + extra).map(shellQuote).joined(separator: " ")
+        session.sendCommand(command + "\r")
+        if request.params["focus"]?.boolValue == true {
+            TerminalManager.revealSession(id: session.id)
+        }
+        return success(request, paneSnapshot(target, caller: caller))
+    }
+
+    private static func promptAgent(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let target = targetAgent(request, caller: caller),
+              let session = target.session,
+              let status = session.agentStatus else {
+            return failure(request, "agent_not_found", "No matching agent exists in this project.")
+        }
+        guard status.phase == .created
+                || status.phase == .working
+                || status.phase == .idle
+                || status.phase == .done else {
+            return failure(
+                request, "agent_not_ready",
+                "\(status.alias) is \(status.phase.rawValue); guarded prompts require created, working, idle, or done. Use +pane send for explicit raw input."
+            )
+        }
+        guard session.isAutomationAgentRunning(kind: status.kind) else {
+            return failure(
+                request, "agent_not_running",
+                "\(status.alias) has exited; start it again before sending a guarded prompt."
+            )
+        }
+        guard let prompt = request.params["text"]?.stringValue,
+              !prompt.isEmpty, prompt.utf8.count <= 262_144,
+              isSafePromptText(prompt) else {
+            return failure(
+                request, "invalid_prompt",
+                "Prompt text must be non-empty, contain no terminal control characters, and fit within 256 KiB."
+            )
+        }
+
+        let normalized = prompt
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        if normalized.contains("\n") {
+            session.sendCommand("\u{1b}[200~" + normalized + "\u{1b}[201~")
+        } else {
+            session.sendCommand(normalized)
+        }
+        session.sendCommand("\r")
+        session.markAutomationAgentPrompted()
+        return success(request, paneSnapshot(target, caller: caller))
+    }
+
+    private static func reportAgent(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> KeroAutomationResponse {
+        guard let session = caller.session else {
+            return failure(request, "terminal_required", "The caller is not a terminal pane.")
+        }
+        guard let name = request.params["state"]?.stringValue,
+              let phase = KeroAgentPhase(rawValue: name),
+              phase != .created else {
+            return failure(
+                request, "invalid_params",
+                "state must be working, blocked, done, idle, or unknown."
+            )
+        }
+        let reason = request.params["reason"]?.stringValue
+        guard reason?.utf8.count ?? 0 <= 4_096 else {
+            return failure(request, "invalid_params", "reason is limited to 4 KiB.")
+        }
+        guard session.reportAutomationAgent(phase: phase, reason: reason) else {
+            return failure(
+                request, "agent_not_recognized",
+                "Declare or start an agent in this terminal before reporting its state."
+            )
+        }
+        return success(request, paneSnapshot(caller, caller: caller))
+    }
+
+    private static func targetPane(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> PaneContext? {
+        guard let value = request.params["pane_id"] else { return caller }
+        guard let string = value.stringValue, let id = UUID(uuidString: string) else {
+            return nil
+        }
+        return projectContexts(caller.project, manager: caller.manager)
+            .first { $0.pane.id == id }
+    }
+
+    private static func targetAgent(
+        _ request: KeroAutomationRequest,
+        caller: PaneContext
+    ) -> PaneContext? {
+        if request.params["pane_id"] != nil {
+            guard let pane = targetPane(request, caller: caller),
+                  pane.session?.agentStatus != nil else { return nil }
+            return pane
+        }
+        if let alias = request.params["alias"]?.stringValue {
+            return projectContexts(caller.project, manager: caller.manager).first {
+                $0.session?.agentStatus?.alias == alias
+            }
+        }
+        return caller.session?.agentStatus == nil ? nil : caller
+    }
+
+    private static func context(forSession id: UUID) -> PaneContext? {
+        for manager in TerminalManager.automationManagers {
+            for project in manager.projects {
+                for tab in project.tabs {
+                    for pane in tab.allPanes {
+                        guard case .session(let session) = pane.content,
+                              session.id == id else { continue }
+                        return PaneContext(
+                            manager: manager, project: project, tab: tab, pane: pane
+                        )
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func projectContexts(
+        _ project: Project,
+        manager: TerminalManager
+    ) -> [PaneContext] {
+        project.tabs.flatMap { tab in
+            tab.allPanes.map {
+                PaneContext(manager: manager, project: project, tab: tab, pane: $0)
+            }
+        }
+    }
+
+    private static func paneSnapshot(
+        _ context: PaneContext,
+        caller: PaneContext
+    ) -> KeroJSONValue {
+        let contentKind: String = switch context.pane.content {
+        case .session: "terminal"
+        case .file: "file"
+        case .browser: "browser"
+        case .diff: "diff"
+        }
+        var object: [String: KeroJSONValue] = [
+            "project_id": .string(context.project.id.uuidString),
+            "project_name": .string(context.project.name),
+            "tab_id": .string(context.tab.id.uuidString),
+            "pane_id": .string(context.pane.id.uuidString),
+            "content": .string(contentKind),
+            "title": .string(context.pane.content.title),
+            "is_caller": .bool(context.pane.id == caller.pane.id),
+            "is_focused": .bool(
+                context.manager.selectedProjectID == context.project.id
+                    && context.project.selectedTabID == context.tab.id
+                    && context.tab.focusedPaneID == context.pane.id
+            ),
+        ]
+        if let session = context.session {
+            object["terminal_id"] = .string(session.id.uuidString)
+            object["cwd"] = .string(session.currentDirectoryPath)
+            object["shell_available"] = .bool(session.isShellAvailableForAutomation)
+            object["exited"] = .bool(session.hasExited)
+            object["agent"] = session.agentStatus.map(agentSnapshot) ?? .null
+        }
+        return .object(object)
+    }
+
+    private static func agentSnapshot(_ status: KeroAgentStatus) -> KeroJSONValue {
+        .object([
+            "alias": .string(status.alias),
+            "kind": .string(status.kind.rawValue),
+            "state": .string(status.phase.rawValue),
+            "authority": .string(status.authority.rawValue),
+            "reason": .string(status.reason),
+            "updated_at": .string(ISO8601DateFormatter().string(from: status.updatedAt)),
+            "process_id": status.processID.map { .number(Double($0)) } ?? .null,
+            "unseen": .bool(status.unseen),
+        ])
+    }
+
+    private static func paneEdge(_ value: String) -> PaneDropEdge? {
+        switch value {
+        case "left": return .left
+        case "right": return .right
+        case "top", "up": return .top
+        case "bottom", "down": return .bottom
+        default: return nil
+        }
+    }
+
+    private static func stringArray(_ value: KeroJSONValue?) -> [String]? {
+        guard let values = value?.arrayValue else { return nil }
+        let strings = values.compactMap(\.stringValue)
+        return strings.count == values.count ? strings : nil
+    }
+
+    private static func isValidAlias(_ value: String) -> Bool {
+        guard (1...64).contains(value.utf8.count) else { return false }
+        return value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0)
+                || (97...122).contains($0) || $0 == 45 || $0 == 46 || $0 == 95
+        }
+    }
+
+    private static func isSafePromptText(_ value: String) -> Bool {
+        value.unicodeScalars.allSatisfy { scalar in
+            (scalar.value >= 0x20 && !(0x7F...0x9F).contains(scalar.value))
+                || scalar.value == 0x0A
+                || scalar.value == 0x0D
+                || scalar.value == 0x09
+        }
+    }
+
+    private static func isSafeShellArgument(_ value: String) -> Bool {
+        value.unicodeScalars.allSatisfy {
+            $0.value >= 0x20 && !(0x7F...0x9F).contains($0.value)
+        }
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func success(
+        _ request: KeroAutomationRequest,
+        _ result: KeroJSONValue
+    ) -> KeroAutomationResponse {
+        .success(id: request.id, result: result)
+    }
+
+    private static func failure(
+        _ request: KeroAutomationRequest,
+        _ code: String,
+        _ message: String
+    ) -> KeroAutomationResponse {
+        .failure(id: request.id, code: code, message: message)
+    }
+}

--- a/kero/KeroAutomationSkill.swift
+++ b/kero/KeroAutomationSkill.swift
@@ -1,0 +1,437 @@
+//
+//  KeroAutomationSkill.swift
+//  kero
+//
+
+import Foundation
+
+/// Loads Kero's canonical Agent Skill from the app bundle and manages
+/// user-scoped discovery links. The shared `.agents` destination covers Codex,
+/// Gemini, Cursor, OpenCode, Amp, and Pi; Claude currently requires its own
+/// root.
+enum KeroAutomationSkill {
+    static let name = "kero-automation"
+
+    enum Destination: String, CaseIterable {
+        case universal
+        case claude
+
+        var relativeDirectory: String {
+            switch self {
+            case .universal: ".agents/skills/\(KeroAutomationSkill.name)"
+            case .claude: ".claude/skills/\(KeroAutomationSkill.name)"
+            }
+        }
+
+        var agents: [String] {
+            switch self {
+            case .universal: ["codex", "gemini", "cursor", "opencode", "amp", "pi"]
+            case .claude: ["claude"]
+            }
+        }
+    }
+
+    enum InstallationState: String {
+        case missing
+        case current
+        case updateAvailable = "update_available"
+        case unmanaged
+        case modified
+    }
+
+    struct Snapshot {
+        let destination: Destination
+        let url: URL
+        let state: InstallationState
+    }
+
+    struct MutationResult {
+        let destination: Destination
+        let url: URL
+        let previousState: InstallationState
+        let state: InstallationState
+    }
+
+    enum SkillError: Error, LocalizedError, CustomStringConvertible {
+        case message(String)
+
+        var description: String {
+            switch self {
+            case .message(let message): message
+            }
+        }
+
+        var errorDescription: String? { description }
+    }
+
+    private struct Source {
+        let skillURL: URL
+        let files: [String: URL]
+
+        var links: [String: String] {
+            files.mapValues { $0.standardizedFileURL.path }
+        }
+    }
+
+    private struct Manifest: Codable {
+        let formatVersion: Int
+        let skill: String
+        let links: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case formatVersion = "format_version"
+            case skill
+            case links
+        }
+    }
+
+    private static let manifestName = ".kero-managed.json"
+
+    static func bundledSkillURL() throws -> URL {
+        try source().skillURL
+    }
+
+    static func bundledSkillText() throws -> String {
+        let source = try source()
+        guard let skillURL = source.files["SKILL.md"] else {
+            throw SkillError.message("Kero's bundled automation SKILL.md is missing.")
+        }
+        let data = try Data(contentsOf: skillURL)
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else {
+            throw SkillError.message("Kero's bundled automation skill is not valid UTF-8.")
+        }
+        return text
+    }
+
+    static func destinations(for provider: String) throws -> [Destination] {
+        switch provider.lowercased() {
+        case "all":
+            return Destination.allCases
+        case "universal", "agents", "codex", "gemini", "cursor",
+             "cursor-agent", "opencode", "amp", "pi":
+            return [.universal]
+        case "claude":
+            return [.claude]
+        default:
+            throw SkillError.message(
+                "Unsupported skill provider \(provider.debugDescription). "
+                    + "Use all, universal, codex, claude, gemini, cursor, "
+                    + "opencode, amp, or pi."
+            )
+        }
+    }
+
+    static func status(
+        destinations: [Destination],
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) throws -> [Snapshot] {
+        let source = try source()
+        return try unique(destinations).map {
+            try snapshot(for: $0, source: source, homeURL: homeURL)
+        }
+    }
+
+    static func install(
+        destinations: [Destination],
+        force: Bool,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) throws -> [MutationResult] {
+        let source = try source()
+        let existing = try unique(destinations).map {
+            try snapshot(for: $0, source: source, homeURL: homeURL)
+        }
+        if let conflict = existing.first(where: { $0.state == .modified }), !force {
+            throw SkillError.message(
+                "The skill at \(conflict.url.path) has local changes. "
+                    + "Re-run with --force to replace it."
+            )
+        }
+
+        return try existing.map { item in
+            if item.state != .current {
+                try replaceSkill(at: item.url, source: source)
+            }
+            return MutationResult(
+                destination: item.destination,
+                url: item.url,
+                previousState: item.state,
+                state: .current
+            )
+        }
+    }
+
+    static func uninstall(
+        destinations: [Destination],
+        force: Bool,
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) throws -> [MutationResult] {
+        let source = try source()
+        let existing = try unique(destinations).map {
+            try snapshot(for: $0, source: source, homeURL: homeURL)
+        }
+        if let conflict = existing.first(where: {
+            $0.state == .modified || $0.state == .unmanaged
+        }), !force {
+            throw SkillError.message(
+                "The skill at \(conflict.url.path) is not safely managed by Kero. "
+                    + "Re-run with --force to remove it."
+            )
+        }
+
+        return try existing.map { item in
+            if item.state != .missing {
+                try FileManager.default.removeItem(at: item.url)
+            }
+            return MutationResult(
+                destination: item.destination,
+                url: item.url,
+                previousState: item.state,
+                state: .missing
+            )
+        }
+    }
+
+    private static func source(bundle: Bundle = .main) throws -> Source {
+        guard let skillURL = bundledURL(
+            name: "SKILL",
+            extension: "md",
+            subdirectories: ["Skills/\(name)", name, nil],
+            bundle: bundle
+        ) else {
+            throw SkillError.message("Kero's bundled automation SKILL.md is missing.")
+        }
+        guard let metadataURL = bundledURL(
+            name: "openai",
+            extension: "yaml",
+            subdirectories: ["Skills/\(name)/agents", "\(name)/agents", "agents", nil],
+            bundle: bundle
+        ) else {
+            throw SkillError.message("Kero's bundled automation skill metadata is missing.")
+        }
+        guard isRegularFile(skillURL), isRegularFile(metadataURL) else {
+            throw SkillError.message("Kero's bundled automation skill resources are not files.")
+        }
+
+        let skillData = try Data(contentsOf: skillURL)
+        guard String(data: skillData, encoding: .utf8)?.contains("name: \(name)") == true else {
+            throw SkillError.message("Kero's bundled automation SKILL.md has unexpected contents.")
+        }
+        return Source(
+            skillURL: skillURL,
+            files: [
+                "SKILL.md": skillURL,
+                "agents/openai.yaml": metadataURL,
+            ]
+        )
+    }
+
+    private static func bundledURL(
+        name: String,
+        extension fileExtension: String,
+        subdirectories: [String?],
+        bundle: Bundle
+    ) -> URL? {
+        for subdirectory in subdirectories {
+            if let url = bundle.url(
+                forResource: name,
+                withExtension: fileExtension,
+                subdirectory: subdirectory
+            ) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func snapshot(
+        for destination: Destination,
+        source: Source,
+        homeURL: URL
+    ) throws -> Snapshot {
+        let url = homeURL.appendingPathComponent(destination.relativeDirectory, isDirectory: true)
+        guard let rootType = itemType(at: url) else {
+            return Snapshot(destination: destination, url: url, state: .missing)
+        }
+        guard rootType == .typeDirectory else {
+            return Snapshot(destination: destination, url: url, state: .modified)
+        }
+
+        let manifestURL = url.appendingPathComponent(manifestName)
+        if isRegularFile(manifestURL),
+           let data = try? Data(contentsOf: manifestURL),
+           let manifest = try? JSONDecoder().decode(Manifest.self, from: data),
+           manifest.formatVersion == 2,
+           manifest.skill == name {
+            let expectedEntries = expectedEntries(
+                paths: manifest.links.keys,
+                includesManifest: true
+            )
+            if try treeEntries(at: url) == expectedEntries,
+               let links = try symbolicLinks(at: url, paths: manifest.links.keys),
+               links == manifest.links {
+                let state: InstallationState = manifest.links == source.links
+                    ? .current
+                    : .updateAvailable
+                return Snapshot(destination: destination, url: url, state: state)
+            }
+            return Snapshot(destination: destination, url: url, state: .modified)
+        }
+
+        let sourceLinks = source.links
+        let entries = try treeEntries(at: url)
+        let links = try symbolicLinks(at: url, paths: sourceLinks.keys)
+        let isUnmanagedMatch = entries == expectedEntries(
+            paths: sourceLinks.keys,
+            includesManifest: false
+        ) && links == sourceLinks
+        let state: InstallationState = isUnmanagedMatch ? .unmanaged : .modified
+        return Snapshot(destination: destination, url: url, state: state)
+    }
+
+    private static func expectedEntries(
+        paths: Dictionary<String, String>.Keys,
+        includesManifest: Bool
+    ) -> Set<String> {
+        var allowed = Set(paths)
+        for path in paths {
+            var components = path.split(separator: "/").map(String.init)
+            components.removeLast()
+            while !components.isEmpty {
+                allowed.insert(components.joined(separator: "/"))
+                components.removeLast()
+            }
+        }
+        if includesManifest { allowed.insert(manifestName) }
+        return allowed
+    }
+
+    private static func symbolicLinks(
+        at root: URL,
+        paths: Dictionary<String, String>.Keys
+    ) throws -> [String: String]? {
+        let fileManager = FileManager.default
+        var result: [String: String] = [:]
+        for path in paths {
+            let url = root.appendingPathComponent(path)
+            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            guard attributes[.type] as? FileAttributeType == .typeSymbolicLink else {
+                return nil
+            }
+            result[path] = try fileManager.destinationOfSymbolicLink(atPath: url.path)
+        }
+        return result
+    }
+
+    private static func treeEntries(at root: URL) throws -> Set<String> {
+        var result: Set<String> = []
+        try collectEntries(at: root, prefix: "", into: &result)
+        return result
+    }
+
+    private static func collectEntries(
+        at directory: URL,
+        prefix: String,
+        into result: inout Set<String>
+    ) throws {
+        let fileManager = FileManager.default
+        for child in try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: []
+        ) {
+            // Build logical relative paths from names rather than absolute
+            // string prefixes. Foundation can return `/private/tmp` child
+            // URLs for a `/tmp` root even when resolving symlinks leaves the
+            // root spelling unchanged.
+            let relative = prefix.isEmpty
+                ? child.lastPathComponent
+                : "\(prefix)/\(child.lastPathComponent)"
+            result.insert(relative)
+            let attributes = try fileManager.attributesOfItem(atPath: child.path)
+            if attributes[.type] as? FileAttributeType == .typeDirectory {
+                try collectEntries(at: child, prefix: relative, into: &result)
+            }
+        }
+    }
+
+    private static func replaceSkill(at destination: URL, source: Source) throws {
+        let fileManager = FileManager.default
+        let parent = destination.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o755]
+        )
+
+        let staging = parent.appendingPathComponent(
+            ".\(name).kero-staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let backup = parent.appendingPathComponent(
+            ".\(name).kero-backup-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: staging) }
+
+        try writeSkill(at: staging, source: source)
+        let existed = itemType(at: destination) != nil
+        if existed {
+            try fileManager.moveItem(at: destination, to: backup)
+        }
+        do {
+            try fileManager.moveItem(at: staging, to: destination)
+        } catch {
+            if existed, itemType(at: destination) == nil {
+                try? fileManager.moveItem(at: backup, to: destination)
+            }
+            throw error
+        }
+        if existed { try? fileManager.removeItem(at: backup) }
+    }
+
+    private static func writeSkill(at destination: URL, source: Source) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: destination,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o755]
+        )
+        for (path, target) in source.files {
+            let url = destination.appendingPathComponent(path)
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o755]
+            )
+            try fileManager.createSymbolicLink(
+                atPath: url.path,
+                withDestinationPath: target.standardizedFileURL.path
+            )
+        }
+
+        let manifest = Manifest(formatVersion: 2, skill: name, links: source.links)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let manifestURL = destination.appendingPathComponent(manifestName)
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o644],
+            ofItemAtPath: manifestURL.path
+        )
+    }
+
+    private static func unique(_ destinations: [Destination]) -> [Destination] {
+        var seen: Set<Destination> = []
+        return destinations.filter { seen.insert($0).inserted }
+    }
+
+    private static func isRegularFile(_ url: URL) -> Bool {
+        itemType(at: url) == .typeRegular
+    }
+
+    private static func itemType(at url: URL) -> FileAttributeType? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return attributes?[.type] as? FileAttributeType
+    }
+
+}

--- a/kero/KeroCLIService.swift
+++ b/kero/KeroCLIService.swift
@@ -10,12 +10,10 @@ import GhosttyTheme
 
 /// Bridges the bundled `kero` executable back to its owning app process.
 ///
-/// The CLI receives a per-launch secret and a generated catalog file through
-/// the terminal environment. Distributed notifications keep preview changes
-/// fast without opening a network listener. The token scopes requests to this
-/// Kero launch and rejects stale or accidental traffic; distributed
-/// notifications are observable by same-user processes, so this is not a
-/// security boundary against them.
+/// Theme previews retain the original per-launch distributed-notification
+/// bridge. Terminal and agent automation use a separate private Unix socket
+/// plus a per-terminal capability, because the broader theme token was never
+/// designed to authorize pane reads or input.
 @MainActor
 final class KeroCLIService {
     static let shared = KeroCLIService()
@@ -45,10 +43,13 @@ final class KeroCLIService {
     private let secret = UUID().uuidString
     private let directoryURL: URL
     private let stateURL: URL
+    private let automationSocketPath: String
     private var notificationObserver: NSObjectProtocol?
     private var terminationObserver: NSObjectProtocol?
     private var previewMonitor: Timer?
     private var activePreview: ActivePreview?
+    private var automationServer: KeroAutomationSocketServer?
+    private var terminalCapabilities: [String: UUID] = [:]
 
     private init() {
         let fileManager = FileManager.default
@@ -58,6 +59,8 @@ final class KeroCLIService {
                 isDirectory: true
             )
         stateURL = directoryURL.appendingPathComponent("themes.json")
+        let socketNonce = UUID().uuidString.prefix(8)
+        automationSocketPath = "/tmp/kero-\(getuid())-\(ProcessInfo.processInfo.processIdentifier)-\(socketNonce).sock"
 
         do {
             try fileManager.createDirectory(
@@ -70,6 +73,18 @@ final class KeroCLIService {
         }
 
         writeState()
+
+        do {
+            automationServer = try KeroAutomationSocketServer(
+                path: automationSocketPath
+            ) { request, reply in
+                Task { @MainActor in
+                    reply(await KeroCLIService.shared.handleAutomation(request))
+                }
+            }
+        } catch {
+            NSLog("kero: failed to start automation socket: \(error)")
+        }
 
         notificationObserver = DistributedNotificationCenter.default()
             .addObserver(
@@ -96,11 +111,21 @@ final class KeroCLIService {
     /// Variables added to every Kero shell. The app executable's directory is
     /// prepended to the inherited PATH, making `kero` available without
     /// modifying a user's dotfiles or installing a global symlink.
-    var terminalEnvironment: [String: String] {
+    func terminalEnvironment(for sessionID: UUID) -> [String: String] {
+        let capability = UUID().uuidString + UUID().uuidString
+        terminalCapabilities[capability] = sessionID
         var environment = [
             "KERO_CLI_STATE": stateURL.path,
             "KERO_CLI_TOKEN": secret,
+            "KERO_AUTOMATION": "1",
+            "KERO_AUTOMATION_HELP": "kero +agent explain",
+            "KERO_AUTOMATION_SOCKET": automationSocketPath,
+            "KERO_AUTOMATION_TOKEN": capability,
+            "KERO_TERMINAL_ID": sessionID.uuidString,
         ]
+        if let skillURL = try? KeroAutomationSkill.bundledSkillURL() {
+            environment["KERO_AUTOMATION_SKILL"] = skillURL.path
+        }
         if let executableURL = Bundle.main.executableURL {
             let bin = executableURL.deletingLastPathComponent().path
             let inherited = ProcessInfo.processInfo.environment["PATH"]
@@ -108,6 +133,35 @@ final class KeroCLIService {
             environment["PATH"] = "\(bin):\(inherited)"
         }
         return environment
+    }
+
+    func revokeTerminal(id: UUID) {
+        terminalCapabilities = terminalCapabilities.filter { $0.value != id }
+    }
+
+    private func handleAutomation(
+        _ request: KeroAutomationRequest
+    ) async -> KeroAutomationResponse {
+        guard request.version == 1 else {
+            return .failure(
+                id: request.id,
+                code: "unsupported_version",
+                message: "Kero supports automation protocol version 1."
+            )
+        }
+        guard let terminalID = UUID(uuidString: request.terminalID),
+              terminalCapabilities[request.token] == terminalID
+        else {
+            return .failure(
+                id: request.id,
+                code: "unauthorized",
+                message: "The terminal automation capability is invalid or expired."
+            )
+        }
+        return await KeroAutomationRouter.route(
+            request,
+            callerTerminalID: terminalID
+        )
     }
 
     private func handle(_ notification: Notification) {
@@ -288,6 +342,8 @@ final class KeroCLIService {
 
     private func removeStateDirectory() {
         clearActivePreview()
+        automationServer = nil
+        terminalCapabilities = [:]
         try? FileManager.default.removeItem(at: directoryURL)
     }
 }

--- a/kero/KeroCommandLine.swift
+++ b/kero/KeroCommandLine.swift
@@ -38,7 +38,7 @@ private enum Appearance: String {
     }
 }
 
-private enum CLIError: Error, CustomStringConvertible {
+enum CLIError: Error, CustomStringConvertible {
     case message(String)
 
     var description: String {
@@ -70,9 +70,12 @@ private func installExitHandlers() {
     }
 }
 
-private final class AppConnection {
+final class AppConnection {
     let stateURL: URL
     let token: String
+    private let automationSocketPath: String?
+    private let automationToken: String?
+    private let terminalID: String?
 
     init(environment: [String: String] = ProcessInfo.processInfo.environment) throws {
         guard let statePath = environment["KERO_CLI_STATE"],
@@ -86,9 +89,12 @@ private final class AppConnection {
         }
         stateURL = URL(fileURLWithPath: statePath)
         self.token = token
+        automationSocketPath = environment["KERO_AUTOMATION_SOCKET"]
+        automationToken = environment["KERO_AUTOMATION_TOKEN"]
+        terminalID = environment["KERO_TERMINAL_ID"]
     }
 
-    func loadState() throws -> ThemeState {
+    fileprivate func loadState() throws -> ThemeState {
         let oldDate = try? stateURL.resourceValues(
             forKeys: [.contentModificationDateKey]
         ).contentModificationDate
@@ -123,7 +129,7 @@ private final class AppConnection {
         }
     }
 
-    func post(
+    fileprivate func post(
         action: String,
         id: String? = nil,
         appearance: Appearance? = nil,
@@ -167,6 +173,49 @@ private final class AppConnection {
         // Let the app's main run loop claim the request before this short-lived
         // process disappears from the invoking terminal.
         Thread.sleep(forTimeInterval: 0.05)
+    }
+
+    func automationRequest(
+        method: String,
+        params: [String: KeroJSONValue] = [:],
+        timeout: TimeInterval = 5
+    ) throws -> KeroJSONValue {
+        guard let automationSocketPath, !automationSocketPath.isEmpty,
+              let automationToken, !automationToken.isEmpty,
+              let terminalID, !terminalID.isEmpty else {
+            throw CLIError.message(
+                String(localized: "This terminal predates Kero automation. Open a new terminal and try again.")
+            )
+        }
+        let request = KeroAutomationRequest(
+            version: 1,
+            id: UUID().uuidString,
+            method: method,
+            token: automationToken,
+            terminalID: terminalID,
+            params: params
+        )
+        let response: KeroAutomationResponse
+        do {
+            response = try KeroAutomationSocketServer.exchange(
+                path: automationSocketPath,
+                request: request,
+                timeout: timeout
+            )
+        } catch {
+            // Swift errors that only implement CustomStringConvertible can
+            // otherwise collapse to the unhelpful "error 0" NSError bridge.
+            throw CLIError.message(String(describing: error))
+        }
+        guard response.version == 1, response.id == request.id else {
+            throw CLIError.message("Kero returned a mismatched automation response.")
+        }
+        guard response.ok, let result = response.result else {
+            let code = response.error?.code ?? "automation_error"
+            let message = response.error?.message ?? "Kero rejected the automation request."
+            throw CLIError.message("\(code): \(message)")
+        }
+        return result
     }
 }
 
@@ -524,6 +573,8 @@ private func printHelp() {
           kero <command> [arguments...]
           kero +themes [--dark | --light]
           kero +themes --list [--dark | --light]
+          kero +pane <command> [options]
+          kero +agent <command> [options]
           kero +help
 
         With no arguments, kero creates a project with a normal login shell.
@@ -532,6 +583,12 @@ private func printHelp() {
         +themes browses Kero's themes in the terminal. Moving through the list
         previews the theme across the whole app; Return saves it and Esc
         restores the previous theme.
+
+        +pane provides project-scoped terminal layout, input, viewport reads,
+        and output waits. +agent adds recognized-agent start, guarded prompts,
+        passive lifecycle waits, result reads, and an installable, auto-updating
+        skill for compatible coding agents. Run either command with --help for
+        its complete contract.
         """)
     )
 }
@@ -540,6 +597,13 @@ private func run() throws {
     let arguments = Array(CommandLine.arguments.dropFirst())
     if arguments == ["+help"] {
         printHelp()
+        return
+    }
+    if arguments.first == "+pane" || arguments.first == "+agent" {
+        try KeroAutomationCommandLine.run(
+            namespace: arguments[0],
+            arguments: Array(arguments.dropFirst())
+        )
         return
     }
     if arguments.first != "+themes" {

--- a/kero/KeroTerminalView.swift
+++ b/kero/KeroTerminalView.swift
@@ -72,6 +72,33 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
 
     func findSelection() { searchSelection() }
 
+    func readVisibleText(maxLines: Int, maxColumns: Int) -> String? {
+        // Ghostty's public host API currently exposes styled screen export but
+        // not its viewport read primitive. Callers choose tight bounds so the
+        // agent monitor does not pay the larger diagnostic-read cost.
+        TerminalHistorySerializer.previewText(
+            from: self,
+            maxLines: min(max(maxLines, 1), 500),
+            maxColumns: min(max(maxColumns, 1), 2_000)
+        )
+    }
+
+    func sendApplicationScroll(lines: Int) -> Bool {
+        guard lines != 0,
+              let cgEvent = CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .line,
+                wheelCount: 1,
+                wheel1: Int32(clamping: lines),
+                wheel2: 0,
+                wheel3: 0
+              ),
+              let event = NSEvent(cgEvent: cgEvent)
+        else { return false }
+        super.scrollWheel(with: event)
+        return true
+    }
+
     func exportScreenFile() -> String? {
         captureHistoryExportPath(action: "write_screen_file:open,vt")
     }

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -121,6 +121,12 @@
         }
       }
     },
+    "%@ finished" : {
+
+    },
+    "%@ needs attention" : {
+
+    },
     "%@ palette · Tab switches appearance" : {
       "localizations" : {
         "ja" : {
@@ -259,6 +265,16 @@
     },
     "%lld" : {
       "shouldTranslate" : false
+    },
+    "%lld agents %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld agents %2$@"
+          }
+        }
+      }
     },
     "%lld fps" : {
 
@@ -519,6 +535,15 @@
         }
       }
     },
+    "Agent %@" : {
+
+    },
+    "AI" : {
+
+    },
+    "Agents" : {
+
+    },
     "Allow" : {
       "localizations" : {
         "ja" : {
@@ -647,6 +672,9 @@
         }
       }
     },
+    "Automation" : {
+
+    },
     "Automatically check for updates" : {
       "localizations" : {
         "ja" : {
@@ -743,6 +771,9 @@
           }
         }
       }
+    },
+    "blocked" : {
+
     },
     "Branch name" : {
 
@@ -1910,6 +1941,9 @@
         }
       }
     },
+    "created" : {
+
+    },
     "Current branch, %@" : {
       "localizations" : {
         "ja" : {
@@ -2321,6 +2355,9 @@
           }
         }
       }
+    },
+    "done" : {
+
     },
     "Down" : {
       "localizations" : {
@@ -3228,6 +3265,9 @@
         }
       }
     },
+    "idle" : {
+
+    },
     "Ignored" : {
       "localizations" : {
         "ja" : {
@@ -3339,6 +3379,9 @@
           }
         }
       }
+    },
+    "Installs Kero's coordination skill and lifecycle integrations" : {
+
     },
     "Insert Absolute Path in Terminal" : {
       "localizations" : {
@@ -4034,6 +4077,9 @@
           }
         }
       }
+    },
+    "Next Agent Needing Attention" : {
+
     },
     "Next match" : {
       "localizations" : {
@@ -6707,6 +6753,9 @@
         }
       }
     },
+    "This terminal predates Kero automation. Open a new terminal and try again." : {
+
+    },
     "This webpage couldn’t be loaded." : {
       "localizations" : {
         "ja" : {
@@ -7031,6 +7080,9 @@
         }
       }
     },
+    "unknown" : {
+
+    },
     "Unknown Kero command “%@”. Run `kero +help`." : {
       "localizations" : {
         "ja" : {
@@ -7224,6 +7276,7 @@
       }
     },
     "Usage:\n  kero\n  kero <command> [arguments...]\n  kero +themes [--dark | --light]\n  kero +themes --list [--dark | --light]\n  kero +help\n\nWith no arguments, kero creates a project with a normal login shell.\nAn argv creates a project whose first terminal runs it directly.\n\n+themes browses Kero's themes in the terminal. Moving through the list\npreviews the theme across the whole app; Return saves it and Esc\nrestores the previous theme." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -7238,6 +7291,9 @@
           }
         }
       }
+    },
+    "Usage:\n  kero\n  kero <command> [arguments...]\n  kero +themes [--dark | --light]\n  kero +themes --list [--dark | --light]\n  kero +pane <command> [options]\n  kero +agent <command> [options]\n  kero +help\n\nWith no arguments, kero creates a project with a normal login shell.\nAn argv creates a project whose first terminal runs it directly.\n\n+themes browses Kero's themes in the terminal. Moving through the list\npreviews the theme across the whole app; Return saves it and Esc\nrestores the previous theme.\n\n+pane provides project-scoped terminal layout, input, viewport reads,\nand output waits. +agent adds recognized-agent start, guarded prompts,\npassive lifecycle waits, result reads, and an installable, auto-updating\nskill for compatible coding agents. Run either command with --help for\nits complete contract." : {
+
     },
     "Use Automatic Directory" : {
       "localizations" : {
@@ -7334,6 +7390,9 @@
           }
         }
       }
+    },
+    "working" : {
+
     },
     "Working tree clean" : {
       "localizations" : {

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -266,15 +266,23 @@
     "%lld" : {
       "shouldTranslate" : false
     },
-    "%lld agents %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld agents %2$@"
-          }
-        }
-      }
+    "%lld agents finished" : {
+
+    },
+    "%lld agents idle" : {
+
+    },
+    "%lld agents in an unknown state" : {
+
+    },
+    "%lld agents need attention" : {
+
+    },
+    "%lld agents starting" : {
+
+    },
+    "%lld agents working" : {
+
     },
     "%lld fps" : {
 
@@ -535,7 +543,22 @@
         }
       }
     },
-    "Agent %@" : {
+    "Agent finished" : {
+
+    },
+    "Agent idle" : {
+
+    },
+    "Agent needs attention" : {
+
+    },
+    "Agent starting" : {
+
+    },
+    "Agent state unknown" : {
+
+    },
+    "Agent working" : {
 
     },
     "AI" : {
@@ -771,9 +794,6 @@
           }
         }
       }
-    },
-    "blocked" : {
-
     },
     "Branch name" : {
 
@@ -1941,9 +1961,6 @@
         }
       }
     },
-    "created" : {
-
-    },
     "Current branch, %@" : {
       "localizations" : {
         "ja" : {
@@ -2355,9 +2372,6 @@
           }
         }
       }
-    },
-    "done" : {
-
     },
     "Down" : {
       "localizations" : {
@@ -3264,9 +3278,6 @@
           }
         }
       }
-    },
-    "idle" : {
-
     },
     "Ignored" : {
       "localizations" : {
@@ -7080,9 +7091,6 @@
         }
       }
     },
-    "unknown" : {
-
-    },
     "Unknown Kero command “%@”. Run `kero +help`." : {
       "localizations" : {
         "ja" : {
@@ -7390,9 +7398,6 @@
           }
         }
       }
-    },
-    "working" : {
-
     },
     "Working tree clean" : {
       "localizations" : {

--- a/kero/PaneLayoutView.swift
+++ b/kero/PaneLayoutView.swift
@@ -740,7 +740,8 @@ private struct SessionPaneHeaderTitle: View {
         PaneHeaderLabel(
             systemImage: "terminal",
             title: session.title,
-            isFocused: isFocused
+            isFocused: isFocused,
+            agentRollup: session.agentRollup
         )
     }
 }
@@ -783,6 +784,7 @@ private struct PaneHeaderLabel: View {
     let title: String
     let isFocused: Bool
     var isDirty = false
+    var agentRollup: KeroAgentRollup? = nil
 
     var body: some View {
         HStack(spacing: 6) {
@@ -805,6 +807,10 @@ private struct PaneHeaderLabel: View {
                 .foregroundStyle(isFocused ? .primary : .secondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
+            if let agentRollup {
+                AgentStatusBadgeRepresentable(rollup: agentRollup)
+                    .fixedSize()
+            }
             if isDirty {
                 Circle()
                     .fill(.secondary)

--- a/kero/Panes.swift
+++ b/kero/Panes.swift
@@ -562,11 +562,28 @@ final class PaneTab: nonisolated ObservableObject, nonisolated Identifiable {
     /// Inserts `pane` inside the focused pane's rectangle, taking half of that
     /// rectangle on the requested edge. Focuses the new pane.
     func split(_ pane: Pane, toward edge: PaneDropEdge) {
+        split(
+            pane,
+            toward: edge,
+            beside: focusedPaneID,
+            focusInserted: true
+        )
+    }
+
+    /// Automation can split a specific pane without stealing the user's tab
+    /// or pane focus. Interactive split commands keep using the convenience
+    /// overload above and therefore focus the inserted pane.
+    func split(
+        _ pane: Pane,
+        toward edge: PaneDropEdge,
+        beside requestedTarget: UUID,
+        focusInserted: Bool
+    ) {
         unzoom()
-        let target = layout.contains(focusedPaneID)
-            ? focusedPaneID : layout.allPanes[0].id
+        let target = layout.contains(requestedTarget)
+            ? requestedTarget : layout.allPanes[0].id
         layout = layout.inserting(pane, toward: edge, beside: target)
-        focusedPaneID = pane.id
+        if focusInserted { focusedPaneID = pane.id }
     }
 
     /// Inserts another tab's complete layout beside a pane in this tab. The

--- a/kero/ProcessWorkingDirectory.swift
+++ b/kero/ProcessWorkingDirectory.swift
@@ -23,3 +23,61 @@ func processWorkingDirectory(pid: pid_t) -> String? {
     }
     return path.isEmpty ? nil : path
 }
+
+/// Absolute executable path for a live process. Agent recognition intentionally
+/// uses the kernel-reported image rather than tab titles or shell command text,
+/// both of which are user-controlled terminal output.
+func processExecutablePath(pid: pid_t) -> String? {
+    guard pid > 0 else { return nil }
+    // PROC_PIDPATHINFO_MAXSIZE is a C arithmetic macro Swift does not import;
+    // Darwin defines it as four MAXPATHLEN buffers (4096 bytes).
+    var buffer = [CChar](repeating: 0, count: 4_096)
+    let count = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+    guard count > 0 else { return nil }
+    let path = String(cString: buffer)
+    return path.isEmpty ? nil : path
+}
+
+/// Kernel-reported argv for a live process. This is the companion to
+/// `processExecutablePath(pid:)` for script-backed CLIs: macOS reports `node`
+/// or `python` as their executable image, while argv still identifies the
+/// script the shell actually launched.
+func processArguments(pid: pid_t) -> [String]? {
+    guard pid > 0 else { return nil }
+    var name = [Int32(CTL_KERN), Int32(KERN_PROCARGS2), pid]
+    var size = 0
+    guard sysctl(&name, u_int(name.count), nil, &size, nil, 0) == 0,
+          size >= MemoryLayout<Int32>.size
+    else { return nil }
+
+    // A process can change argv between the size and value calls. Give the
+    // kernel a little headroom, then honor the returned byte count.
+    var bytes = [UInt8](repeating: 0, count: size + 4_096)
+    size = bytes.count
+    guard sysctl(&name, u_int(name.count), &bytes, &size, nil, 0) == 0,
+          size >= MemoryLayout<Int32>.size
+    else { return nil }
+    bytes.removeSubrange(size..<bytes.count)
+
+    let argumentCount = bytes.withUnsafeBytes {
+        Int($0.loadUnaligned(as: Int32.self))
+    }
+    guard argumentCount > 0, argumentCount <= 4_096 else { return nil }
+
+    var cursor = MemoryLayout<Int32>.size
+    // KERN_PROCARGS2 starts with the executable path, followed by padding and
+    // then argc NUL-terminated argument strings.
+    while cursor < bytes.count, bytes[cursor] != 0 { cursor += 1 }
+    while cursor < bytes.count, bytes[cursor] == 0 { cursor += 1 }
+
+    var result: [String] = []
+    result.reserveCapacity(min(argumentCount, 32))
+    while cursor < bytes.count, result.count < argumentCount {
+        let start = cursor
+        while cursor < bytes.count, bytes[cursor] != 0 { cursor += 1 }
+        guard cursor > start else { break }
+        result.append(String(decoding: bytes[start..<cursor], as: UTF8.self))
+        cursor += 1
+    }
+    return result.isEmpty ? nil : result
+}

--- a/kero/Project.swift
+++ b/kero/Project.swift
@@ -296,6 +296,37 @@ final class Project: nonisolated ObservableObject, nonisolated Identifiable {
         tab.split(Pane(content: .session(session)), toward: edge)
     }
 
+    /// Creates a terminal beside an exact pane for the local automation API.
+    /// The caller chooses whether focus follows; the safe default at the API
+    /// boundary is false so background agents cannot disrupt the user.
+    func automationSplitTerminal(
+        beside targetPaneID: UUID,
+        toward edge: PaneDropEdge,
+        directory: String?,
+        focus: Bool
+    ) -> (tab: PaneTab, pane: Pane, session: TerminalSession)? {
+        guard let tab = tabs.first(where: { $0.layout.contains(targetPaneID) }),
+              let target = tab.allPanes.first(where: { $0.id == targetPaneID }),
+              !target.content.isDiff
+        else { return nil }
+
+        let contextDirectory: String? = switch target.content {
+        case .session(let session): session.currentDirectoryPath
+        default: tab.sessions.first?.currentDirectoryPath
+            ?? tab.contextSession?.currentDirectoryPath
+        }
+        let session = makeSession(directory: directory ?? contextDirectory)
+        let pane = Pane(content: .session(session))
+        tab.split(
+            pane,
+            toward: edge,
+            beside: targetPaneID,
+            focusInserted: focus
+        )
+        if focus { selectedTabID = tab.id }
+        return (tab, pane, session)
+    }
+
     func focusLeft() { selectedTab?.focusLeft() }
     func focusRight() { selectedTab?.focusRight() }
     func focusUp() { selectedTab?.focusUp() }

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -212,6 +212,14 @@ struct SettingsView: View {
                 Toggle("Wrap lines to editor width", isOn: $settings.wrapLines)
             }
 
+            Section("Automation") {
+                AgentCLISupportSettingsRow(
+                    isEnabled: settings.aiEnabled,
+                    onChange: { try settings.setAIEnabled($0) }
+                )
+                .frame(minHeight: 44)
+            }
+
             Section("Updates") {
                 Toggle(
                     "Automatically check for updates",
@@ -242,6 +250,7 @@ struct SettingsView: View {
                         && settings.toolbarVisibility == AppSettings.defaultToolbarVisibility
                         && !settings.wrapLines
                         && !settings.restoreTerminalHistory
+                        && !settings.aiEnabled
                         && settings.terminalBackend == .fallback)
                 }
             }

--- a/kero/SidebarView.swift
+++ b/kero/SidebarView.swift
@@ -350,6 +350,11 @@ private struct SidebarProjectRow: View {
 
             Spacer(minLength: 0)
 
+            if let rollup = project.agentRollup, !isRenaming {
+                AgentStatusBadgeRepresentable(rollup: rollup)
+                    .fixedSize()
+            }
+
             // Fixed trailing slot: close and the ⌘N hint share the same
             // width so hover does not reflow the row. Continuous title
             // updates from the terminal re-render the strip; without a

--- a/kero/Skills/kero-automation/SKILL.md
+++ b/kero/Skills/kero-automation/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: kero-automation
+description: Coordinate coding agents and terminal panes inside Kero with `kero +pane` and `kero +agent`. Use when delegating work to another Kero pane, starting or prompting a coding agent, waiting for its state, or reading its result.
+---
+
+# Kero Automation
+
+Use Kero's authenticated, project-scoped CLI to coordinate terminal panes and
+recognized coding agents. Keep layout creation, agent prompts, and raw terminal
+input as separate actions.
+
+## Check availability
+
+1. Require `KERO_AUTOMATION=1`. If it is absent, explain that the command must
+   run inside a newly opened Kero terminal.
+2. Run `kero +pane protocol` before a multi-step workflow.
+3. Treat successful command output as JSON. Record returned `pane_id` values;
+   do not infer pane IDs from titles or screen position.
+4. Stay within the invoking terminal's project. Kero intentionally rejects
+   targets in other projects and windows.
+
+Use `kero +agent explain` for the lifecycle and security contract, and use
+`kero +agent --help` or `kero +pane --help` for complete syntax.
+
+## Delegate to another pane
+
+Follow this sequence:
+
+1. Inspect existing state with `kero +pane list` and `kero +agent list`.
+2. Create one background pane unless the user explicitly selected an existing
+   available shell:
+
+   ```sh
+   kero +pane split --right --cwd "$PWD"
+   ```
+
+   Record the response's `pane_id`. Do not start an agent in the invoking pane:
+   the running `kero` command temporarily makes that shell unavailable.
+3. Choose the agent kind requested by the user. If none was requested, prefer
+   the current recognized agent's kind from `kero +agent get --current`; do not
+   silently switch to a provider with different credentials or permissions.
+4. Start the worker with a short, unique project-local alias:
+
+   ```sh
+   kero +agent start tests --kind codex --pane PANE_ID
+   ```
+
+   `start` returns once Kero recognizes the requested foreground process. Its
+   state is `created`; Kero does not inspect the CLI screen or wait for a
+   provider-specific ready prompt.
+
+5. Send a bounded task with acceptance criteria. Do not add Kero lifecycle
+   commands to the task; Kero observes the agent independently:
+
+   ```sh
+   kero +agent prompt tests --text "Run the focused tests, fix failures in scope, and verify the result."
+   ```
+
+6. Wait without stealing focus, then inspect the terminal result:
+
+   ```sh
+   kero +agent wait tests --state done,blocked --timeout 1800000
+   kero +agent read tests --lines 160
+   ```
+
+7. If the worker is blocked, surface its reason to the user. If it is done,
+   independently inspect the claimed files or verification output before
+   presenting the work as complete.
+
+If `start`, `prompt`, or `wait` fails or times out, inspect the worker pane
+before deciding what happened:
+
+```sh
+kero +agent read tests --lines 160
+```
+
+Use that output to diagnose startup, authentication, trust, or command errors.
+Do not answer an interactive approval or credential prompt on the user's
+behalf; report the blocker instead.
+
+Reuse the same alias for follow-up prompts only while that recognized agent is
+still running. Use a new alias for a new worker.
+
+## Lifecycle and result reads
+
+Never ask a worker model to report `working`, `blocked`, or `done`. Kero derives
+state from native CLI lifecycle integrations when they are complete and from a
+debounced, process-scoped live-screen classifier otherwise. `done` is the
+unseen presentation of an idle agent, not a state the model must announce.
+
+Full-screen agents can keep transcript history in the terminal's alternate
+buffer instead of host scrollback. After `wait` reaches `idle` or `done`, use an
+explicit line count with `agent read`; Kero may page the agent's own transcript
+and always returns it to the bottom before completing the read:
+
+```sh
+kero +agent read tests --lines 160
+```
+
+Do not request alternate-screen history while an agent is working, blocked, or
+unknown. Wait for a settled state first. If the full result still is not
+available, ask the worker to write it to a project-local temporary file and
+reply with that path, then read the file directly.
+
+## Guardrails
+
+- Use `kero +agent prompt` for agent-to-agent messages. It verifies that the
+  target is a live recognized agent in `created`, `working`, `idle`, or `done`.
+  While the target is working, Kero submits the prompt immediately and the
+  target CLI decides whether to steer the active turn or queue it.
+- Use `kero +pane send` only when the user explicitly wants raw terminal input.
+  Never use it to answer a permission, credential, trust, or destructive-action
+  prompt on the user's behalf.
+- Keep background splits unfocused unless the user asks to see them.
+- Do not ask an agent to run lifecycle-reporting commands. Kero's AI setting
+  owns supported hooks/plugins and keeps screen detection as the fallback.
+- Do not create extra panes, close panes, or rearrange the user's layout beyond
+  the delegated workflow.
+- Treat `blocked` as a handoff to the user, not an invitation to bypass the
+  blocker.

--- a/kero/Skills/kero-automation/agents/openai.yaml
+++ b/kero/Skills/kero-automation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kero Automation"
+  short_description: "Coordinate agents across Kero panes"
+  default_prompt: "Use $kero-automation to delegate this task to another Kero pane and return its result."

--- a/kero/TerminalBackend.swift
+++ b/kero/TerminalBackend.swift
@@ -189,6 +189,17 @@ protocol TerminalBackendSurface: NSView {
 
     func sendText(_ text: String)
 
+    /// Sends line-oriented wheel input to the foreground terminal application.
+    /// Returns false when the current terminal mode would consume scrolling as
+    /// host scrollback instead. Automation uses this only to page a settled
+    /// full-screen agent transcript and restores the application to the bottom.
+    func sendApplicationScroll(lines: Int) -> Bool
+
+    /// Plain UTF-8 text for the current viewport. Implementations keep this
+    /// bounded and avoid walking full scrollback; use an in-memory snapshot
+    /// when the backend exposes one and a bounded screen export otherwise.
+    func readVisibleText(maxLines: Int, maxColumns: Int) -> String?
+
     /// Clears the screen and scrollback, then repaints the shell's prompt at
     /// the top.
     func clearScreen()

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -84,6 +84,9 @@ final class TerminalManager: nonisolated ObservableObject {
     /// Live managers in window-creation order; the persisted snapshot is
     /// one entry per registered manager.
     private static var registry: [TerminalManager] = []
+    /// Read-only module access for the authenticated local automation router.
+    /// Mutation and window ownership remain private to `TerminalManager`.
+    static var automationManagers: [TerminalManager] { registry }
     private struct CLIProjectLaunch {
         let arguments: [String]
         let directory: String
@@ -481,6 +484,58 @@ final class TerminalManager: nonisolated ObservableObject {
         if let manager = registry.first(where: { $0.window != nil }) {
             manager.window?.makeKeyAndOrderFront(nil)
         }
+    }
+
+    /// "Seen" is a model focus decision, not an API read. A background CLI can
+    /// inspect output repeatedly without clearing a finished badge; selecting
+    /// the pane through any UI path clears it on the next monitor tick.
+    static func automationIsSessionFocused(_ id: UUID) -> Bool {
+        guard NSApp.isActive else { return false }
+        for manager in registry where manager.window?.isKeyWindow == true {
+            guard let project = manager.selectedProject,
+                  let tab = project.selectedTab,
+                  let pane = tab.focusedPane,
+                  case .session(let session) = pane.content
+            else { continue }
+            if session.id == id { return true }
+        }
+        return false
+    }
+
+    var hasAgentAttention: Bool {
+        projects.contains { project in
+            project.sessions.contains {
+                $0.agentStatus?.phase == .blocked || $0.agentStatus?.phase == .done
+            }
+        }
+    }
+
+    /// Cycles blocked agents first, then unseen completions, preserving project,
+    /// tab, and split-tree order within each state. Only an explicit focus
+    /// action acknowledges `done`; automation reads never call this path.
+    func focusNextAgentAttention() {
+        let ordered = projects.flatMap { project in
+            project.tabs.flatMap(\.sessions)
+        }
+        let attention = ordered.filter { $0.agentStatus?.phase == .blocked }
+            + ordered.filter { $0.agentStatus?.phase == .done }
+        guard !attention.isEmpty else { return }
+
+        let currentID: UUID? = {
+            guard let pane = selectedProject?.selectedTab?.focusedPane,
+                  case .session(let session) = pane.content else { return nil }
+            return session.id
+        }()
+        let next: TerminalSession
+        if let currentID,
+           let index = attention.firstIndex(where: { $0.id == currentID }) {
+            next = attention[(index + 1) % attention.count]
+        } else {
+            next = attention[0]
+        }
+        revealSession(next)
+        next.markAutomationAgentSeen()
+        window?.makeKeyAndOrderFront(nil)
     }
 
     /// Clears the terminal in the focused pane. No-op while another content

--- a/kero/TerminalSession.swift
+++ b/kero/TerminalSession.swift
@@ -18,13 +18,16 @@ import Foundation
 /// ``TerminalBackendEvents``, and names no emulator's types itself.
 @MainActor
 final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated Identifiable {
-    nonisolated let id = UUID()
+    nonisolated let id: UUID
 
     @Published var title: String
     @Published var workingDirectory: String?
     @Published var hasExited = false
     @Published private(set) var commandLifecycle = TerminalCommandLifecycle()
     @Published private(set) var terminalCellSize: CGSize?
+    /// Recognized coding agent occupying this terminal, if any. Native lifecycle
+    /// events and passive screen detection are reconciled by the monitor.
+    @Published var agentStatus: KeroAgentStatus?
 
     /// The emulator driving this session. Fixed for the session's lifetime —
     /// changing the setting only affects terminals opened afterwards.
@@ -45,6 +48,10 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     private var lastHistorySnapshot: String?
     private var isTerminating = false
     private var commandExecutionStartedAtNanos: UInt64?
+    /// Screen-based agent detection must follow the live prompt, never text
+    /// the user has scrolled back to inspect.
+    var terminalIsAtLiveBottom = true
+    let agentObservation = KeroAgentObservationState()
 
     init(
         initialDirectory: String? = nil,
@@ -52,6 +59,7 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         commandArguments: [String]? = nil,
         environmentPath: String? = nil
     ) {
+        let sessionID = UUID()
         let directCommand = commandArguments.flatMap { $0.isEmpty ? nil : $0 }
         let shellPath = directCommand?.first ?? Self.loginShell()
         let directory = Self.validWorkingDirectory(initialDirectory)
@@ -69,15 +77,20 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
             arguments: ["-c", script],
             commandLine: "/bin/sh -c \(Self.shellQuote(script))",
             workingDirectory: directory,
-            environment: Self.surfaceEnvironment(pathOverride: environmentPath)
+            environment: Self.surfaceEnvironment(
+                pathOverride: environmentPath,
+                sessionID: sessionID
+            )
         )
 
+        id = sessionID
         self.shellPath = shellPath
         self.backend = backend
         launchWorkingDirectory = directory
         launchDirectoryURL = artifacts.directoryURL
         shellPidFileURL = artifacts.pidFileURL
         title = (shellPath as NSString).lastPathComponent
+        agentStatus = nil
 
         let surface = Self.makeSurface(backend: backend, launch: launch)
         self.surface = surface
@@ -88,6 +101,7 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
         surface.events = self
         installOverlayScrollbar()
         applyTheme()
+        AgentAutomationMonitor.shared.register(self)
     }
 
     deinit {
@@ -183,6 +197,7 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
     }
 
     private func removeLaunchArtifacts() {
+        KeroCLIService.shared.revokeTerminal(id: id)
         guard let launchDirectoryURL else { return }
         try? FileManager.default.removeItem(at: launchDirectoryURL)
     }
@@ -280,13 +295,16 @@ final class TerminalSession: NSObject, nonisolated ObservableObject, nonisolated
 
     // MARK: - Launch
 
-    private static func surfaceEnvironment(pathOverride: String?) -> [String: String] {
+    private static func surfaceEnvironment(
+        pathOverride: String?,
+        sessionID: UUID
+    ) -> [String: String] {
         var environment = [
             "TERM": "xterm-256color",
             "COLORTERM": "truecolor",
         ]
         environment.merge(
-            KeroCLIService.shared.terminalEnvironment,
+            KeroCLIService.shared.terminalEnvironment(for: sessionID),
             uniquingKeysWith: { _, cliValue in cliValue }
         )
         if let pathOverride, !pathOverride.isEmpty {
@@ -550,6 +568,7 @@ extension TerminalSession: TerminalBackendEvents {
     }
 
     func terminalDidScroll(_ position: TerminalScrollPosition) {
+        terminalIsAtLiveBottom = position.position >= 0.999
         overlayScrollbar.update(
             position: position.position,
             proportion: position.proportion,

--- a/kero/keroApp.swift
+++ b/kero/keroApp.swift
@@ -16,6 +16,7 @@ struct keroApp: App {
     init() {
         TerminalFont.registerBundledFonts()
         TerminalNotificationService.shared.configure()
+        AppSettings.shared.reconcileAIEnabled()
     }
 
     var body: some Scene {
@@ -254,6 +255,14 @@ private struct KeroCommands: Commands {
                 manager?.openSelectedPageInDefaultBrowser()
             }
             .disabled(manager?.hasSelectedBrowser != true)
+        }
+
+        CommandMenu("Agents") {
+            Button("Next Agent Needing Attention") {
+                manager?.focusNextAgentAttention()
+            }
+            .keyboardShortcut("a", modifiers: [.command, .shift])
+            .disabled(manager?.hasAgentAttention != true)
         }
 
         CommandMenu("Tabs") {


### PR DESCRIPTION
## Summary
- Add project-scoped `+pane` and `+agent` terminal commands
- Provide capability-scoped automation over a private Unix socket
- Add agent lifecycle monitoring, status badges, notifications, and attention navigation
- Add one-click AI skill and integration setup with persistent settings
- Support bounded terminal viewport reads and application scrolling

## Testing
- Not run (not requested)