### PR TITLE
Reclaim file descriptors leaked by Ghostty screen exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Fix new terminal panes failing to start a shell after hours of coding-agent use: the Ghostty backend's screen exports leaked two file descriptors each, exhausting the process descriptor table
+
 ## [0.1.45]
 
 - Automate project-scoped panes and coding agents from Kero terminals with guarded `+pane` and `+agent` commands, one-click AI setup, semantic status badges, completion notifications, and attention navigation

--- a/kero/KeroTerminalView.swift
+++ b/kero/KeroTerminalView.swift
@@ -138,8 +138,22 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
             isCapturingHistoryExport = false
             capturedHistoryExportPath = nil
         }
-        guard performBindingAction(action) else { return nil }
-        return capturedHistoryExportPath
+        // Bracket the export: Ghostty's write_*_file actions leak two
+        // directory descriptors per call inside the prebuilt binary, which
+        // exhausts the descriptor table after hours of agent monitoring and
+        // leaves every new pane shell-less - see TerminalExportDescriptorLeak.
+        let descriptorsBefore = TerminalExportDescriptorLeak.openDescriptors()
+        guard performBindingAction(action) else {
+            TerminalExportDescriptorLeak.reclaim(
+                appearedSince: descriptorsBefore, exportedFilePath: nil
+            )
+            return nil
+        }
+        let path = capturedHistoryExportPath
+        TerminalExportDescriptorLeak.reclaim(
+            appearedSince: descriptorsBefore, exportedFilePath: path
+        )
+        return path
     }
 
     func consumeHistoryExportURL(_ url: String, kind: TerminalOpenURLKind) -> Bool {

--- a/kero/TerminalExportDescriptorLeak.swift
+++ b/kero/TerminalExportDescriptorLeak.swift
@@ -1,0 +1,98 @@
+//
+//  TerminalExportDescriptorLeak.swift
+//  kero
+//
+
+import Darwin
+import Foundation
+
+/// Reclaims file descriptors that libghostty's screen export leaks.
+///
+/// Ghostty's `write_screen_file`/`write_scrollback_file` actions create a
+/// fresh temporary directory per export via `os.TempDir`, which opens two
+/// directory descriptors: the new random-name subdirectory and its parent,
+/// the process temporary directory. On the success path neither is closed -
+/// `tmp_dir.deinit()` runs only under `errdefer`, and even `deinit` never
+/// closes the parent (ghostty `src/Surface.zig` `writeScreenFile`,
+/// `src/os/TempDir.zig`). Every export therefore leaks two descriptors
+/// inside the prebuilt GhosttyKit binary, where Kero cannot fix it directly.
+///
+/// Kero exports a screen file roughly every 0.75s per recognized agent
+/// session (the agent monitor's viewport read), so the process descriptor
+/// table fills after a few hours of agent use. From then on `openpty()`
+/// fails and every new split or tab opens as an empty pane with no shell.
+///
+/// The reclaim is deliberately conservative. Only descriptors that appeared
+/// during the bracketed export call, are directories, and resolve to the
+/// temporary root - or to the export's own subdirectory - are closed;
+/// everything else is left untouched.
+enum TerminalExportDescriptorLeak {
+    /// `F_GETPATH` reports kernel-resolved paths, so canonicalize with
+    /// `realpath(3)` - Foundation's `resolvingSymlinksInPath` strips the
+    /// `/private` prefix that the kernel keeps, which would make every
+    /// comparison against `/private/var/folders/…/T` silently fail.
+    private static let temporaryRootPath: String =
+        canonicalPath(FileManager.default.temporaryDirectory.path)
+            ?? FileManager.default.temporaryDirectory.path
+
+    private static func canonicalPath(_ path: String) -> String? {
+        var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(path, &resolved) != nil else { return nil }
+        return String(cString: resolved)
+    }
+
+    /// Every descriptor currently open in this process.
+    static func openDescriptors() -> Set<Int32> {
+        let pid = getpid()
+        let entrySize = MemoryLayout<proc_fdinfo>.stride
+        let size = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        guard size > 0 else { return [] }
+        // Headroom for descriptors another thread opens between the two calls.
+        let capacity = Int(size) / entrySize + 32
+        var buffer = [proc_fdinfo](repeating: proc_fdinfo(), count: capacity)
+        let filled = proc_pidinfo(
+            pid, PROC_PIDLISTFDS, 0, &buffer, Int32(capacity * entrySize)
+        )
+        guard filled > 0 else { return [] }
+        return Set(buffer.prefix(Int(filled) / entrySize).map(\.proc_fd))
+    }
+
+    /// Closes descriptors the bracketed export leaked: ones not in `before`,
+    /// open on a directory that is the temporary root or the export's own
+    /// subdirectory beneath it. When the export produced no file (an empty
+    /// alternate screen, or a failure inside Ghostty) the temporary directory
+    /// was still created, so any fresh direct child of the root qualifies.
+    static func reclaim(appearedSince before: Set<Int32>, exportedFilePath: String?) {
+        let exportDirectory = exportedFilePath.flatMap {
+            canonicalPath(($0 as NSString).deletingLastPathComponent)
+        }
+        for descriptor in openDescriptors().subtracting(before) {
+            var status = stat()
+            guard fstat(descriptor, &status) == 0,
+                  (status.st_mode & S_IFMT) == S_IFDIR
+            else { continue }
+            var pathBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+            let resolved = pathBuffer.withUnsafeMutableBytes { raw -> Int32 in
+                guard let base = raw.baseAddress else { return -1 }
+                return fcntl(descriptor, F_GETPATH, base)
+            }
+            guard resolved != -1 else { continue }
+            let path = String(cString: pathBuffer)
+            guard isLeakedExportDirectory(
+                path: path, exportDirectory: exportDirectory
+            ) else { continue }
+            close(descriptor)
+        }
+    }
+
+    private static func isLeakedExportDirectory(
+        path: String, exportDirectory: String?
+    ) -> Bool {
+        if path == temporaryRootPath { return true }
+        if let exportDirectory { return path == exportDirectory }
+        // No file was emitted, so the subdirectory's random name is unknown;
+        // accept a direct child of the root but nothing deeper.
+        return path.hasPrefix(temporaryRootPath + "/")
+            && !path.dropFirst(temporaryRootPath.count + 1).contains("/")
+    }
+}


### PR DESCRIPTION
**Problem**

Long-running coding agent sessions eventually break pane creation: after a few hours with claude-code open, every new split/tab/window comes up blank, no shell. Reproduces on two MacBooks (one higher spec, one lower). Only relaunching Kero recovers.

**Cause**

The agent monitor reads each agent pane's viewport every 0.75s. On the Ghostty backend that read is `write_screen_file` (`captureHistoryExportPath` -> `TerminalHistorySerializer.previewText`). In libghostty, `writeScreenFile` creates a temp dir per export through `os.TempDir`, which opens two directory fds (subdir + parent); on the success path neither is closed - `tmp_dir.deinit()` is `errdefer`-only, and `deinit` never closed the parent handle either. Fixed upstream in ghostty-org/ghostty@2b32b5b75cfe7a31a6043a82d111065b0279b875 (ghostty-org/ghostty#13219), but the GhosttyKit prebuilt pinned by `Vendor/libghostty-spm` predates it.

Net effect: ~2 leaked fds/second per agent pane. ghostty's init raises the fd soft limit to the hard limit, so instead of failing fast the table fills over hours; then `openpty()` fails and new surfaces can't spawn shells. On my instance after a morning: 22,300 leaked fds, nearly all directory fds on `$TMPDIR` or a random-named child.

**Fix**

The leak is inside the prebuilt binary, so this reclaims from Kero's side at the single choke point both export actions pass through. `captureHistoryExportPath` snapshots open fds before the binding action; afterwards, `TerminalExportDescriptorLeak.reclaim` closes only fds that (a) appeared during the call, (b) are directories per `fstat`, and (c) resolve via `F_GETPATH` to the temp root or the export's own subdirectory. Reference paths are canonicalised with `realpath(3)`: `F_GETPATH` reports `/private/var/...` while Foundation's `resolvingSymlinksInPath()` strips `/private`, and that mismatch silently defeated the first version of this patch.

Caveat: an fd number freed by another thread and reused by the leak inside the export window escapes the before/after diff. Measured residue: 5 fds over 30 minutes with six agent sessions, non-compounding (vs ~20k/hour unpatched). When libghostty-spm eventually rebases past the upstream fix, the sweep finds nothing and is a no-op, so it stays safe.

**Verification**

Built and ran the app. Unpatched: two claude sessions leak ~160 fds/min (each `kero +pane read` adds exactly +2 to +4). Patched: six agents polling continuously for 30+ min, fd count flat, splits/tabs keep spawning shells. The alacritty backend snapshots the viewport in-memory and is unaffected.

**Follow-up (separate)**

The monitor currently round-trips a full screen dump through disk every 0.75s per agent pane. libghostty already exports `ghostty_surface_read_text` (see `InMemoryTerminalSession.readViewportText`); exposing it for the AppKit surface in libghostty-spm would remove both the leak exposure and the per-poll disk I/O. Happy to do that separately.
