### PR TITLE
Expose terminal input to accessibility tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Let dictation and other accessibility tools enter text in terminal panes
 - Respect the selected System, Light, or Dark appearance when Kero launches
 - Stop inferring coding-agent progress from terminal text, preventing false Working, Blocked, and Done states from ordinary terminal output
 

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -1854,6 +1854,55 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         }
         return pasteboard.string(forType: .string)
     }
+
+    override func isAccessibilityElement() -> Bool { true }
+
+    override func isAccessibilityEnabled() -> Bool { true }
+
+    override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
+
+    override func accessibilityRoleDescription() -> String? {
+        NSAccessibility.Role.description(for: self)
+    }
+
+    override func accessibilityLabel() -> String? {
+        String(localized: "Terminal")
+    }
+
+    override func accessibilityHelp() -> String? {
+        String(localized: "Type to enter terminal text.")
+    }
+
+    override func accessibilityValue() -> Any? { "" }
+
+    override func accessibilityNumberOfCharacters() -> Int { 0 }
+
+    override func accessibilitySelectedText() -> String? { "" }
+
+    override func setAccessibilitySelectedText(_ text: String?) {
+        guard let text, !text.isEmpty else { return }
+        sendText(text)
+    }
+
+    override func accessibilitySelectedTextRange() -> NSRange {
+        NSRange(location: 0, length: 0)
+    }
+
+    override func accessibilityVisibleCharacterRange() -> NSRange {
+        NSRange(location: 0, length: 0)
+    }
+
+    override func isAccessibilityFocused() -> Bool {
+        window?.firstResponder === self
+    }
+
+    override func setAccessibilityFocused(_ focused: Bool) {
+        if !focused, window?.firstResponder === self {
+            window?.makeFirstResponder(nil)
+        } else if focused {
+            window?.makeFirstResponder(self)
+        }
+    }
 }
 
 // MARK: - Text input

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -1855,9 +1855,9 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         return pasteboard.string(forType: .string)
     }
 
-    override func isAccessibilityElement() -> Bool { true }
+    override func isAccessibilityElement() -> Bool { isSurfaceVisible }
 
-    override func isAccessibilityEnabled() -> Bool { true }
+    override func isAccessibilityEnabled() -> Bool { isSurfaceVisible }
 
     override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
 
@@ -1875,13 +1875,16 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     override func accessibilityValue() -> Any? { "" }
 
+    override func setAccessibilityValue(_ value: Any?) {
+        insertAccessibilityText(value)
+    }
+
     override func accessibilityNumberOfCharacters() -> Int { 0 }
 
     override func accessibilitySelectedText() -> String? { "" }
 
     override func setAccessibilitySelectedText(_ text: String?) {
-        guard let text, !text.isEmpty else { return }
-        sendText(text)
+        insertAccessibilityText(text)
     }
 
     override func accessibilitySelectedTextRange() -> NSRange {
@@ -1893,15 +1896,35 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     }
 
     override func isAccessibilityFocused() -> Bool {
-        window?.firstResponder === self
+        hasEffectiveTerminalFocus
     }
 
     override func setAccessibilityFocused(_ focused: Bool) {
         if !focused, window?.firstResponder === self {
             window?.makeFirstResponder(nil)
-        } else if focused {
+        } else if focused, isSurfaceVisible {
             window?.makeFirstResponder(self)
         }
+    }
+
+    override func isAccessibilitySelectorAllowed(_ selector: Selector) -> Bool {
+        if selector == #selector(setAccessibilityValue(_:))
+            || selector == #selector(setAccessibilitySelectedText(_:)) {
+            // Keep the setter discoverable while Kero is inactive, but never
+            // advertise a parked or otherwise unfocused terminal as writable.
+            return isSurfaceVisible && window?.firstResponder === self
+        }
+        return super.isAccessibilitySelectorAllowed(selector)
+    }
+
+    /// A terminal is append-at-cursor rather than a document whose value can
+    /// be replaced. Both editable AX insertion routes therefore feed the PTY,
+    /// but only while this exact surface is the live text destination.
+    private func insertAccessibilityText(_ value: Any?) {
+        guard isSurfaceVisible, hasEffectiveTerminalFocus else { return }
+        let text = (value as? String) ?? (value as? NSAttributedString)?.string ?? ""
+        guard !text.isEmpty else { return }
+        sendText(text)
     }
 }
 

--- a/kero/KeroTerminalView.swift
+++ b/kero/KeroTerminalView.swift
@@ -155,6 +155,55 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
         NSApp.isActive && window?.isKeyWindow == true && window?.firstResponder === self
     }
 
+    override func isAccessibilityElement() -> Bool { true }
+
+    override func isAccessibilityEnabled() -> Bool { true }
+
+    override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
+
+    override func accessibilityRoleDescription() -> String? {
+        NSAccessibility.Role.description(for: self)
+    }
+
+    override func accessibilityLabel() -> String? {
+        String(localized: "Terminal")
+    }
+
+    override func accessibilityHelp() -> String? {
+        String(localized: "Type to enter terminal text.")
+    }
+
+    override func accessibilityValue() -> Any? { "" }
+
+    override func accessibilityNumberOfCharacters() -> Int { 0 }
+
+    override func accessibilitySelectedText() -> String? { "" }
+
+    override func setAccessibilitySelectedText(_ text: String?) {
+        guard let text, !text.isEmpty else { return }
+        sendText(text)
+    }
+
+    override func accessibilitySelectedTextRange() -> NSRange {
+        NSRange(location: 0, length: 0)
+    }
+
+    override func accessibilityVisibleCharacterRange() -> NSRange {
+        NSRange(location: 0, length: 0)
+    }
+
+    override func isAccessibilityFocused() -> Bool {
+        window?.firstResponder === self
+    }
+
+    override func setAccessibilityFocused(_ focused: Bool) {
+        if !focused, window?.firstResponder === self {
+            window?.makeFirstResponder(nil)
+        } else if focused {
+            window?.makeFirstResponder(self)
+        }
+    }
+
     override func becomeFirstResponder() -> Bool {
         let accepted = super.becomeFirstResponder()
         if accepted { onBecomeFirstResponder?() }

--- a/kero/KeroTerminalView.swift
+++ b/kero/KeroTerminalView.swift
@@ -36,6 +36,7 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
     private let progressBar = KeroTerminalProgressBarView(frame: .zero)
     private var isCapturingHistoryExport = false
     private var capturedHistoryExportPath: String?
+    private var isSurfaceVisible = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -52,6 +53,11 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
     }
 
     // MARK: - TerminalBackendSurface
+
+    override func setSurfaceVisible(_ visible: Bool) {
+        isSurfaceVisible = visible
+        super.setSurfaceVisible(visible)
+    }
 
     func clearScreen() {
         performBindingAction("clear_screen")
@@ -155,9 +161,9 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
         NSApp.isActive && window?.isKeyWindow == true && window?.firstResponder === self
     }
 
-    override func isAccessibilityElement() -> Bool { true }
+    override func isAccessibilityElement() -> Bool { isSurfaceVisible }
 
-    override func isAccessibilityEnabled() -> Bool { true }
+    override func isAccessibilityEnabled() -> Bool { isSurfaceVisible }
 
     override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
 
@@ -175,13 +181,16 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
 
     override func accessibilityValue() -> Any? { "" }
 
+    override func setAccessibilityValue(_ value: Any?) {
+        insertAccessibilityText(value)
+    }
+
     override func accessibilityNumberOfCharacters() -> Int { 0 }
 
     override func accessibilitySelectedText() -> String? { "" }
 
     override func setAccessibilitySelectedText(_ text: String?) {
-        guard let text, !text.isEmpty else { return }
-        sendText(text)
+        insertAccessibilityText(text)
     }
 
     override func accessibilitySelectedTextRange() -> NSRange {
@@ -193,15 +202,35 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
     }
 
     override func isAccessibilityFocused() -> Bool {
-        window?.firstResponder === self
+        hasEffectiveTerminalFocus
     }
 
     override func setAccessibilityFocused(_ focused: Bool) {
         if !focused, window?.firstResponder === self {
             window?.makeFirstResponder(nil)
-        } else if focused {
+        } else if focused, isSurfaceVisible {
             window?.makeFirstResponder(self)
         }
+    }
+
+    override func isAccessibilitySelectorAllowed(_ selector: Selector) -> Bool {
+        if selector == #selector(setAccessibilityValue(_:))
+            || selector == #selector(setAccessibilitySelectedText(_:)) {
+            // Keep the setter discoverable while Kero is inactive, but never
+            // advertise a parked or otherwise unfocused terminal as writable.
+            return isSurfaceVisible && window?.firstResponder === self
+        }
+        return super.isAccessibilitySelectorAllowed(selector)
+    }
+
+    /// A terminal is append-at-cursor rather than a document whose value can
+    /// be replaced. Both editable AX insertion routes therefore feed the PTY,
+    /// but only while this exact surface is the live text destination.
+    private func insertAccessibilityText(_ value: Any?) {
+        guard isSurfaceVisible, hasEffectiveTerminalFocus else { return }
+        let text = (value as? String) ?? (value as? NSAttributedString)?.string ?? ""
+        guard !text.isEmpty else { return }
+        sendText(text)
     }
 
     override func becomeFirstResponder() -> Bool {

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -7015,6 +7015,22 @@
         }
       }
     },
+    "Type to enter terminal text." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力するとターミナルにテキストが送信されます。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "键入以向终端输入文本。"
+          }
+        }
+      }
+    },
     "Type to filter:" : {
       "localizations" : {
         "ja" : {


### PR DESCRIPTION
Fixes accessibility issues, making dictation apps unable to insert text into Kero's input field.