### PR TITLE
Add an agent palette for finding and jumping to running agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Find any coding agent across every project with ⌥⌘A: search by name, project, or folder, narrow the list with `status:`, `agent:`, and `project:` filters, and read the agent's latest terminal output beside the list before jumping to it
+
 ## [0.1.47]
 
 - Let dictation and other accessibility tools enter text in terminal panes

--- a/kero/AgentPalette.swift
+++ b/kero/AgentPalette.swift
@@ -1,0 +1,1107 @@
+//
+//  AgentPalette.swift
+//  kero
+//
+
+import AppKit
+import FuzzyMatch
+import SwiftUI
+
+private enum AgentPaletteLayout {
+    static let panelWidth: CGFloat = 920
+    static let topInset: CGFloat = 96
+    /// The list needs only enough width for an alias over a path; every point
+    /// beyond that is better spent on the capture, which is far wider.
+    static let listWidth: CGFloat = 336
+    static let cornerRadius: CGFloat = 14
+    static let rowHeight: CGFloat = 40
+    static let headerHeight: CGFloat = 52
+    static let footerHeight: CGFloat = 30
+    static let gutter: CGFloat = 14
+    /// The body grows with the result count between these bounds, so a single
+    /// match does not leave a wall of empty space and a long list still fits.
+    static let minBodyHeight: CGFloat = 216
+    static let maxBodyHeight: CGFloat = 348
+    static let previewFontSize: CGFloat = 10
+    static let previewLines = 44
+    /// Wide enough to hold an agent's own box drawing without reflowing it.
+    /// Overflow is clipped rather than wrapped.
+    static let previewColumns = 200
+}
+
+/// ⌥⌘A overlay: every running agent across every project, filterable by typed
+/// tokens, with the highlighted agent's terminal tail beside the list.
+///
+/// Row membership and order are settled on each keystroke and then held still.
+/// Agents change phase on a sub-second cadence, so re-sorting on every refresh
+/// would slide the row out from under Return; instead the periodic refresh
+/// only restates badges and drops rows whose session has closed. A newly
+/// started agent joins the list on the next keystroke.
+@MainActor
+final class AgentPaletteViewController: NSViewController {
+    private let manager: TerminalManager
+
+    private let panel = AgentPalettePanelView(frame: .zero)
+    private let searchField = NSTextField()
+    private let summaryLabel = NSTextField(labelWithString: "")
+    private let tableView = NSTableView()
+    private let tableScrollView = NSScrollView()
+    private let previewTextView = NSTextView()
+    private let previewScrollView = NSScrollView()
+    private let previewWell = AgentPalettePreviewWell(frame: .zero)
+    private let previewPlaceholder = NSTextField(labelWithString: "")
+    private let emptyLabel = NSTextField(labelWithString: "")
+    private var bodyHeightConstraint: NSLayoutConstraint?
+
+    /// Every agent session right now, rebuilt on demand.
+    private var allEntries: [AgentPaletteEntry] = []
+    /// The rows on screen. Order is recomputed only when the query changes.
+    private var visibleEntries: [AgentPaletteEntry] = []
+    private var selectedSessionID: UUID?
+    private var refreshTimer: Timer?
+    private var previewWorkItem: DispatchWorkItem?
+    /// What the preview currently shows, so a periodic refresh that produces
+    /// identical output can leave the text storage — and the reader's scroll
+    /// position — untouched.
+    private var previewedSessionID: UUID?
+    private var previewedText = ""
+
+    private static let fuzzyMatcher = FuzzyMatcher(config: .smithWaterman)
+
+    init(manager: TerminalManager) {
+        self.manager = manager
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = AgentPaletteBackdropView { [weak self] in self?.dismiss() }
+        buildPanel()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        applyQuery()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        view.window?.makeFirstResponder(searchField)
+        startRefreshTimer()
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        stopTimers()
+        manager.restoreFocusAfterPalette()
+    }
+
+    private func stopTimers() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        previewWorkItem?.cancel()
+        previewWorkItem = nil
+    }
+
+    // MARK: - Chrome
+
+    private func buildPanel() {
+        panel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(panel)
+
+        let magnifier = NSImageView()
+        magnifier.translatesAutoresizingMaskIntoConstraints = false
+        magnifier.image = NSImage(
+            systemSymbolName: "magnifyingglass", accessibilityDescription: nil
+        )
+        magnifier.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: 14, weight: .medium
+        )
+        magnifier.contentTintColor = .tertiaryLabelColor
+
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.isBordered = false
+        searchField.drawsBackground = false
+        searchField.focusRingType = .none
+        searchField.font = .systemFont(ofSize: 15, weight: .regular)
+        searchField.delegate = self
+        searchField.placeholderString = String(
+            localized: "Search agents…",
+            comment: "Placeholder in the agent palette search field."
+        )
+        searchField.setAccessibilityLabel(
+            String(localized: "Search agents", comment: "Accessibility label.")
+        )
+
+        // Doubles as the result count, so the header never holds empty space.
+        summaryLabel.translatesAutoresizingMaskIntoConstraints = false
+        summaryLabel.font = .systemFont(ofSize: 11)
+        summaryLabel.textColor = .tertiaryLabelColor
+        summaryLabel.alignment = .right
+        summaryLabel.lineBreakMode = .byTruncatingHead
+        summaryLabel.setContentCompressionResistancePriority(
+            .defaultHigh, for: .horizontal
+        )
+
+        let headerRule = NSBox()
+        headerRule.translatesAutoresizingMaskIntoConstraints = false
+        headerRule.boxType = .separator
+
+        let footerRule = NSBox()
+        footerRule.translatesAutoresizingMaskIntoConstraints = false
+        footerRule.boxType = .separator
+
+        let verticalRule = NSBox()
+        verticalRule.translatesAutoresizingMaskIntoConstraints = false
+        verticalRule.boxType = .separator
+
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.font = .systemFont(ofSize: 12)
+        emptyLabel.textColor = .tertiaryLabelColor
+        emptyLabel.alignment = .center
+        emptyLabel.isHidden = true
+
+        let keyHints = NSTextField(labelWithString: String(
+            localized: "⌃N/⌃P move · ↩ jump · ⎋ close",
+            comment: "Key hints along the bottom of the agent palette."
+        ))
+        keyHints.translatesAutoresizingMaskIntoConstraints = false
+        keyHints.font = .systemFont(ofSize: 10)
+        keyHints.textColor = .tertiaryLabelColor
+
+        // Filter syntax lives here rather than in the placeholder, so it stays
+        // discoverable without shouting over the field the user types into.
+        let filterHints = NSTextField(labelWithString: String(
+            localized: "status:  agent:  project:",
+            comment: "Available agent palette filter prefixes."
+        ))
+        filterHints.translatesAutoresizingMaskIntoConstraints = false
+        filterHints.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+        filterHints.textColor = .quaternaryLabelColor
+
+        buildList()
+        buildPreview()
+
+        for subview in [
+            magnifier, searchField, summaryLabel, headerRule, tableScrollView,
+            emptyLabel, verticalRule, previewWell, footerRule, keyHints,
+            filterHints,
+        ] as [NSView] {
+            panel.addSubview(subview)
+        }
+
+        let bodyHeight = tableScrollView.heightAnchor.constraint(
+            equalToConstant: AgentPaletteLayout.minBodyHeight
+        )
+        bodyHeightConstraint = bodyHeight
+
+        NSLayoutConstraint.activate([
+            panel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            panel.topAnchor.constraint(
+                equalTo: view.topAnchor, constant: AgentPaletteLayout.topInset
+            ),
+            panel.widthAnchor.constraint(
+                equalToConstant: AgentPaletteLayout.panelWidth
+            ),
+
+            // An NSTextField draws its text at the top of its frame, so the
+            // field is centred on the header rather than stretched to fill it.
+            magnifier.leadingAnchor.constraint(
+                equalTo: panel.leadingAnchor, constant: AgentPaletteLayout.gutter
+            ),
+            magnifier.centerYAnchor.constraint(
+                equalTo: searchField.centerYAnchor
+            ),
+            magnifier.widthAnchor.constraint(equalToConstant: 17),
+
+            searchField.leadingAnchor.constraint(
+                equalTo: magnifier.trailingAnchor, constant: 9
+            ),
+            searchField.topAnchor.constraint(
+                equalTo: panel.topAnchor,
+                constant: (AgentPaletteLayout.headerHeight - 19) / 2
+            ),
+
+            summaryLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: searchField.trailingAnchor, constant: 12
+            ),
+            summaryLabel.trailingAnchor.constraint(
+                equalTo: panel.trailingAnchor, constant: -AgentPaletteLayout.gutter
+            ),
+            summaryLabel.firstBaselineAnchor.constraint(
+                equalTo: searchField.firstBaselineAnchor
+            ),
+
+            headerRule.leadingAnchor.constraint(equalTo: panel.leadingAnchor),
+            headerRule.trailingAnchor.constraint(equalTo: panel.trailingAnchor),
+            headerRule.topAnchor.constraint(
+                equalTo: panel.topAnchor,
+                constant: AgentPaletteLayout.headerHeight
+            ),
+
+            tableScrollView.leadingAnchor.constraint(
+                equalTo: panel.leadingAnchor, constant: 8
+            ),
+            tableScrollView.topAnchor.constraint(
+                equalTo: headerRule.bottomAnchor, constant: 8
+            ),
+            tableScrollView.widthAnchor.constraint(
+                equalToConstant: AgentPaletteLayout.listWidth
+            ),
+            bodyHeight,
+
+            emptyLabel.centerXAnchor.constraint(
+                equalTo: tableScrollView.centerXAnchor
+            ),
+            emptyLabel.centerYAnchor.constraint(
+                equalTo: tableScrollView.centerYAnchor
+            ),
+            emptyLabel.widthAnchor.constraint(
+                equalTo: tableScrollView.widthAnchor
+            ),
+
+            verticalRule.leadingAnchor.constraint(
+                equalTo: tableScrollView.trailingAnchor, constant: 8
+            ),
+            verticalRule.topAnchor.constraint(equalTo: headerRule.bottomAnchor),
+            verticalRule.bottomAnchor.constraint(equalTo: footerRule.topAnchor),
+            verticalRule.widthAnchor.constraint(equalToConstant: 1),
+
+            previewWell.leadingAnchor.constraint(
+                equalTo: verticalRule.trailingAnchor, constant: 8
+            ),
+            previewWell.trailingAnchor.constraint(
+                equalTo: panel.trailingAnchor, constant: -8
+            ),
+            previewWell.topAnchor.constraint(
+                equalTo: tableScrollView.topAnchor
+            ),
+            previewWell.bottomAnchor.constraint(
+                equalTo: tableScrollView.bottomAnchor
+            ),
+
+            footerRule.leadingAnchor.constraint(equalTo: panel.leadingAnchor),
+            footerRule.trailingAnchor.constraint(equalTo: panel.trailingAnchor),
+            footerRule.topAnchor.constraint(
+                equalTo: tableScrollView.bottomAnchor, constant: 8
+            ),
+
+            keyHints.leadingAnchor.constraint(
+                equalTo: panel.leadingAnchor, constant: AgentPaletteLayout.gutter
+            ),
+            keyHints.centerYAnchor.constraint(
+                equalTo: footerRule.bottomAnchor,
+                constant: AgentPaletteLayout.footerHeight / 2
+            ),
+
+            filterHints.trailingAnchor.constraint(
+                equalTo: panel.trailingAnchor, constant: -AgentPaletteLayout.gutter
+            ),
+            filterHints.centerYAnchor.constraint(equalTo: keyHints.centerYAnchor),
+
+            panel.bottomAnchor.constraint(
+                equalTo: footerRule.bottomAnchor,
+                constant: AgentPaletteLayout.footerHeight
+            ),
+        ])
+    }
+
+    /// Grow the list to its contents between the layout's bounds. Sizing on
+    /// the result count keeps one match from sitting in a wall of empty space.
+    private func updateBodyHeight() {
+        let contentHeight = CGFloat(max(visibleEntries.count, 1))
+            * (AgentPaletteLayout.rowHeight + 1) + 8
+        bodyHeightConstraint?.constant = min(
+            max(contentHeight, AgentPaletteLayout.minBodyHeight),
+            AgentPaletteLayout.maxBodyHeight
+        )
+    }
+
+    private func buildList() {
+        tableView.headerView = nil
+        tableView.rowHeight = AgentPaletteLayout.rowHeight
+        tableView.backgroundColor = .clear
+        tableView.style = .plain
+        tableView.intercellSpacing = NSSize(width: 0, height: 1)
+        // The search field keeps focus for the whole gesture; the list is
+        // driven programmatically and must never take the responder.
+        tableView.refusesFirstResponder = true
+        tableView.allowsEmptySelection = true
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.target = self
+        tableView.action = #selector(rowClicked)
+
+        let column = NSTableColumn(
+            identifier: NSUserInterfaceItemIdentifier("agent")
+        )
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+
+        tableScrollView.translatesAutoresizingMaskIntoConstraints = false
+        tableScrollView.documentView = tableView
+        tableScrollView.hasVerticalScroller = true
+        tableScrollView.drawsBackground = false
+        tableScrollView.autohidesScrollers = true
+    }
+
+    private func buildPreview() {
+        previewWell.translatesAutoresizingMaskIntoConstraints = false
+        previewScrollView.translatesAutoresizingMaskIntoConstraints = false
+        previewScrollView.hasVerticalScroller = true
+        previewScrollView.hasHorizontalScroller = false
+        previewScrollView.drawsBackground = false
+        previewScrollView.autohidesScrollers = true
+
+        previewTextView.isEditable = false
+        // Selection would compete with the search field for the responder and
+        // give the terminal tail an I-beam it cannot act on.
+        previewTextView.isSelectable = false
+        previewTextView.drawsBackground = false
+        previewTextView.textContainerInset = NSSize(width: 12, height: 11)
+        previewTextView.isVerticallyResizable = true
+        previewTextView.isHorizontallyResizable = true
+        previewTextView.autoresizingMask = []
+        previewTextView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        // Terminal output is already laid out in columns. Reflowing it to the
+        // pane width folds an agent's own box drawing onto itself, so give the
+        // container unbounded width and let the well clip the overflow.
+        previewTextView.textContainer?.widthTracksTextView = false
+        previewTextView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        previewTextView.textContainer?.lineFragmentPadding = 0
+
+        previewPlaceholder.translatesAutoresizingMaskIntoConstraints = false
+        previewPlaceholder.font = .systemFont(ofSize: 11)
+        previewPlaceholder.textColor = .quaternaryLabelColor
+        previewPlaceholder.alignment = .center
+        previewPlaceholder.stringValue = String(
+            localized: "No output yet",
+            comment: "Agent palette preview pane with nothing to show."
+        )
+        previewPlaceholder.isHidden = true
+
+        previewWell.addSubview(previewScrollView)
+        previewWell.addSubview(previewPlaceholder)
+        NSLayoutConstraint.activate([
+            previewPlaceholder.centerXAnchor.constraint(
+                equalTo: previewWell.centerXAnchor
+            ),
+            previewPlaceholder.centerYAnchor.constraint(
+                equalTo: previewWell.centerYAnchor
+            ),
+            previewScrollView.leadingAnchor.constraint(
+                equalTo: previewWell.leadingAnchor
+            ),
+            previewScrollView.trailingAnchor.constraint(
+                equalTo: previewWell.trailingAnchor
+            ),
+            previewScrollView.topAnchor.constraint(
+                equalTo: previewWell.topAnchor
+            ),
+            previewScrollView.bottomAnchor.constraint(
+                equalTo: previewWell.bottomAnchor
+            ),
+        ])
+        previewScrollView.documentView = previewTextView
+    }
+
+    // MARK: - Data
+
+    /// Walks projects in window order so an unfiltered list matches the project
+    /// sidebar and tab strip wherever attention rank ties.
+    private func rebuildSnapshot() {
+        var entries: [AgentPaletteEntry] = []
+        for project in manager.projects {
+            let projectName = project.name
+            for tab in project.tabs {
+                let tabTitle = tab.displayTitle ?? String(
+                    localized: "Untitled", comment: "Fallback tab title."
+                )
+                for session in tab.sessions {
+                    guard let status = session.agentStatus else { continue }
+                    let directory = Self.abbreviated(session.currentDirectoryPath)
+                    entries.append(
+                        AgentPaletteEntry(
+                            sessionID: session.id,
+                            alias: status.alias,
+                            kind: status.kind,
+                            projectName: projectName,
+                            tabTitle: tabTitle,
+                            directory: directory,
+                            searchText: [
+                                status.alias, status.kind.displayName,
+                                projectName, tabTitle, directory,
+                            ].joined(separator: " "),
+                            phase: status.phase,
+                            unseen: status.unseen,
+                            updatedAt: status.updatedAt
+                        )
+                    )
+                }
+            }
+        }
+        allEntries = entries
+    }
+
+    /// Recompute membership and order from the current query. The only path
+    /// allowed to move a row.
+    private func applyQuery() {
+        rebuildSnapshot()
+        let query = AgentPaletteQuery.parse(searchField.stringValue)
+
+        var candidates = allEntries.filter { query.admits($0) }
+        if query.freeText.isEmpty {
+            candidates.sort(by: Self.byAttention)
+        } else {
+            let fuzzyQuery = Self.fuzzyMatcher.prepare(query.freeText)
+            var buffer = Self.fuzzyMatcher.makeBuffer()
+            var scored: [(entry: AgentPaletteEntry, score: Double)] = []
+            for entry in candidates {
+                guard let score = Self.fuzzyScore(
+                    entry.searchText, fuzzyQuery, buffer: &buffer
+                ) else { continue }
+                scored.append((entry, score))
+            }
+            scored.sort {
+                if $0.score != $1.score { return $0.score > $1.score }
+                return Self.byAttention($0.entry, $1.entry)
+            }
+            candidates = scored.map(\.entry)
+        }
+
+        visibleEntries = candidates
+        tableView.reloadData()
+        updateBodyHeight()
+        updateSummary(query)
+        updateEmptyState()
+        select(row: 0, scroll: true)
+    }
+
+    /// Right side of the header: how many agents matched, and what the typed
+    /// tokens were understood to mean.
+    private func updateSummary(_ query: AgentPaletteQuery) {
+        let count = visibleEntries.count
+        let total = allEntries.count
+        var parts: [String] = []
+        if count == total {
+            parts.append(count == 1
+                ? String(localized: "1 agent", comment: "Agent palette count.")
+                : String(localized: "\(count) agents", comment: "Agent palette count."))
+        } else {
+            parts.append(String(
+                localized: "\(count) of \(total)",
+                comment: "Agent palette count when filters are narrowing the list."
+            ))
+        }
+        if let summary = query.summary { parts.append(summary) }
+        summaryLabel.stringValue = parts.joined(separator: "  ·  ")
+    }
+
+    /// Periodic refresh: status only. Rows never move and new agents never
+    /// appear here — both would disturb a selection the user is aiming at.
+    /// Closed sessions do drop out, since jumping to one is a dead end.
+    private func refreshStatuses() {
+        rebuildSnapshot()
+        let live = Dictionary(
+            allEntries.map { ($0.sessionID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let refreshed = visibleEntries.compactMap { live[$0.sessionID] }
+        let membershipChanged = refreshed.count != visibleEntries.count
+        visibleEntries = refreshed
+
+        tableView.reloadData()
+        if membershipChanged {
+            updateBodyHeight()
+            updateSummary(AgentPaletteQuery.parse(searchField.stringValue))
+            updateEmptyState()
+        }
+        restoreSelection()
+        refreshPreview(debounced: false)
+    }
+
+    private func updateEmptyState() {
+        emptyLabel.isHidden = !visibleEntries.isEmpty
+        emptyLabel.stringValue = allEntries.isEmpty
+            ? String(
+                localized: "No agents running",
+                comment: "Agent palette empty state when no agent is active anywhere."
+            )
+            : String(
+                localized: "No agents match",
+                comment: "Agent palette empty state when the filters exclude every agent."
+            )
+    }
+
+    private func startRefreshTimer() {
+        refreshTimer?.invalidate()
+        // Matches the automation monitor's own cadence, so a badge here never
+        // lags the one in the tab strip by more than a tick.
+        let timer = Timer(timeInterval: 0.75, repeats: true) { [weak self] timer in
+            MainActor.assumeIsolated {
+                guard let self else {
+                    timer.invalidate()
+                    return
+                }
+                self.refreshStatuses()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        refreshTimer = timer
+    }
+
+    private static func byAttention(
+        _ lhs: AgentPaletteEntry, _ rhs: AgentPaletteEntry
+    ) -> Bool {
+        if lhs.attentionRank != rhs.attentionRank {
+            return lhs.attentionRank < rhs.attentionRank
+        }
+        return lhs.updatedAt > rhs.updatedAt
+    }
+
+    // MARK: - Selection
+
+    private var selectedRow: Int? {
+        guard let selectedSessionID else { return nil }
+        return visibleEntries.firstIndex { $0.sessionID == selectedSessionID }
+    }
+
+    private func select(row: Int, scroll: Bool) {
+        guard visibleEntries.indices.contains(row) else {
+            selectedSessionID = nil
+            showPreview(nil)
+            return
+        }
+        selectedSessionID = visibleEntries[row].sessionID
+        tableView.selectRowIndexes(
+            IndexSet(integer: row), byExtendingSelection: false
+        )
+        if scroll { tableView.scrollRowToVisible(row) }
+        refreshPreview(debounced: true)
+    }
+
+    /// After a membership change, keep the same agent selected where possible
+    /// and otherwise fall back to the top of the list.
+    private func restoreSelection() {
+        if let row = selectedRow {
+            tableView.selectRowIndexes(
+                IndexSet(integer: row), byExtendingSelection: false
+            )
+            return
+        }
+        select(row: 0, scroll: false)
+    }
+
+    private func move(_ delta: Int) {
+        guard !visibleEntries.isEmpty else { return }
+        let current = selectedRow ?? 0
+        let next = (current + delta + visibleEntries.count) % visibleEntries.count
+        select(row: next, scroll: true)
+    }
+
+    // MARK: - Preview
+
+    /// Exporting a screen writes and reads a capture file, so coalesce the
+    /// bursts that key repeat produces while walking the list.
+    private func refreshPreview(debounced: Bool) {
+        previewWorkItem?.cancel()
+        guard let row = selectedRow else {
+            showPreview(nil)
+            return
+        }
+        let sessionID = visibleEntries[row].sessionID
+        guard debounced else {
+            renderPreview(for: sessionID)
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in
+            self?.renderPreview(for: sessionID)
+        }
+        previewWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: work)
+    }
+
+    private func renderPreview(for sessionID: UUID) {
+        guard let session = manager.session(withID: sessionID),
+              let capture = TerminalHistorySerializer.previewCapture(
+                  from: session.surface
+              )
+        else {
+            showPreview(nil, sessionID: sessionID)
+            return
+        }
+        let isDark = view.effectiveAppearance.bestMatch(
+            from: [.darkAqua, .aqua]
+        ) == .darkAqua
+        let font = NSFont(
+            descriptor: TerminalFont.current().fontDescriptor,
+            size: AgentPaletteLayout.previewFontSize
+        ) ?? .monospacedSystemFont(
+            ofSize: AgentPaletteLayout.previewFontSize, weight: .regular
+        )
+        showPreview(
+            TerminalPreviewStyle.attributedPreview(
+                vt: capture,
+                maxLines: AgentPaletteLayout.previewLines,
+                maxColumns: AgentPaletteLayout.previewColumns,
+                theme: Theme.terminal(dark: isDark),
+                font: font
+            ),
+            sessionID: sessionID
+        )
+    }
+
+    private func showPreview(
+        _ text: NSAttributedString?, sessionID: UUID? = nil
+    ) {
+        guard let text, text.length > 0 else {
+            previewPlaceholder.isHidden = false
+            previewScrollView.isHidden = true
+            previewTextView.string = ""
+            previewedSessionID = sessionID
+            previewedText = ""
+            return
+        }
+        previewPlaceholder.isHidden = true
+        previewScrollView.isHidden = false
+
+        let isNewSelection = sessionID != previewedSessionID
+        // A still agent re-renders identically every tick. Replacing the text
+        // storage anyway would fight the scroll wheel, so do nothing at all.
+        guard isNewSelection || text.string != previewedText else { return }
+
+        let clipView = previewScrollView.contentView
+        let previousOrigin = clipView.bounds.origin
+        // Follow live output only for a reader who is already at the bottom.
+        // Someone who scrolled up is reading, and must not be yanked back.
+        let followTail = isNewSelection || isScrolledToTail
+
+        previewTextView.textStorage?.setAttributedString(text)
+        // The container is unbounded, so the text view has to be sized to its
+        // own laid-out content before the scroll view can position it.
+        previewTextView.sizeToFit()
+        previewedSessionID = sessionID
+        previewedText = text.string
+
+        if followTail {
+            // An agent's newest output is its last row — the question it is
+            // blocked on, or the prompt it waits at. Open on that, not on the
+            // banner that happens to sit at the top of the screen.
+            previewTextView.scrollToEndOfDocument(nil)
+        } else {
+            clipView.scroll(to: previousOrigin)
+            previewScrollView.reflectScrolledClipView(clipView)
+        }
+    }
+
+    private var isScrolledToTail: Bool {
+        let clipView = previewScrollView.contentView
+        let documentHeight = previewTextView.frame.height
+        guard documentHeight > clipView.bounds.height else { return true }
+        return clipView.bounds.maxY >= documentHeight - 6
+    }
+
+    // MARK: - Actions
+
+    @objc private func rowClicked() {
+        let row = tableView.clickedRow
+        guard visibleEntries.indices.contains(row) else { return }
+        select(row: row, scroll: false)
+        activateSelection()
+    }
+
+    private func activateSelection() {
+        guard let row = selectedRow,
+              let session = manager.session(withID: visibleEntries[row].sessionID)
+        else { return }
+        dismiss()
+        manager.revealSession(session)
+        // Jumping to an agent is the explicit focus action that acknowledges a
+        // finished run, exactly as the ⇧⌘A cycle treats it.
+        session.markAutomationAgentSeen()
+    }
+
+    private func dismiss() {
+        manager.dismissAgentPalette()
+    }
+
+    private func handleEscape() {
+        if searchField.stringValue.isEmpty {
+            dismiss()
+        } else {
+            searchField.stringValue = ""
+            applyQuery()
+        }
+    }
+
+    /// Tilde-abbreviated directory, matching how the ⌘P palette writes a
+    /// session's path.
+    private static func abbreviated(_ path: String) -> String {
+        guard !path.isEmpty else { return "" }
+        let home = NSHomeDirectory()
+        if path == home { return "~" }
+        if path.hasPrefix(home + "/") {
+            return "~" + String(path.dropFirst(home.count))
+        }
+        return path
+    }
+
+    /// Score via the library's prepared-query, reusable-buffer UTF-8 API, the
+    /// same path the ⌘P palette uses to stay allocation-free per candidate.
+    @inline(__always)
+    private static func fuzzyScore(
+        _ candidate: String,
+        _ query: FuzzyQuery,
+        buffer: inout ScoringBuffer
+    ) -> Double? {
+        var candidate = candidate
+        return candidate.withUTF8 { bytes in
+            fuzzyMatcher.score(utf8: bytes, against: query, buffer: &buffer)?.score
+        }
+    }
+}
+
+extension AgentPaletteViewController: NSTextFieldDelegate {
+    func controlTextDidChange(_ notification: Notification) {
+        applyQuery()
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        // AppKit's default bindings already map ⌃N/⌃P onto these two, so
+        // handling them covers both the arrows and the emacs pair.
+        switch commandSelector {
+        case #selector(NSResponder.moveDown(_:)):
+            move(1)
+            return true
+        case #selector(NSResponder.moveUp(_:)):
+            move(-1)
+            return true
+        case #selector(NSResponder.insertNewline(_:)):
+            activateSelection()
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            handleEscape()
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+extension AgentPaletteViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        visibleEntries.count
+    }
+
+    func tableView(
+        _ tableView: NSTableView, rowViewForRow row: Int
+    ) -> NSTableRowView? {
+        let identifier = NSUserInterfaceItemIdentifier("agentRow")
+        let rowView = tableView.makeView(withIdentifier: identifier, owner: self)
+            as? AgentPaletteRowBackgroundView
+            ?? AgentPaletteRowBackgroundView(frame: .zero)
+        rowView.identifier = identifier
+        // The palette owns its highlight; AppKit's emphasized blue would fight
+        // the badge colors that carry the actual status.
+        rowView.isEmphasized = false
+        return rowView
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        guard visibleEntries.indices.contains(row) else { return nil }
+        let identifier = NSUserInterfaceItemIdentifier("agentCell")
+        let cell = tableView.makeView(withIdentifier: identifier, owner: self)
+            as? AgentPaletteCellView ?? AgentPaletteCellView(frame: .zero)
+        cell.identifier = identifier
+        cell.apply(visibleEntries[row])
+        return cell
+    }
+}
+
+/// Panel chrome. Layer colors are resolved rather than dynamic, so they are
+/// reapplied whenever the effective appearance changes.
+private final class AgentPalettePanelView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = AgentPaletteLayout.cornerRadius
+        layer?.cornerCurve = .continuous
+        layer?.borderWidth = 1
+        let shadow = NSShadow()
+        shadow.shadowColor = .black.withAlphaComponent(0.3)
+        shadow.shadowBlurRadius = 28
+        shadow.shadowOffset = NSSize(width: 0, height: -10)
+        self.shadow = shadow
+        applyColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
+
+    private func applyColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = Theme.background.cgColor
+            layer?.borderColor = NSColor.separatorColor.cgColor
+        }
+    }
+}
+
+/// Recessed surface behind the terminal tail. Terminal output is a different
+/// kind of content from the list beside it, and a faint well says so without
+/// adding another border to the panel.
+private final class AgentPalettePreviewWell: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.cornerCurve = .continuous
+        // Clips the unwrapped terminal lines that overflow the pane.
+        layer?.masksToBounds = true
+        applyColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
+
+    private func applyColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let isDark = effectiveAppearance.bestMatch(
+                from: [.darkAqua, .aqua]
+            ) == .darkAqua
+            layer?.backgroundColor = NSColor.labelColor
+                .withAlphaComponent(isDark ? 0.045 : 0.03).cgColor
+        }
+    }
+}
+
+/// Rounded selection fill matching the ⌘P palette's row highlight; AppKit's
+/// own regular and source-list styles both draw a full-bleed bar.
+private final class AgentPaletteRowBackgroundView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        guard isSelected else { return }
+        let path = NSBezierPath(
+            roundedRect: bounds.insetBy(dx: 2, dy: 1), xRadius: 7, yRadius: 7
+        )
+        NSColor.labelColor.withAlphaComponent(0.085).setFill()
+        path.fill()
+    }
+}
+
+/// One agent row, in two lines: the agent's identity over the directory it is
+/// working in, with its state and age held in a fixed right-hand column.
+///
+/// The directory is the line that actually distinguishes two runs of the same
+/// CLI, so it gets the width and truncates from the head — the tail of a path
+/// carries the repository name, the head carries `/Users/someone`.
+private final class AgentPaletteCellView: NSTableCellView {
+    private let badge = AgentStatusBadgeView(frame: .zero)
+    private let aliasLabel = NSTextField(labelWithString: "")
+    private let directoryLabel = NSTextField(labelWithString: "")
+    private let phaseLabel = NSTextField(labelWithString: "")
+    private let ageLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        aliasLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        aliasLabel.textColor = .labelColor
+        aliasLabel.lineBreakMode = .byTruncatingTail
+
+        directoryLabel.font = .systemFont(ofSize: 10.5)
+        directoryLabel.textColor = .tertiaryLabelColor
+        directoryLabel.lineBreakMode = .byTruncatingHead
+
+        // The badge encodes state by shape and colour, which reads at a glance
+        // but not precisely; a resting ring and a starting ring are a pixel
+        // apart. In a picker whose whole job is choosing by state, the word
+        // has to be there too.
+        phaseLabel.font = .systemFont(ofSize: 10, weight: .medium)
+        phaseLabel.alignment = .right
+
+        ageLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        ageLabel.textColor = .quaternaryLabelColor
+        ageLabel.alignment = .right
+
+        for label in [aliasLabel, directoryLabel, phaseLabel, ageLabel] {
+            label.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(label)
+        }
+        addSubview(badge)
+
+        directoryLabel.setContentCompressionResistancePriority(
+            .defaultLow, for: .horizontal
+        )
+        directoryLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        for label in [aliasLabel, phaseLabel, ageLabel] {
+            label.setContentCompressionResistancePriority(
+                .defaultHigh, for: .horizontal
+            )
+        }
+
+        NSLayoutConstraint.activate([
+            badge.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 11),
+            badge.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            aliasLabel.leadingAnchor.constraint(
+                equalTo: badge.trailingAnchor, constant: 10
+            ),
+            aliasLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            aliasLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: phaseLabel.leadingAnchor, constant: -8
+            ),
+
+            directoryLabel.leadingAnchor.constraint(
+                equalTo: aliasLabel.leadingAnchor
+            ),
+            directoryLabel.topAnchor.constraint(
+                equalTo: aliasLabel.bottomAnchor, constant: 1
+            ),
+            directoryLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: ageLabel.leadingAnchor, constant: -8
+            ),
+
+            phaseLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor, constant: -12
+            ),
+            phaseLabel.firstBaselineAnchor.constraint(
+                equalTo: aliasLabel.firstBaselineAnchor
+            ),
+
+            ageLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor, constant: -12
+            ),
+            ageLabel.firstBaselineAnchor.constraint(
+                equalTo: directoryLabel.firstBaselineAnchor
+            ),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(_ entry: AgentPaletteEntry) {
+        badge.apply(phase: entry.phase, count: 1)
+        aliasLabel.stringValue = entry.alias
+        directoryLabel.stringValue = entry.directory.isEmpty
+            ? entry.projectName
+            : entry.directory
+        directoryLabel.toolTip = entry.tabTitle
+        phaseLabel.stringValue = Self.phaseName(entry.phase)
+        phaseLabel.textColor = Self.phaseColor(entry.phase)
+        ageLabel.stringValue = Self.age(since: entry.updatedAt)
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.row)
+        setAccessibilityLabel(
+            "\(entry.alias), \(Self.phaseName(entry.phase)), \(directoryLabel.stringValue)"
+        )
+    }
+
+    /// Matches the vocabulary the status badge's own tooltips use.
+    private static func phaseName(_ phase: KeroAgentPhase) -> String {
+        switch phase {
+        case .created: return String(localized: "starting", comment: "Agent state.")
+        case .working: return String(localized: "working", comment: "Agent state.")
+        case .blocked: return String(localized: "needs you", comment: "Agent state.")
+        case .done: return String(localized: "finished", comment: "Agent state.")
+        case .idle: return String(localized: "idle", comment: "Agent state.")
+        case .unknown: return String(localized: "unknown", comment: "Agent state.")
+        }
+    }
+
+    /// Only the two states that also post a notification carry colour; the
+    /// resting states stay grey so a wall of running agents never shouts.
+    private static func phaseColor(_ phase: KeroAgentPhase) -> NSColor {
+        switch phase {
+        case .blocked: return .systemOrange
+        case .done: return .systemGreen
+        case .working: return .systemBlue
+        case .created, .idle, .unknown: return .tertiaryLabelColor
+        }
+    }
+
+    /// Compact elapsed time — a status column, not prose, so it has to stay
+    /// narrow and stable in width.
+    private static func age(since date: Date) -> String {
+        let seconds = max(0, Int(Date().timeIntervalSince(date)))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3_600 { return "\(seconds / 60)m" }
+        if seconds < 86_400 { return "\(seconds / 3_600)h" }
+        return "\(seconds / 86_400)d"
+    }
+}
+
+/// Dim backdrop that closes the palette when clicked outside the panel.
+private final class AgentPaletteBackdropView: NSView {
+    private let onClick: () -> Void
+
+    init(onClick: @escaping () -> Void) {
+        self.onClick = onClick
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.withAlphaComponent(0.15).cgColor
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onClick()
+    }
+
+    /// The terminal surface underneath sets an I-beam cursor rect that would
+    /// otherwise show through the whole backdrop.
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .arrow)
+    }
+}
+
+/// Mount point only. All palette rendering, layout, and interaction lives in
+/// the AppKit controller above.
+struct AgentPaletteMount: NSViewControllerRepresentable {
+    let manager: TerminalManager
+
+    func makeNSViewController(context: Context) -> AgentPaletteViewController {
+        AgentPaletteViewController(manager: manager)
+    }
+
+    func updateNSViewController(
+        _ controller: AgentPaletteViewController, context: Context
+    ) {}
+}

--- a/kero/AgentPalette.swift
+++ b/kero/AgentPalette.swift
@@ -22,11 +22,6 @@ private enum AgentPaletteLayout {
     /// match does not leave a wall of empty space and a long list still fits.
     static let minBodyHeight: CGFloat = 216
     static let maxBodyHeight: CGFloat = 348
-    static let previewFontSize: CGFloat = 10
-    static let previewLines = 44
-    /// Wide enough to hold an agent's own box drawing without reflowing it.
-    /// Overflow is clipped rather than wrapped.
-    static let previewColumns = 200
 }
 
 /// ⌥⌘A overlay: every running agent across every project, filterable by typed
@@ -46,10 +41,7 @@ final class AgentPaletteViewController: NSViewController {
     private let summaryLabel = NSTextField(labelWithString: "")
     private let tableView = NSTableView()
     private let tableScrollView = NSScrollView()
-    private let previewTextView = NSTextView()
-    private let previewScrollView = NSScrollView()
-    private let previewWell = AgentPalettePreviewWell(frame: .zero)
-    private let previewPlaceholder = NSTextField(labelWithString: "")
+    private let preview = AgentPalettePreviewView(frame: .zero)
     private let emptyLabel = NSTextField(labelWithString: "")
     private var bodyHeightConstraint: NSLayoutConstraint?
 
@@ -58,13 +50,10 @@ final class AgentPaletteViewController: NSViewController {
     /// The rows on screen. Order is recomputed only when the query changes.
     private var visibleEntries: [AgentPaletteEntry] = []
     private var selectedSessionID: UUID?
+    /// The query the visible rows were built from, so the periodic refresh can
+    /// restate the header without re-parsing the field.
+    private var activeQuery = AgentPaletteQuery()
     private var refreshTimer: Timer?
-    private var previewWorkItem: DispatchWorkItem?
-    /// What the preview currently shows, so a periodic refresh that produces
-    /// identical output can leave the text storage — and the reader's scroll
-    /// position — untouched.
-    private var previewedSessionID: UUID?
-    private var previewedText = ""
 
     private static let fuzzyMatcher = FuzzyMatcher(config: .smithWaterman)
 
@@ -103,8 +92,7 @@ final class AgentPaletteViewController: NSViewController {
     private func stopTimers() {
         refreshTimer?.invalidate()
         refreshTimer = nil
-        previewWorkItem?.cancel()
-        previewWorkItem = nil
+        preview.clear()
     }
 
     // MARK: - Chrome
@@ -184,11 +172,10 @@ final class AgentPaletteViewController: NSViewController {
         filterHints.textColor = .quaternaryLabelColor
 
         buildList()
-        buildPreview()
 
         for subview in [
             magnifier, searchField, summaryLabel, headerRule, tableScrollView,
-            emptyLabel, verticalRule, previewWell, footerRule, keyHints,
+            emptyLabel, verticalRule, preview, footerRule, keyHints,
             filterHints,
         ] as [NSView] {
             panel.addSubview(subview)
@@ -271,16 +258,16 @@ final class AgentPaletteViewController: NSViewController {
             verticalRule.bottomAnchor.constraint(equalTo: footerRule.topAnchor),
             verticalRule.widthAnchor.constraint(equalToConstant: 1),
 
-            previewWell.leadingAnchor.constraint(
+            preview.leadingAnchor.constraint(
                 equalTo: verticalRule.trailingAnchor, constant: 8
             ),
-            previewWell.trailingAnchor.constraint(
+            preview.trailingAnchor.constraint(
                 equalTo: panel.trailingAnchor, constant: -8
             ),
-            previewWell.topAnchor.constraint(
+            preview.topAnchor.constraint(
                 equalTo: tableScrollView.topAnchor
             ),
-            previewWell.bottomAnchor.constraint(
+            preview.bottomAnchor.constraint(
                 equalTo: tableScrollView.bottomAnchor
             ),
 
@@ -349,72 +336,6 @@ final class AgentPaletteViewController: NSViewController {
         tableScrollView.autohidesScrollers = true
     }
 
-    private func buildPreview() {
-        previewWell.translatesAutoresizingMaskIntoConstraints = false
-        previewScrollView.translatesAutoresizingMaskIntoConstraints = false
-        previewScrollView.hasVerticalScroller = true
-        previewScrollView.hasHorizontalScroller = false
-        previewScrollView.drawsBackground = false
-        previewScrollView.autohidesScrollers = true
-
-        previewTextView.isEditable = false
-        // Selection would compete with the search field for the responder and
-        // give the terminal tail an I-beam it cannot act on.
-        previewTextView.isSelectable = false
-        previewTextView.drawsBackground = false
-        previewTextView.textContainerInset = NSSize(width: 12, height: 11)
-        previewTextView.isVerticallyResizable = true
-        previewTextView.isHorizontallyResizable = true
-        previewTextView.autoresizingMask = []
-        previewTextView.maxSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        // Terminal output is already laid out in columns. Reflowing it to the
-        // pane width folds an agent's own box drawing onto itself, so give the
-        // container unbounded width and let the well clip the overflow.
-        previewTextView.textContainer?.widthTracksTextView = false
-        previewTextView.textContainer?.containerSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        previewTextView.textContainer?.lineFragmentPadding = 0
-
-        previewPlaceholder.translatesAutoresizingMaskIntoConstraints = false
-        previewPlaceholder.font = .systemFont(ofSize: 11)
-        previewPlaceholder.textColor = .quaternaryLabelColor
-        previewPlaceholder.alignment = .center
-        previewPlaceholder.stringValue = String(
-            localized: "No output yet",
-            comment: "Agent palette preview pane with nothing to show."
-        )
-        previewPlaceholder.isHidden = true
-
-        previewWell.addSubview(previewScrollView)
-        previewWell.addSubview(previewPlaceholder)
-        NSLayoutConstraint.activate([
-            previewPlaceholder.centerXAnchor.constraint(
-                equalTo: previewWell.centerXAnchor
-            ),
-            previewPlaceholder.centerYAnchor.constraint(
-                equalTo: previewWell.centerYAnchor
-            ),
-            previewScrollView.leadingAnchor.constraint(
-                equalTo: previewWell.leadingAnchor
-            ),
-            previewScrollView.trailingAnchor.constraint(
-                equalTo: previewWell.trailingAnchor
-            ),
-            previewScrollView.topAnchor.constraint(
-                equalTo: previewWell.topAnchor
-            ),
-            previewScrollView.bottomAnchor.constraint(
-                equalTo: previewWell.bottomAnchor
-            ),
-        ])
-        previewScrollView.documentView = previewTextView
-    }
-
     // MARK: - Data
 
     /// Walks projects in window order so an unfiltered list matches the project
@@ -429,7 +350,7 @@ final class AgentPaletteViewController: NSViewController {
                 )
                 for session in tab.sessions {
                     guard let status = session.agentStatus else { continue }
-                    let directory = Self.abbreviated(session.currentDirectoryPath)
+                    let directory = session.currentDirectoryPath.abbreviatingHomeDirectory
                     entries.append(
                         AgentPaletteEntry(
                             sessionID: session.id,
@@ -458,6 +379,7 @@ final class AgentPaletteViewController: NSViewController {
     private func applyQuery() {
         rebuildSnapshot()
         let query = AgentPaletteQuery.parse(searchField.stringValue)
+        activeQuery = query
 
         var candidates = allEntries.filter { query.admits($0) }
         if query.freeText.isEmpty {
@@ -511,19 +433,31 @@ final class AgentPaletteViewController: NSViewController {
     /// appear here — both would disturb a selection the user is aiming at.
     /// Closed sessions do drop out, since jumping to one is a dead end.
     private func refreshStatuses() {
-        rebuildSnapshot()
-        let live = Dictionary(
-            allEntries.map { ($0.sessionID, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        let refreshed = visibleEntries.compactMap { live[$0.sessionID] }
+        // Only the three status fields can have changed, so look each visible
+        // row up by identity rather than rebuilding the whole snapshot. That
+        // keeps a sub-second timer off the walk over every project, tab, and
+        // session, and away from rebuilding search strings nothing reads here.
+        var refreshed: [AgentPaletteEntry] = []
+        refreshed.reserveCapacity(visibleEntries.count)
+        for var entry in visibleEntries {
+            guard let status = manager.session(withID: entry.sessionID)?.agentStatus
+            else { continue }
+            entry.phase = status.phase
+            entry.unseen = status.unseen
+            entry.updatedAt = status.updatedAt
+            refreshed.append(entry)
+        }
+
         let membershipChanged = refreshed.count != visibleEntries.count
         visibleEntries = refreshed
 
         tableView.reloadData()
         if membershipChanged {
+            // The count in the header is drawn from both lists, so the full
+            // snapshot is only worth rebuilding when one of them shrank.
+            rebuildSnapshot()
             updateBodyHeight()
-            updateSummary(AgentPaletteQuery.parse(searchField.stringValue))
+            updateSummary(activeQuery)
             updateEmptyState()
         }
         restoreSelection()
@@ -579,7 +513,7 @@ final class AgentPaletteViewController: NSViewController {
     private func select(row: Int, scroll: Bool) {
         guard visibleEntries.indices.contains(row) else {
             selectedSessionID = nil
-            showPreview(nil)
+            preview.clear()
             return
         }
         selectedSessionID = visibleEntries[row].sessionID
@@ -611,104 +545,21 @@ final class AgentPaletteViewController: NSViewController {
 
     // MARK: - Preview
 
-    /// Exporting a screen writes and reads a capture file, so coalesce the
-    /// bursts that key repeat produces while walking the list.
+    /// Hands the highlighted agent to the preview, which owns its own scroll
+    /// position, debounce, and change detection. `debounced` marks a move
+    /// through the list, where key repeat would otherwise export a screen per
+    /// row; the periodic refresh renders immediately.
     private func refreshPreview(debounced: Bool) {
-        previewWorkItem?.cancel()
         guard let row = selectedRow else {
-            showPreview(nil)
+            preview.clear()
             return
         }
         let sessionID = visibleEntries[row].sessionID
-        guard debounced else {
-            renderPreview(for: sessionID)
-            return
-        }
-        let work = DispatchWorkItem { [weak self] in
-            self?.renderPreview(for: sessionID)
-        }
-        previewWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: work)
-    }
-
-    private func renderPreview(for sessionID: UUID) {
-        guard let session = manager.session(withID: sessionID),
-              let capture = TerminalHistorySerializer.previewCapture(
-                  from: session.surface
-              )
-        else {
-            showPreview(nil, sessionID: sessionID)
-            return
-        }
-        let isDark = view.effectiveAppearance.bestMatch(
-            from: [.darkAqua, .aqua]
-        ) == .darkAqua
-        let font = NSFont(
-            descriptor: TerminalFont.current().fontDescriptor,
-            size: AgentPaletteLayout.previewFontSize
-        ) ?? .monospacedSystemFont(
-            ofSize: AgentPaletteLayout.previewFontSize, weight: .regular
+        preview.show(
+            manager.session(withID: sessionID),
+            id: sessionID,
+            debounced: debounced
         )
-        showPreview(
-            TerminalPreviewStyle.attributedPreview(
-                vt: capture,
-                maxLines: AgentPaletteLayout.previewLines,
-                maxColumns: AgentPaletteLayout.previewColumns,
-                theme: Theme.terminal(dark: isDark),
-                font: font
-            ),
-            sessionID: sessionID
-        )
-    }
-
-    private func showPreview(
-        _ text: NSAttributedString?, sessionID: UUID? = nil
-    ) {
-        guard let text, text.length > 0 else {
-            previewPlaceholder.isHidden = false
-            previewScrollView.isHidden = true
-            previewTextView.string = ""
-            previewedSessionID = sessionID
-            previewedText = ""
-            return
-        }
-        previewPlaceholder.isHidden = true
-        previewScrollView.isHidden = false
-
-        let isNewSelection = sessionID != previewedSessionID
-        // A still agent re-renders identically every tick. Replacing the text
-        // storage anyway would fight the scroll wheel, so do nothing at all.
-        guard isNewSelection || text.string != previewedText else { return }
-
-        let clipView = previewScrollView.contentView
-        let previousOrigin = clipView.bounds.origin
-        // Follow live output only for a reader who is already at the bottom.
-        // Someone who scrolled up is reading, and must not be yanked back.
-        let followTail = isNewSelection || isScrolledToTail
-
-        previewTextView.textStorage?.setAttributedString(text)
-        // The container is unbounded, so the text view has to be sized to its
-        // own laid-out content before the scroll view can position it.
-        previewTextView.sizeToFit()
-        previewedSessionID = sessionID
-        previewedText = text.string
-
-        if followTail {
-            // An agent's newest output is its last row — the question it is
-            // blocked on, or the prompt it waits at. Open on that, not on the
-            // banner that happens to sit at the top of the screen.
-            previewTextView.scrollToEndOfDocument(nil)
-        } else {
-            clipView.scroll(to: previousOrigin)
-            previewScrollView.reflectScrolledClipView(clipView)
-        }
-    }
-
-    private var isScrolledToTail: Bool {
-        let clipView = previewScrollView.contentView
-        let documentHeight = previewTextView.frame.height
-        guard documentHeight > clipView.bounds.height else { return true }
-        return clipView.bounds.maxY >= documentHeight - 6
     }
 
     // MARK: - Actions
@@ -742,18 +593,6 @@ final class AgentPaletteViewController: NSViewController {
             searchField.stringValue = ""
             applyQuery()
         }
-    }
-
-    /// Tilde-abbreviated directory, matching how the ⌘P palette writes a
-    /// session's path.
-    private static func abbreviated(_ path: String) -> String {
-        guard !path.isEmpty else { return "" }
-        let home = NSHomeDirectory()
-        if path == home { return "~" }
-        if path.hasPrefix(home + "/") {
-            return "~" + String(path.dropFirst(home.count))
-        }
-        return path
     }
 
     /// Score via the library's prepared-query, reusable-buffer UTF-8 API, the
@@ -868,200 +707,6 @@ private final class AgentPalettePanelView: NSView {
             layer?.backgroundColor = Theme.background.cgColor
             layer?.borderColor = NSColor.separatorColor.cgColor
         }
-    }
-}
-
-/// Recessed surface behind the terminal tail. Terminal output is a different
-/// kind of content from the list beside it, and a faint well says so without
-/// adding another border to the panel.
-private final class AgentPalettePreviewWell: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.cornerRadius = 8
-        layer?.cornerCurve = .continuous
-        // Clips the unwrapped terminal lines that overflow the pane.
-        layer?.masksToBounds = true
-        applyColors()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        applyColors()
-    }
-
-    private func applyColors() {
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            let isDark = effectiveAppearance.bestMatch(
-                from: [.darkAqua, .aqua]
-            ) == .darkAqua
-            layer?.backgroundColor = NSColor.labelColor
-                .withAlphaComponent(isDark ? 0.045 : 0.03).cgColor
-        }
-    }
-}
-
-/// Rounded selection fill matching the ⌘P palette's row highlight; AppKit's
-/// own regular and source-list styles both draw a full-bleed bar.
-private final class AgentPaletteRowBackgroundView: NSTableRowView {
-    override func drawSelection(in dirtyRect: NSRect) {
-        guard isSelected else { return }
-        let path = NSBezierPath(
-            roundedRect: bounds.insetBy(dx: 2, dy: 1), xRadius: 7, yRadius: 7
-        )
-        NSColor.labelColor.withAlphaComponent(0.085).setFill()
-        path.fill()
-    }
-}
-
-/// One agent row, in two lines: the agent's identity over the directory it is
-/// working in, with its state and age held in a fixed right-hand column.
-///
-/// The directory is the line that actually distinguishes two runs of the same
-/// CLI, so it gets the width and truncates from the head — the tail of a path
-/// carries the repository name, the head carries `/Users/someone`.
-private final class AgentPaletteCellView: NSTableCellView {
-    private let badge = AgentStatusBadgeView(frame: .zero)
-    private let aliasLabel = NSTextField(labelWithString: "")
-    private let directoryLabel = NSTextField(labelWithString: "")
-    private let phaseLabel = NSTextField(labelWithString: "")
-    private let ageLabel = NSTextField(labelWithString: "")
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-
-        aliasLabel.font = .systemFont(ofSize: 13, weight: .semibold)
-        aliasLabel.textColor = .labelColor
-        aliasLabel.lineBreakMode = .byTruncatingTail
-
-        directoryLabel.font = .systemFont(ofSize: 10.5)
-        directoryLabel.textColor = .tertiaryLabelColor
-        directoryLabel.lineBreakMode = .byTruncatingHead
-
-        // The badge encodes state by shape and colour, which reads at a glance
-        // but not precisely; a resting ring and a starting ring are a pixel
-        // apart. In a picker whose whole job is choosing by state, the word
-        // has to be there too.
-        phaseLabel.font = .systemFont(ofSize: 10, weight: .medium)
-        phaseLabel.alignment = .right
-
-        ageLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
-        ageLabel.textColor = .quaternaryLabelColor
-        ageLabel.alignment = .right
-
-        for label in [aliasLabel, directoryLabel, phaseLabel, ageLabel] {
-            label.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(label)
-        }
-        addSubview(badge)
-
-        directoryLabel.setContentCompressionResistancePriority(
-            .defaultLow, for: .horizontal
-        )
-        directoryLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        for label in [aliasLabel, phaseLabel, ageLabel] {
-            label.setContentCompressionResistancePriority(
-                .defaultHigh, for: .horizontal
-            )
-        }
-
-        NSLayoutConstraint.activate([
-            badge.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 11),
-            badge.centerYAnchor.constraint(equalTo: centerYAnchor),
-
-            aliasLabel.leadingAnchor.constraint(
-                equalTo: badge.trailingAnchor, constant: 10
-            ),
-            aliasLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
-            aliasLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: phaseLabel.leadingAnchor, constant: -8
-            ),
-
-            directoryLabel.leadingAnchor.constraint(
-                equalTo: aliasLabel.leadingAnchor
-            ),
-            directoryLabel.topAnchor.constraint(
-                equalTo: aliasLabel.bottomAnchor, constant: 1
-            ),
-            directoryLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: ageLabel.leadingAnchor, constant: -8
-            ),
-
-            phaseLabel.trailingAnchor.constraint(
-                equalTo: trailingAnchor, constant: -12
-            ),
-            phaseLabel.firstBaselineAnchor.constraint(
-                equalTo: aliasLabel.firstBaselineAnchor
-            ),
-
-            ageLabel.trailingAnchor.constraint(
-                equalTo: trailingAnchor, constant: -12
-            ),
-            ageLabel.firstBaselineAnchor.constraint(
-                equalTo: directoryLabel.firstBaselineAnchor
-            ),
-        ])
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func apply(_ entry: AgentPaletteEntry) {
-        badge.apply(phase: entry.phase, count: 1)
-        aliasLabel.stringValue = entry.alias
-        directoryLabel.stringValue = entry.directory.isEmpty
-            ? entry.projectName
-            : entry.directory
-        directoryLabel.toolTip = entry.tabTitle
-        phaseLabel.stringValue = Self.phaseName(entry.phase)
-        phaseLabel.textColor = Self.phaseColor(entry.phase)
-        ageLabel.stringValue = Self.age(since: entry.updatedAt)
-
-        setAccessibilityElement(true)
-        setAccessibilityRole(.row)
-        setAccessibilityLabel(
-            "\(entry.alias), \(Self.phaseName(entry.phase)), \(directoryLabel.stringValue)"
-        )
-    }
-
-    /// Matches the vocabulary the status badge's own tooltips use.
-    private static func phaseName(_ phase: KeroAgentPhase) -> String {
-        switch phase {
-        case .created: return String(localized: "starting", comment: "Agent state.")
-        case .working: return String(localized: "working", comment: "Agent state.")
-        case .blocked: return String(localized: "needs you", comment: "Agent state.")
-        case .done: return String(localized: "finished", comment: "Agent state.")
-        case .idle: return String(localized: "idle", comment: "Agent state.")
-        case .unknown: return String(localized: "unknown", comment: "Agent state.")
-        }
-    }
-
-    /// Only the two states that also post a notification carry colour; the
-    /// resting states stay grey so a wall of running agents never shouts.
-    private static func phaseColor(_ phase: KeroAgentPhase) -> NSColor {
-        switch phase {
-        case .blocked: return .systemOrange
-        case .done: return .systemGreen
-        case .working: return .systemBlue
-        case .created, .idle, .unknown: return .tertiaryLabelColor
-        }
-    }
-
-    /// Compact elapsed time — a status column, not prose, so it has to stay
-    /// narrow and stable in width.
-    private static func age(since date: Date) -> String {
-        let seconds = max(0, Int(Date().timeIntervalSince(date)))
-        if seconds < 60 { return "\(seconds)s" }
-        if seconds < 3_600 { return "\(seconds / 60)m" }
-        if seconds < 86_400 { return "\(seconds / 3_600)h" }
-        return "\(seconds / 86_400)d"
     }
 }
 

--- a/kero/AgentPalettePreview.swift
+++ b/kero/AgentPalettePreview.swift
@@ -1,0 +1,228 @@
+//
+//  AgentPalettePreview.swift
+//  kero
+//
+
+import AppKit
+
+/// The agent palette's terminal pane: a recessed well holding the highlighted
+/// agent's own screen, in its own colors.
+///
+/// This owns everything about showing that capture — the scroll position it
+/// must not disturb, the debounce that keeps key repeat from exporting a
+/// screen per keystroke, and the change detection that lets a still agent
+/// refresh for free. The controller only says which session is highlighted.
+@MainActor
+final class AgentPalettePreviewView: NSView {
+    private enum Metrics {
+        static let cornerRadius: CGFloat = 8
+        static let fontSize: CGFloat = 10
+        static let lines = 44
+        /// Wide enough to hold an agent's own box drawing without reflowing
+        /// it. Overflow is clipped rather than wrapped.
+        static let columns = 200
+        static let inset = NSSize(width: 12, height: 11)
+        /// Coalesces the export burst that arrow-key repeat produces.
+        static let debounce: TimeInterval = 0.06
+        /// Slack when deciding whether the reader sits at the bottom.
+        static let tailTolerance: CGFloat = 6
+    }
+
+    private let scrollView = NSScrollView()
+    private let textView = NSTextView()
+    private let placeholder = NSTextField(labelWithString: "")
+
+    /// What is on screen now, so a refresh producing identical output can
+    /// leave the text storage — and the reader's scroll position — alone.
+    private var shownSessionID: UUID?
+    private var shownText = ""
+    private var pendingRender: DispatchWorkItem?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+        layer?.cornerRadius = Metrics.cornerRadius
+        layer?.cornerCurve = .continuous
+        // Clips the unwrapped terminal lines that overflow the pane.
+        layer?.masksToBounds = true
+        applyColors()
+        buildSubviews()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
+
+    /// Terminal output is a different kind of content from the list beside it,
+    /// and a faint well says so without adding another border to the panel.
+    private func applyColors() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            let isDark = effectiveAppearance.bestMatch(
+                from: [.darkAqua, .aqua]
+            ) == .darkAqua
+            layer?.backgroundColor = NSColor.labelColor
+                .withAlphaComponent(isDark ? 0.045 : 0.03).cgColor
+        }
+    }
+
+    private func buildSubviews() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.autohidesScrollers = true
+
+        textView.isEditable = false
+        // Selection would compete with the search field for the responder and
+        // give the terminal tail an I-beam it cannot act on.
+        textView.isSelectable = false
+        textView.drawsBackground = false
+        textView.textContainerInset = Metrics.inset
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = []
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        // Terminal output is already laid out in columns. Reflowing it to the
+        // pane width folds an agent's own box drawing onto itself, so give the
+        // container unbounded width and let this well clip the overflow.
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.lineFragmentPadding = 0
+        scrollView.documentView = textView
+
+        placeholder.translatesAutoresizingMaskIntoConstraints = false
+        placeholder.font = .systemFont(ofSize: 11)
+        placeholder.textColor = .quaternaryLabelColor
+        placeholder.alignment = .center
+        placeholder.stringValue = String(
+            localized: "No output yet",
+            comment: "Agent palette preview pane with nothing to show."
+        )
+        placeholder.isHidden = true
+
+        addSubview(scrollView)
+        addSubview(placeholder)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            placeholder.centerXAnchor.constraint(equalTo: centerXAnchor),
+            placeholder.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    // MARK: - Presenting
+
+    /// Shows `session`'s screen. Pass `debounced` when walking the list, so key
+    /// repeat does not export a screen per row; the periodic refresh of an
+    /// already-shown session passes false and renders immediately.
+    func show(_ session: TerminalSession?, id: UUID?, debounced: Bool) {
+        pendingRender?.cancel()
+        guard let session, let id else {
+            clear()
+            return
+        }
+        guard debounced else {
+            render(session, id: id)
+            return
+        }
+        let work = DispatchWorkItem { [weak self, weak session] in
+            guard let self, let session else { return }
+            self.render(session, id: id)
+        }
+        pendingRender = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Metrics.debounce, execute: work)
+    }
+
+    func clear() {
+        pendingRender?.cancel()
+        pendingRender = nil
+        placeholder.isHidden = false
+        scrollView.isHidden = true
+        textView.string = ""
+        shownSessionID = nil
+        shownText = ""
+    }
+
+    private func render(_ session: TerminalSession, id: UUID) {
+        guard let capture = TerminalHistorySerializer.previewCapture(
+            from: session.surface
+        ) else {
+            clear()
+            return
+        }
+        let isDark = effectiveAppearance.bestMatch(
+            from: [.darkAqua, .aqua]
+        ) == .darkAqua
+        let font = NSFont(
+            descriptor: TerminalFont.current().fontDescriptor,
+            size: Metrics.fontSize
+        ) ?? .monospacedSystemFont(ofSize: Metrics.fontSize, weight: .regular)
+
+        guard let styled = TerminalPreviewStyle.attributedPreview(
+            vt: capture,
+            maxLines: Metrics.lines,
+            maxColumns: Metrics.columns,
+            theme: Theme.terminal(dark: isDark),
+            font: font
+        ), styled.length > 0 else {
+            clear()
+            return
+        }
+        display(styled, id: id)
+    }
+
+    private func display(_ text: NSAttributedString, id: UUID) {
+        placeholder.isHidden = true
+        scrollView.isHidden = false
+
+        let isNewSelection = id != shownSessionID
+        // A still agent re-renders identically every tick. Replacing the text
+        // storage anyway would fight the scroll wheel, so do nothing at all.
+        guard isNewSelection || text.string != shownText else { return }
+
+        let clipView = scrollView.contentView
+        let previousOrigin = clipView.bounds.origin
+        // Follow live output only for a reader already at the bottom. Someone
+        // who scrolled up is reading, and must not be yanked back.
+        let followTail = isNewSelection || isScrolledToTail
+
+        textView.textStorage?.setAttributedString(text)
+        // The container is unbounded, so the text view has to be sized to its
+        // own laid-out content before the scroll view can position it.
+        textView.sizeToFit()
+        shownSessionID = id
+        shownText = text.string
+
+        if followTail {
+            // An agent's newest output is its last row — the question it is
+            // blocked on, or the prompt it waits at. Open on that, not on the
+            // banner that happens to sit at the top of the screen.
+            textView.scrollToEndOfDocument(nil)
+        } else {
+            clipView.scroll(to: previousOrigin)
+            scrollView.reflectScrolledClipView(clipView)
+        }
+    }
+
+    private var isScrolledToTail: Bool {
+        let clipView = scrollView.contentView
+        let documentHeight = textView.frame.height
+        guard documentHeight > clipView.bounds.height else { return true }
+        return clipView.bounds.maxY >= documentHeight - Metrics.tailTolerance
+    }
+}

--- a/kero/AgentPaletteQuery.swift
+++ b/kero/AgentPaletteQuery.swift
@@ -21,9 +21,11 @@ struct AgentPaletteEntry {
     /// Alias, agent name, project, tab, and directory folded together so one
     /// unprefixed word can find a session by any of them.
     let searchText: String
-    let phase: KeroAgentPhase
-    let unseen: Bool
-    let updatedAt: Date
+    /// Status is restated in place while the palette is open, so a badge stays
+    /// truthful without its row moving.
+    var phase: KeroAgentPhase
+    var unseen: Bool
+    var updatedAt: Date
 
     /// Ordering for an unfiltered palette: whatever wants the user first. An
     /// unacknowledged completion outranks one already seen, the same

--- a/kero/AgentPaletteQuery.swift
+++ b/kero/AgentPaletteQuery.swift
@@ -1,0 +1,150 @@
+//
+//  AgentPaletteQuery.swift
+//  kero
+//
+
+import Foundation
+
+/// One agent-bearing terminal session, flattened for the palette.
+///
+/// Only the session's identity is captured; the live `TerminalSession` is
+/// resolved through the manager when the palette needs its surface. That keeps
+/// a transient overlay from extending the lifetime of a terminal the user has
+/// since closed, and makes a vanished session detectable rather than stale.
+struct AgentPaletteEntry {
+    let sessionID: UUID
+    let alias: String
+    let kind: KeroAgentKind
+    let projectName: String
+    let tabTitle: String
+    let directory: String
+    /// Alias, agent name, project, tab, and directory folded together so one
+    /// unprefixed word can find a session by any of them.
+    let searchText: String
+    let phase: KeroAgentPhase
+    let unseen: Bool
+    let updatedAt: Date
+
+    /// Ordering for an unfiltered palette: whatever wants the user first. An
+    /// unacknowledged completion outranks one already seen, the same
+    /// distinction the ⇧⌘A cycle and the status badge already draw.
+    var attentionRank: Int {
+        switch phase {
+        case .blocked: return 0
+        case .done: return unseen ? 1 : 2
+        case .working: return 3
+        case .created: return 4
+        case .idle: return 5
+        case .unknown: return 6
+        }
+    }
+}
+
+/// The search field parsed into structured filters plus leftover fuzzy text.
+///
+/// Tokens are `key:value`, values comma-separate as OR, and separate tokens
+/// AND together. A token whose key is unknown — or whose values are all
+/// unrecognized — degrades to plain search text rather than silently matching
+/// nothing, so a typo narrows the list instead of emptying it.
+struct AgentPaletteQuery {
+    var statuses: Set<KeroAgentPhase> = []
+    var kinds: Set<KeroAgentKind> = []
+    /// One element per `project:` token; the names inside a token are the
+    /// comma-separated alternatives. Flattening these would turn `a,b` into a
+    /// requirement to match both, which no project name can satisfy.
+    var projects: [[String]] = []
+    var freeText = ""
+
+    var hasFilters: Bool {
+        !statuses.isEmpty || !kinds.isEmpty || !projects.isEmpty
+    }
+
+    var isEmpty: Bool { !hasFilters && freeText.isEmpty }
+
+    /// `cursor-agent` is the executable name the recognizer keys on, but nobody
+    /// types the suffix; the CLIs' own brand spellings are accepted too.
+    private static let kindsByToken: [String: KeroAgentKind] = {
+        var map: [String: KeroAgentKind] = [:]
+        for kind in KeroAgentKind.allCases {
+            map[kind.rawValue] = kind
+        }
+        map["cursor"] = .cursor
+        map["claude-code"] = .claude
+        map["opencode-ai"] = .opencode
+        return map
+    }()
+
+    static func parse(_ raw: String) -> AgentPaletteQuery {
+        var query = AgentPaletteQuery()
+        var text: [String] = []
+
+        for token in raw.split(separator: " ", omittingEmptySubsequences: true) {
+            guard let separator = token.firstIndex(of: ":") else {
+                text.append(String(token))
+                continue
+            }
+            let key = token[token.startIndex..<separator].lowercased()
+            let values = token[token.index(after: separator)...]
+                .split(separator: ",", omittingEmptySubsequences: true)
+                .map { $0.lowercased() }
+            if values.isEmpty || !query.consume(key: key, values: values) {
+                text.append(String(token))
+            }
+        }
+
+        query.freeText = text.joined(separator: " ")
+        return query
+    }
+
+    /// Returns false when the token is not a filter this palette understands,
+    /// leaving the caller to treat it as search text.
+    private mutating func consume(key: String, values: [String]) -> Bool {
+        switch key {
+        case "status", "s":
+            let parsed = values.compactMap(KeroAgentPhase.init(rawValue:))
+            guard !parsed.isEmpty else { return false }
+            statuses.formUnion(parsed)
+            return true
+        case "agent", "a":
+            let parsed = values.compactMap { Self.kindsByToken[$0] }
+            guard !parsed.isEmpty else { return false }
+            kinds.formUnion(parsed)
+            return true
+        case "project", "p":
+            projects.append(values)
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Structured filters only. Fuzzy text is applied separately because it
+    /// also produces the score the results are ranked by.
+    func admits(_ entry: AgentPaletteEntry) -> Bool {
+        if !statuses.isEmpty, !statuses.contains(entry.phase) { return false }
+        if !kinds.isEmpty, !kinds.contains(entry.kind) { return false }
+        for alternatives in projects where !alternatives.contains(
+            where: { entry.projectName.localizedCaseInsensitiveContains($0) }
+        ) {
+            return false
+        }
+        return true
+    }
+
+    /// Human read-out of what the query is doing, shown under the field so
+    /// typed filters are visibly understood before the results settle.
+    var summary: String? {
+        var parts: [String] = []
+        if !statuses.isEmpty {
+            parts.append(statuses.map(\.rawValue).sorted().joined(separator: "/"))
+        }
+        if !kinds.isEmpty {
+            parts.append(kinds.map(\.displayName).sorted().joined(separator: "/"))
+        }
+        parts.append(contentsOf: projects.map {
+            "project \($0.joined(separator: "/"))"
+        })
+        if !freeText.isEmpty { parts.append("\"\(freeText)\"") }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}

--- a/kero/AgentPaletteRow.swift
+++ b/kero/AgentPaletteRow.swift
@@ -1,0 +1,168 @@
+//
+//  AgentPaletteRow.swift
+//  kero
+//
+
+import AppKit
+
+/// How a phase reads in a list, where the badge's shape-and-color encoding is
+/// glanceable but not precise — a resting ring and a starting ring are a pixel
+/// apart. A picker whose whole job is choosing by state needs the word too.
+extension KeroAgentPhase {
+    /// Matches the vocabulary the status badge's own tooltips use.
+    var paletteLabel: String {
+        switch self {
+        case .created: return String(localized: "starting", comment: "Agent state.")
+        case .working: return String(localized: "working", comment: "Agent state.")
+        case .blocked: return String(localized: "needs you", comment: "Agent state.")
+        case .done: return String(localized: "finished", comment: "Agent state.")
+        case .idle: return String(localized: "idle", comment: "Agent state.")
+        case .unknown: return String(localized: "unknown", comment: "Agent state.")
+        }
+    }
+
+    /// Only the states that also post a notification carry color; the resting
+    /// ones stay grey so a wall of running agents never shouts. This mirrors
+    /// the tiering `AgentStatusBadgeView` documents and draws.
+    var paletteTint: NSColor {
+        switch self {
+        case .blocked: return .systemOrange
+        case .done: return .systemGreen
+        case .working: return .systemBlue
+        case .created, .idle, .unknown: return .tertiaryLabelColor
+        }
+    }
+}
+
+/// Rounded selection fill matching the ⌘P palette's row highlight; AppKit's
+/// own regular and source-list styles both draw a full-bleed bar.
+final class AgentPaletteRowBackgroundView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        guard isSelected else { return }
+        let path = NSBezierPath(
+            roundedRect: bounds.insetBy(dx: 2, dy: 1), xRadius: 7, yRadius: 7
+        )
+        NSColor.labelColor.withAlphaComponent(0.085).setFill()
+        path.fill()
+    }
+}
+
+/// One agent row, in two lines: the agent's identity over the directory it is
+/// working in, with its state and age held in a fixed right-hand column.
+///
+/// The directory is the line that actually distinguishes two runs of the same
+/// CLI, so it gets the width and truncates from the head — the tail of a path
+/// carries the repository name, the head carries `/Users/someone`.
+final class AgentPaletteCellView: NSTableCellView {
+    private let badge = AgentStatusBadgeView(frame: .zero)
+    private let aliasLabel = NSTextField(labelWithString: "")
+    private let directoryLabel = NSTextField(labelWithString: "")
+    private let phaseLabel = NSTextField(labelWithString: "")
+    private let ageLabel = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        aliasLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        aliasLabel.textColor = .labelColor
+        aliasLabel.lineBreakMode = .byTruncatingTail
+
+        directoryLabel.font = .systemFont(ofSize: 10.5)
+        directoryLabel.textColor = .tertiaryLabelColor
+        directoryLabel.lineBreakMode = .byTruncatingHead
+
+        phaseLabel.font = .systemFont(ofSize: 10, weight: .medium)
+        phaseLabel.alignment = .right
+
+        ageLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        ageLabel.textColor = .quaternaryLabelColor
+        ageLabel.alignment = .right
+
+        for label in [aliasLabel, directoryLabel, phaseLabel, ageLabel] {
+            label.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(label)
+        }
+        addSubview(badge)
+
+        directoryLabel.setContentCompressionResistancePriority(
+            .defaultLow, for: .horizontal
+        )
+        directoryLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        for label in [aliasLabel, phaseLabel, ageLabel] {
+            label.setContentCompressionResistancePriority(
+                .defaultHigh, for: .horizontal
+            )
+        }
+
+        NSLayoutConstraint.activate([
+            badge.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 11),
+            badge.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            aliasLabel.leadingAnchor.constraint(
+                equalTo: badge.trailingAnchor, constant: 10
+            ),
+            aliasLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            aliasLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: phaseLabel.leadingAnchor, constant: -8
+            ),
+
+            directoryLabel.leadingAnchor.constraint(
+                equalTo: aliasLabel.leadingAnchor
+            ),
+            directoryLabel.topAnchor.constraint(
+                equalTo: aliasLabel.bottomAnchor, constant: 1
+            ),
+            directoryLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: ageLabel.leadingAnchor, constant: -8
+            ),
+
+            phaseLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor, constant: -12
+            ),
+            phaseLabel.firstBaselineAnchor.constraint(
+                equalTo: aliasLabel.firstBaselineAnchor
+            ),
+
+            ageLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor, constant: -12
+            ),
+            ageLabel.firstBaselineAnchor.constraint(
+                equalTo: directoryLabel.firstBaselineAnchor
+            ),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(_ entry: AgentPaletteEntry) {
+        badge.apply(phase: entry.phase, count: 1)
+        aliasLabel.stringValue = entry.alias
+        directoryLabel.stringValue = entry.directory.isEmpty
+            ? entry.projectName
+            : entry.directory
+        directoryLabel.toolTip = entry.tabTitle
+        phaseLabel.stringValue = entry.phase.paletteLabel
+        phaseLabel.textColor = entry.phase.paletteTint
+        ageLabel.stringValue = Self.age(since: entry.updatedAt)
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.row)
+        setAccessibilityLabel(
+            "\(entry.alias), \(entry.phase.paletteLabel), \(directoryLabel.stringValue)"
+        )
+    }
+
+    /// Compact elapsed time — a status column, not prose, so it has to stay
+    /// narrow and stable in width.
+    private static func age(since date: Date) -> String {
+        let seconds = max(0, Int(Date().timeIntervalSince(date)))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3_600 { return "\(seconds / 60)m" }
+        if seconds < 86_400 { return "\(seconds / 3_600)h" }
+        return "\(seconds / 86_400)d"
+    }
+}
+

--- a/kero/CommandPaletteView.swift
+++ b/kero/CommandPaletteView.swift
@@ -152,7 +152,7 @@ struct CommandPaletteView: View {
             PalettePointerEventMonitor(controller: pointerSelectionController)
         )
         .onExitCommand { handleEscapeFromKeyboard() }
-        .onDisappear { manager.restoreFocusAfterCommandPalette() }
+        .onDisappear { manager.restoreFocusAfterPalette() }
         .task(id: fileIndexRoot) {
             projectFiles = []
             guard let root = fileIndexRoot else { return }
@@ -232,6 +232,9 @@ struct CommandPaletteView: View {
             },
             PaletteCommand(id: "resize-pane-right", title: "Resize Pane Right", systemImage: "arrow.right.to.line", shortcut: "⌃⌘→") {
                 manager.resizePaneRight()
+            },
+            PaletteCommand(id: "find-agent", title: "Find Agent…", systemImage: "sparkle.magnifyingglass", shortcut: "⌥⌘A") {
+                manager.toggleAgentPalette()
             },
             PaletteCommand(id: "new-project", title: "New Project", systemImage: "folder.badge.plus", shortcut: "⌘N") {
                 manager.newProject()

--- a/kero/CommandPaletteView.swift
+++ b/kero/CommandPaletteView.swift
@@ -340,10 +340,7 @@ struct CommandPaletteView: View {
         guard let dir = session.workingDirectory else { return nil }
         let path = URL(string: dir)?.path ?? dir
         guard !path.isEmpty else { return nil }
-        let home = NSHomeDirectory()
-        if path == home { return "~" }
-        if path.hasPrefix(home + "/") { return "~" + String(path.dropFirst(home.count)) }
-        return path
+        return path.abbreviatingHomeDirectory
     }
 
     /// The current project's pinned/automatic panel root. Indexing starts only

--- a/kero/ContentView.swift
+++ b/kero/ContentView.swift
@@ -272,6 +272,13 @@ struct ContentView: View {
             }
         }
         .overlay {
+            if manager.isAgentPaletteVisible {
+                AgentPaletteMount(manager: manager)
+                    .ignoresSafeArea()
+                    .zIndex(9)
+            }
+        }
+        .overlay {
             if tabSwitcher.isPresented, let project = manager.selectedProject {
                 TabSwitcherOverlay(project: project, controller: tabSwitcher)
                     .zIndex(10)

--- a/kero/ProcessWorkingDirectory.swift
+++ b/kero/ProcessWorkingDirectory.swift
@@ -81,3 +81,17 @@ func processArguments(pid: pid_t) -> [String]? {
     }
     return result.isEmpty ? nil : result
 }
+
+extension String {
+    /// This path with the user's home directory written as `~`.
+    ///
+    /// Both palettes show a session's directory in a single narrow row, where
+    /// the `/Users/<name>` prefix is the least distinguishing part of the path
+    /// and costs the width that identifies it.
+    var abbreviatingHomeDirectory: String {
+        let home = NSHomeDirectory()
+        if self == home { return "~" }
+        guard hasPrefix(home + "/") else { return self }
+        return "~" + String(dropFirst(home.count))
+    }
+}

--- a/kero/TerminalHistory.swift
+++ b/kero/TerminalHistory.swift
@@ -47,8 +47,39 @@ enum TerminalHistorySerializer {
         maxColumns: Int
     ) -> String? {
         guard maxLines > 0, maxColumns > 0,
-              let captureFile = validatedCaptureFile(for: surface.exportScreenFile())
+              let capture = previewCapture(from: surface)
         else { return nil }
+
+        var lines = capture
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { visibleText(in: String($0)) }
+
+        while let last = lines.last,
+              last.trimmingCharacters(in: .whitespaces).isEmpty {
+            lines.removeLast()
+        }
+        guard !lines.isEmpty else { return nil }
+
+        return lines.suffix(maxLines).map { line in
+            var cropped = String(line.prefix(maxColumns))
+            while cropped.last == " " || cropped.last == "\t" {
+                cropped.removeLast()
+            }
+            return cropped
+        }
+        .joined(separator: "\n")
+    }
+
+    /// The tail of a backend's screen export, newline-normalized but with its
+    /// escapes intact. Callers that want plain rows use `previewText`; callers
+    /// that render the agent's own colors parse this themselves.
+    @MainActor
+    static func previewCapture(
+        from surface: any TerminalBackendSurface
+    ) -> String? {
+        guard let captureFile = validatedCaptureFile(
+            for: surface.exportScreenFile()
+        ) else { return nil }
         defer { removeCaptureFile(captureFile) }
 
         guard let handle = try? FileHandle(forReadingFrom: captureFile.fileURL) else {
@@ -72,32 +103,13 @@ enum TerminalHistorySerializer {
 
         var capture = String(decoding: data, as: UTF8.self)
         // A tail read can start halfway through a UTF-8 scalar or ANSI run.
-        // Discard its first partial row so no fragment reaches the thumbnail.
+        // Discard its first partial row so no fragment reaches the preview.
         if start > 0, let newline = capture.firstIndex(of: "\n") {
             capture.removeSubrange(...newline)
         }
-        capture = capture
+        return capture
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
-
-        var lines = capture
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .map { visibleText(in: String($0)) }
-
-        while let last = lines.last,
-              last.trimmingCharacters(in: .whitespaces).isEmpty {
-            lines.removeLast()
-        }
-        guard !lines.isEmpty else { return nil }
-
-        return lines.suffix(maxLines).map { line in
-            var cropped = String(line.prefix(maxColumns))
-            while cropped.last == " " || cropped.last == "\t" {
-                cropped.removeLast()
-            }
-            return cropped
-        }
-        .joined(separator: "\n")
     }
 
     /// A positive-only probe for a primary-buffer scrollback snapshot. A

--- a/kero/TerminalManager.swift
+++ b/kero/TerminalManager.swift
@@ -56,6 +56,7 @@ final class TerminalManager: nonisolated ObservableObject {
     /// every launch starts with it hidden.
     @Published var isFPSCounterVisible = false
     @Published private(set) var isCommandPaletteVisible = false
+    @Published private(set) var isAgentPaletteVisible = false
 
     /// Projects publish their own changes (session list, session selection);
     /// re-publish them so views observing the manager stay current.
@@ -68,11 +69,12 @@ final class TerminalManager: nonisolated ObservableObject {
     private var settingsObservation: AnyCancellable?
     private var autosaveObservation: AnyCancellable?
     private var terminationObservation: AnyCancellable?
-    /// The stable terminal/editor responder displaced by the command palette's
-    /// search field. AppKit field editors are deliberately excluded because a
-    /// SwiftUI TextField can reuse the same responder for the palette itself.
-    private weak var commandPalettePreviousResponder: NSResponder?
-    private weak var commandPaletteWindow: NSWindow?
+    /// The stable terminal/editor responder displaced by a palette's search
+    /// field. AppKit field editors are deliberately excluded because a SwiftUI
+    /// TextField can reuse the same responder for the palette itself. Shared
+    /// by ⌘P and the ⌥⌘A agent palette, which are never open together.
+    private weak var palettePreviousResponder: NSResponder?
+    private weak var paletteWindow: NSWindow?
     /// Window hosting this manager, once SwiftUI has attached its content.
     /// Finder service requests use it to target the active Kero window.
     private weak var window: NSWindow?
@@ -470,6 +472,18 @@ final class TerminalManager: nonisolated ObservableObject {
         }
     }
 
+    /// The open session with this identifier in this window, or nil once it
+    /// has been closed. The agent palette holds identifiers rather than
+    /// sessions so a closed terminal drops out instead of lingering.
+    func session(withID id: UUID) -> TerminalSession? {
+        for project in projects {
+            if let session = project.sessions.first(where: { $0.id == id }) {
+                return session
+            }
+        }
+        return nil
+    }
+
     /// Activates Kero and reveals the session that emitted a desktop
     /// notification. Searches every open window; if the session is gone,
     /// still brings the app forward so the click isn't a dead end.
@@ -742,13 +756,8 @@ final class TerminalManager: nonisolated ObservableObject {
         if isCommandPaletteVisible {
             dismissCommandPalette()
         } else {
-            commandPaletteWindow = NSApp.keyWindow
-            if let responder = commandPaletteWindow?.firstResponder,
-               isStableWorkspaceResponder(responder) {
-                commandPalettePreviousResponder = responder
-            } else {
-                commandPalettePreviousResponder = nil
-            }
+            dismissAgentPalette()
+            capturePaletteFocus()
             isCommandPaletteVisible = true
         }
     }
@@ -758,13 +767,41 @@ final class TerminalManager: nonisolated ObservableObject {
         isCommandPaletteVisible = false
     }
 
-    /// Called by the palette after SwiftUI has actually removed its focused
-    /// search field from the window.
-    func restoreFocusAfterCommandPalette() {
-        let window = commandPaletteWindow
-        let responder = commandPalettePreviousResponder
-        commandPaletteWindow = nil
-        commandPalettePreviousResponder = nil
+    /// ⌥⌘A: the agent switcher across every project in this window.
+    func toggleAgentPalette() {
+        if isAgentPaletteVisible {
+            dismissAgentPalette()
+        } else {
+            dismissCommandPalette()
+            capturePaletteFocus()
+            isAgentPaletteVisible = true
+        }
+    }
+
+    func dismissAgentPalette() {
+        guard isAgentPaletteVisible else { return }
+        isAgentPaletteVisible = false
+    }
+
+    /// Remembers the terminal or editor a palette is about to displace, so its
+    /// dismissal can hand keyboard focus back where the user left it.
+    private func capturePaletteFocus() {
+        paletteWindow = NSApp.keyWindow
+        if let responder = paletteWindow?.firstResponder,
+           isStableWorkspaceResponder(responder) {
+            palettePreviousResponder = responder
+        } else {
+            palettePreviousResponder = nil
+        }
+    }
+
+    /// Called by a palette after its focused search field has actually left
+    /// the window.
+    func restoreFocusAfterPalette() {
+        let window = paletteWindow
+        let responder = palettePreviousResponder
+        paletteWindow = nil
+        palettePreviousResponder = nil
 
         // Let the removal transaction finish before restoring the displaced
         // AppKit responder.

--- a/kero/TerminalPreviewStyle.swift
+++ b/kero/TerminalPreviewStyle.swift
@@ -1,0 +1,442 @@
+//
+//  TerminalPreviewStyle.swift
+//  kero
+//
+
+import AppKit
+import GhosttyTheme
+
+/// Renders a terminal screen export as styled text.
+///
+/// A backend's export is a VT stream, so the colors an agent drew with are
+/// still in it — `TerminalHistorySerializer.previewText` simply discards every
+/// escape to produce plain rows. Anything showing that export to a human wants
+/// them back: a coding agent's UI is largely color (a highlighted prompt, a
+/// red diff, an orange warning), and stripped of it the screen reads as an
+/// undifferentiated wall.
+///
+/// Only SGR is interpreted. Cursor motion, scroll regions, and the rest of the
+/// VT vocabulary are skipped rather than emulated: this renders the export a
+/// backend already flattened into rows, not a terminal.
+enum TerminalPreviewStyle {
+    /// Character attributes carried across a run of the stream. SGR state
+    /// persists over newlines, so this is threaded through the whole capture
+    /// rather than reset per row.
+    private struct Attributes: Equatable {
+        var foreground: NSColor?
+        var background: NSColor?
+        var bold = false
+        var dim = false
+        var italic = false
+        var underline = false
+        var inverse = false
+
+        mutating func reset() { self = Attributes() }
+    }
+
+    static func attributedPreview(
+        vt: String,
+        maxLines: Int,
+        maxColumns: Int,
+        theme: GhosttyThemeDefinition,
+        font: NSFont
+    ) -> NSAttributedString? {
+        guard maxLines > 0, maxColumns > 0 else { return nil }
+
+        let defaultForeground = theme.foregroundNSColor
+        let boldFont = NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+        let italicFont = NSFontManager.shared.convert(font, toHaveTrait: .italicFontMask)
+
+        let scalars = Array(vt.unicodeScalars)
+        var attributes = Attributes()
+        var lines: [NSAttributedString] = []
+        var line = NSMutableAttributedString()
+        var pending = ""
+        var pendingAttributes = attributes
+        var columns = 0
+        var index = 0
+
+        func flush() {
+            guard !pending.isEmpty else { return }
+            line.append(NSAttributedString(
+                string: pending,
+                attributes: cocoaAttributes(
+                    pendingAttributes,
+                    theme: theme,
+                    defaultForeground: defaultForeground,
+                    font: font,
+                    boldFont: boldFont,
+                    italicFont: italicFont
+                )
+            ))
+            pending = ""
+        }
+
+        func endLine() {
+            flush()
+            lines.append(NSAttributedString(attributedString: line))
+            line = NSMutableAttributedString()
+            columns = 0
+        }
+
+        while index < scalars.count {
+            let value = scalars[index].value
+
+            if let end = oscSequenceEnd(in: scalars, at: index) {
+                index = end
+                continue
+            }
+            if let sequence = csiSequence(in: scalars, at: index) {
+                if sequence.final == "m" {
+                    flush()
+                    apply(
+                        parameters: sequence.parameters,
+                        to: &attributes,
+                        theme: theme
+                    )
+                    pendingAttributes = attributes
+                }
+                index = sequence.end
+                continue
+            }
+
+            if value == 0x0a {
+                endLine()
+                index += 1
+                continue
+            }
+
+            // Printable only, matching the plain-text serializer: C0 controls
+            // and DEL never reach the preview.
+            if value >= 0x20, value != 0x7f {
+                if columns < maxColumns {
+                    if pendingAttributes != attributes {
+                        flush()
+                        pendingAttributes = attributes
+                    }
+                    pending.unicodeScalars.append(scalars[index])
+                    columns += 1
+                }
+                // Past the column budget the glyph is dropped, but the scan
+                // continues so escapes still update state for the next row.
+            }
+            index += 1
+        }
+        endLine()
+        lines = condense(lines)
+        guard !lines.isEmpty else { return nil }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byClipping
+        // Terminal rows are already laid out; keep them on a fixed rhythm so
+        // box drawing lines up vertically.
+        paragraph.minimumLineHeight = ceil(font.ascender - font.descender)
+        paragraph.maximumLineHeight = paragraph.minimumLineHeight
+
+        let output = NSMutableAttributedString()
+        for (offset, styled) in lines.suffix(maxLines).enumerated() {
+            if offset > 0 {
+                output.append(NSAttributedString(string: "\n"))
+            }
+            output.append(styled)
+        }
+        output.addAttribute(
+            .paragraphStyle,
+            value: paragraph,
+            range: NSRange(location: 0, length: output.length)
+        )
+        return output
+    }
+
+    /// Drops blank rows from both ends and collapses interior runs to a single
+    /// separator.
+    ///
+    /// A full-screen agent lays its UI out over the whole terminal: a header at
+    /// the top, a prompt pinned to the bottom, and a tall empty conversation
+    /// area between them. Reproduced faithfully in a pane a fraction of that
+    /// height, the empty area *is* the preview — the reader gets a rectangle of
+    /// nothing while the two informative bands sit off-screen. Squeezing the
+    /// gaps is what makes both visible at once, and blank rows carry no
+    /// information worth the space anyway.
+    private static func condense(
+        _ lines: [NSAttributedString]
+    ) -> [NSAttributedString] {
+        func isBlank(_ line: NSAttributedString) -> Bool {
+            line.string.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+
+        var trimmed = lines[...]
+        while let first = trimmed.first, isBlank(first) {
+            trimmed = trimmed.dropFirst()
+        }
+        while let last = trimmed.last, isBlank(last) {
+            trimmed = trimmed.dropLast()
+        }
+
+        var condensed: [NSAttributedString] = []
+        condensed.reserveCapacity(trimmed.count)
+        var blankRun = 0
+        for line in trimmed {
+            if isBlank(line) {
+                blankRun += 1
+                // Keep one, so the bands stay visually separated.
+                if blankRun > 1 { continue }
+            } else {
+                blankRun = 0
+            }
+            condensed.append(line)
+        }
+        return condensed
+    }
+
+    private static func cocoaAttributes(
+        _ attributes: Attributes,
+        theme: GhosttyThemeDefinition,
+        defaultForeground: NSColor,
+        font: NSFont,
+        boldFont: NSFont,
+        italicFont: NSFont
+    ) -> [NSAttributedString.Key: Any] {
+        var foreground = attributes.foreground ?? defaultForeground
+        var background = attributes.background
+
+        if attributes.inverse {
+            let swapped = background ?? theme.backgroundNSColor
+            background = foreground
+            foreground = swapped
+        }
+        if attributes.dim {
+            foreground = foreground.withAlphaComponent(0.6)
+        }
+
+        var result: [NSAttributedString.Key: Any] = [
+            .foregroundColor: foreground,
+            .font: attributes.bold ? boldFont : (attributes.italic ? italicFont : font),
+        ]
+        if let background {
+            result[.backgroundColor] = background
+        }
+        if attributes.underline {
+            result[.underlineStyle] = NSUnderlineStyle.single.rawValue
+        }
+        return result
+    }
+
+    private static func apply(
+        parameters: [Int],
+        to attributes: inout Attributes,
+        theme: GhosttyThemeDefinition
+    ) {
+        // A bare `ESC [ m` is a reset, same as `ESC [ 0 m`.
+        guard !parameters.isEmpty else {
+            attributes.reset()
+            return
+        }
+
+        var index = 0
+        while index < parameters.count {
+            let code = parameters[index]
+            switch code {
+            case 0: attributes.reset()
+            case 1: attributes.bold = true
+            case 2: attributes.dim = true
+            case 3: attributes.italic = true
+            case 4: attributes.underline = true
+            case 7: attributes.inverse = true
+            case 22: attributes.bold = false; attributes.dim = false
+            case 23: attributes.italic = false
+            case 24: attributes.underline = false
+            case 27: attributes.inverse = false
+            case 30...37:
+                attributes.foreground = paletteColor(code - 30, theme: theme)
+            case 39: attributes.foreground = nil
+            case 40...47:
+                attributes.background = paletteColor(code - 40, theme: theme)
+            case 49: attributes.background = nil
+            case 90...97:
+                attributes.foreground = paletteColor(code - 90 + 8, theme: theme)
+            case 100...107:
+                attributes.background = paletteColor(code - 100 + 8, theme: theme)
+            case 38, 48:
+                let (color, consumed) = extendedColor(
+                    parameters, from: index + 1, theme: theme
+                )
+                if code == 38 {
+                    attributes.foreground = color
+                } else {
+                    attributes.background = color
+                }
+                index += consumed
+            default:
+                break
+            }
+            index += 1
+        }
+    }
+
+    /// `38;5;n` indexed and `38;2;r;g;b` direct forms. Returns how many extra
+    /// parameters were consumed so the caller can resume after them.
+    private static func extendedColor(
+        _ parameters: [Int], from start: Int, theme: GhosttyThemeDefinition
+    ) -> (NSColor?, Int) {
+        guard start < parameters.count else { return (nil, 0) }
+        switch parameters[start] {
+        case 5:
+            guard start + 1 < parameters.count else { return (nil, 1) }
+            return (indexedColor(parameters[start + 1], theme: theme), 2)
+        case 2:
+            guard start + 3 < parameters.count else { return (nil, 1) }
+            return (
+                NSColor(
+                    srgbRed: CGFloat(clampByte(parameters[start + 1])) / 255,
+                    green: CGFloat(clampByte(parameters[start + 2])) / 255,
+                    blue: CGFloat(clampByte(parameters[start + 3])) / 255,
+                    alpha: 1
+                ),
+                4
+            )
+        default:
+            return (nil, 1)
+        }
+    }
+
+    /// xterm's 256-color layout: the themed 16, a 6×6×6 cube, then 24 greys.
+    private static func indexedColor(
+        _ value: Int, theme: GhosttyThemeDefinition
+    ) -> NSColor? {
+        switch value {
+        case 0...15:
+            return paletteColor(value, theme: theme)
+        case 16...231:
+            let offset = value - 16
+            let steps: [CGFloat] = [0, 95, 135, 175, 215, 255]
+            return NSColor(
+                srgbRed: steps[(offset / 36) % 6] / 255,
+                green: steps[(offset / 6) % 6] / 255,
+                blue: steps[offset % 6] / 255,
+                alpha: 1
+            )
+        case 232...255:
+            let level = CGFloat(8 + (value - 232) * 10) / 255
+            return NSColor(srgbRed: level, green: level, blue: level, alpha: 1)
+        default:
+            return nil
+        }
+    }
+
+    /// The user's own terminal theme owns these sixteen, so a preview matches
+    /// the pane it was captured from. The xterm defaults only cover a theme
+    /// that left an entry undefined.
+    private static func paletteColor(
+        _ index: Int, theme: GhosttyThemeDefinition
+    ) -> NSColor? {
+        if let hex = theme.palette[index], let color = nsColor(hex) {
+            return color
+        }
+        guard index >= 0, index < fallbackPalette.count else { return nil }
+        return nsColor(fallbackPalette[index])
+    }
+
+    private static let fallbackPalette = [
+        "#000000", "#cc0000", "#4e9a06", "#c4a000",
+        "#3465a4", "#75507b", "#06989a", "#d3d7cf",
+        "#555753", "#ef2929", "#8ae234", "#fce94f",
+        "#729fcf", "#ad7fa8", "#34e2e2", "#eeeeec",
+    ]
+
+    private static func clampByte(_ value: Int) -> Int {
+        min(max(value, 0), 255)
+    }
+
+    private static func nsColor(_ hex: String) -> NSColor? {
+        let digits = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard digits.count == 6, let value = Int(digits, radix: 16) else {
+            return nil
+        }
+        return NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xff) / 255,
+            green: CGFloat((value >> 8) & 0xff) / 255,
+            blue: CGFloat(value & 0xff) / 255,
+            alpha: 1
+        )
+    }
+
+    // MARK: - VT scanning
+
+    private struct CSISequence {
+        let end: Int
+        let parameters: [Int]
+        let final: Unicode.Scalar
+    }
+
+    /// Mirrors the serializer's own CSI scan, additionally returning the
+    /// numeric parameters and the final byte so SGR can be interpreted.
+    private static func csiSequence(
+        in scalars: [Unicode.Scalar], at index: Int
+    ) -> CSISequence? {
+        let parameterStart: Int
+        if scalars[index].value == 0x9b {
+            parameterStart = index + 1
+        } else if scalars[index].value == 0x1b,
+                  index + 1 < scalars.count,
+                  scalars[index + 1].value == 0x5b {
+            parameterStart = index + 2
+        } else {
+            return nil
+        }
+
+        var cursor = parameterStart
+        while cursor < scalars.count {
+            let value = scalars[cursor].value
+            if (0x40...0x7e).contains(value) {
+                let body = String(String.UnicodeScalarView(
+                    scalars[parameterStart..<cursor]
+                ))
+                // A private-parameter marker such as `?` is not SGR; leaving
+                // the parameters empty makes it a no-op rather than a reset.
+                let parameters = body.hasPrefix("?")
+                    ? [-1]
+                    : body.split(separator: ";", omittingEmptySubsequences: false)
+                        .map { Int($0) ?? 0 }
+                return CSISequence(
+                    end: cursor + 1,
+                    parameters: body.isEmpty ? [] : parameters,
+                    final: scalars[cursor]
+                )
+            }
+            cursor += 1
+        }
+        return nil
+    }
+
+    /// OSC runs to BEL or ST and can legally contain semicolons and text, so
+    /// it has to be skipped whole before CSI scanning sees its payload.
+    private static func oscSequenceEnd(
+        in scalars: [Unicode.Scalar], at index: Int
+    ) -> Int? {
+        let start: Int
+        if scalars[index].value == 0x9d {
+            start = index + 1
+        } else if scalars[index].value == 0x1b,
+                  index + 1 < scalars.count,
+                  scalars[index + 1].value == 0x5d {
+            start = index + 2
+        } else {
+            return nil
+        }
+
+        var cursor = start
+        while cursor < scalars.count {
+            let value = scalars[cursor].value
+            if value == 0x07 { return cursor + 1 }
+            if value == 0x9c { return cursor + 1 }
+            if value == 0x1b,
+               cursor + 1 < scalars.count,
+               scalars[cursor + 1].value == 0x5c {
+                return cursor + 2
+            }
+            cursor += 1
+        }
+        return nil
+    }
+}

--- a/kero/keroApp.swift
+++ b/kero/keroApp.swift
@@ -258,6 +258,11 @@ private struct KeroCommands: Commands {
         }
 
         CommandMenu("Agents") {
+            Button("Find Agent…") {
+                manager?.toggleAgentPalette()
+            }
+            .keyboardShortcut("a", modifiers: [.command, .option])
+
             Button("Next Agent Needing Attention") {
                 manager?.focusNextAgentAttention()
             }


### PR DESCRIPTION
Proposes #132. Happy to close this if a fleet view is not a direction Kero wants — the code is here in case it is useful, not to presume the answer.

`⌥⌘A` opens a picker over every coding agent in the window, across all projects.

<img width="1920" height="1200" alt="file-21bf29170656490c4450b53fc8f587df" src="https://github.com/user-attachments/assets/4d6e37ed-a35b-4074-95df-f7d35415d147" />


### What it does

Rows are ordered by what wants attention first — blocked, then unacknowledged completions, then working — so the palette opens already pointing at the agent that needs a person. That makes it a superset of the existing `⇧⌘A` cycle rather than a competitor to it; `⇧⌘A` and `⌘P` are both untouched.

Typed tokens narrow the list — `status:`, `agent:`, `project:` — with comma-separated values as OR and separate tokens as AND. An unrecognized key or value degrades to fuzzy text rather than matching nothing, so `status:blockd` narrows the list instead of emptying it. Remaining words fuzzy-match alias, agent name, project, tab, and directory through the same `FuzzyMatcher` the command palette uses.

The highlighted agent's terminal shows beside the list, so its question is readable before jumping.

### Notable implementation points

**Colour in the preview.** `TerminalHistorySerializer.previewText` strips every escape, which is right for the Ctrl-Tab thumbnail it was written for but leaves an agent's UI as a grey wall. The serializer now also exposes `previewCapture(from:)` — the same tail read with escapes intact — and the new `TerminalPreviewStyle` interprets SGR against the user's own theme palette, so the preview matches the pane it came from. Only SGR is interpreted; cursor motion and the rest are skipped rather than emulated, since this renders rows a backend already flattened.

**Blank rows are condensed.** A full-screen agent lays its UI over the whole terminal — header at top, prompt at the bottom, tall empty area between. Cropped faithfully into a short pane, that empty area *is* the preview. Interior blank runs collapse to a single separator so both informative bands are visible at once. This is a deliberate distortion, called out in the code.

**Order freezes while open.** Agents change phase every ~0.75s; re-sorting live would slide a row out from under Return. Membership and order settle per keystroke, and the periodic refresh only restates badges and drops sessions that have closed. Same call `TabSwitcherController` already makes by freezing `orderedTabIDs`.

**AppKit.** All rendering, layout, and interaction is in `AgentPaletteViewController`; the `NSViewControllerRepresentable` is a mount point only, matching how `AgentStatusBadgeRepresentable` is used today. Status glyphs reuse the existing `AgentStatusBadgeView` rather than reimplementing state rendering, so Reduce Motion and light/dark behaviour are inherited. Rows pair the badge with the state in words, since a picker whose job is choosing by state needs it legible, not just glanceable.

### Verification

Built and exercised: zero / one / several agents across multiple projects, each filter token and compound queries, the deliberate-typo fallback, Escape clearing then closing, Return jumping and clearing a finished badge, and preview scrolling (it follows the tail only when you are already at the tail, so scrolling up to read is not interrupted by the refresh).

No version bump, per RELEASING.md. `CHANGELOG.md` gets one user-facing line under `[unreleased]`.

### Open question

Two agents with the same alias in the same directory still render identically — only the preview tells them apart. I left that rather than guess: appending the project name on collision, adding the tab title as a third line, and numbering duplicates all trade off differently, and it seemed better to ask than to pick.