### PR TITLE
Stop crashing when Git reports a path twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Fix Kero crashing seconds after launch when a project's repository has staged file deletions whose files are still on disk
+
 ## [0.1.47]
 
 - Let dictation and other accessibility tools enter text in terminal panes

--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -1080,8 +1080,16 @@ final class GitStatusModel: nonisolated ObservableObject {
             entry.repositoryRoot = result.topLevel
             return entry
         }
+        // Git reports one path more than once for legitimate states: a staged
+        // deletion whose file is still on disk arrives as both a `1 D.` record
+        // and a `? ` untracked record. Collapse those with the precedence
+        // directories already use, so the state that most needs attention wins
+        // instead of trapping on a duplicate key.
         fileDecorations = Dictionary(
-            uniqueKeysWithValues: entries.map { ($0.path, Self.fileDecoration(for: $0)) }
+            entries.map { ($0.path, Self.fileDecoration(for: $0)) },
+            uniquingKeysWith: {
+                $0.directoryPriority >= $1.directoryPriority ? $0 : $1
+            }
         )
         ignoredPaths = result.ignoredPaths
         mergeEntries = entries.filter(\.isConflict)

--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -1080,9 +1080,11 @@ final class GitStatusModel: nonisolated ObservableObject {
             entry.repositoryRoot = result.topLevel
             return entry
         }
-        // Git can report a path twice (a staged deletion whose file is still on
-        // disk is both deleted and untracked), so collapse duplicates instead
-        // of trapping on a repeated key.
+        // Git reports one path more than once for legitimate states: a staged
+        // deletion whose file is still on disk arrives as both a `1 D.` record
+        // and a `? ` untracked record. Collapse those with the precedence
+        // directories already use, so the state that most needs attention wins
+        // instead of trapping on a duplicate key.
         fileDecorations = Dictionary(
             entries.map { ($0.path, Self.fileDecoration(for: $0)) },
             uniquingKeysWith: {

--- a/kero/GitStatusModel.swift
+++ b/kero/GitStatusModel.swift
@@ -1080,11 +1080,9 @@ final class GitStatusModel: nonisolated ObservableObject {
             entry.repositoryRoot = result.topLevel
             return entry
         }
-        // Git reports one path more than once for legitimate states: a staged
-        // deletion whose file is still on disk arrives as both a `1 D.` record
-        // and a `? ` untracked record. Collapse those with the precedence
-        // directories already use, so the state that most needs attention wins
-        // instead of trapping on a duplicate key.
+        // Git can report a path twice (a staged deletion whose file is still on
+        // disk is both deleted and untracked), so collapse duplicates instead
+        // of trapping on a repeated key.
         fileDecorations = Dictionary(
             entries.map { ($0.path, Self.fileDecoration(for: $0)) },
             uniquingKeysWith: {


### PR DESCRIPTION
Fixes https://github.com/egoist/kero/issues/139 — the git panel no longer traps when `git status` reports the same path twice.

**Why:** `git status --porcelain=v2` legitimately emits two records for one path when a staged deletion's file is still on disk — a `1 D.` record *and* a `? ` untracked record:

```
$ git init repo && cd repo
$ echo hi > a.txt && git add a.txt && git commit -m init
$ git rm --cached a.txt          # stage the deletion, leave the file alone
$ git status --porcelain=v2 -z --untracked-files=all | tr '\0' '\n'
1 D. N... 100644 000000 000000 45b983b… 0000000… a.txt
? a.txt
```

`fileDecorations` was built with `Dictionary(uniqueKeysWithValues:)`, which traps on the duplicate: `Fatal error: Duplicate values for key: 'a.txt'`. It's a `SIGTRAP` on the main thread a few seconds after the panel refreshes, with no error UI. Worse, it's sticky: once such a repository is in the restored session, every launch dies the same way and the app looks permanently broken. Any repo where the index was emptied without touching the worktree (`git rm -r --cached .`) hits it on the first status refresh.

**How:** collapse duplicate paths with `uniquingKeysWith:`, reusing the existing `FileDecoration.directoryPriority` ordering that already decides which child state a directory bubbles up. A staged deletion (7) therefore outranks untracked (4), which is the more urgent of the two states and consistent with what the tree shows for the parent directory.

Verified against the real crash: the fatal-error message is `_assertionFailure` at `GitStatusModel.applyResult`, and the same key pair reproduces the identical trap in isolation before the change and resolves to `.deleted` after it. `parseStatus` is unchanged — both records still become entries, so the staged and changed sections keep listing the path in both places, which matches Git.
