### PR TITLE
Fix stuck IME preedit in the Alacritty backend

### DIFF
--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -35,7 +35,6 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     private var metrics: AlacrittyMetrics
     private var gridSize = (columns: 0, rows: 0)
     private var markedText = ""
-    private let markedTextField = NSTextField(labelWithString: "")
     private var isSurfaceVisible = false
     /// Covers Metal while a parked surface is moving back into a real pane.
     /// The cover lives above the drawable so the GPU can acquire and present
@@ -109,11 +108,6 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         wantsLayer = true
         layerContentsRedrawPolicy = .onSetNeedsDisplay
         registerForDraggedTypes([.fileURL])
-        markedTextField.isHidden = true
-        markedTextField.isBezeled = false
-        markedTextField.drawsBackground = true
-        markedTextField.lineBreakMode = .byClipping
-        addSubview(markedTextField)
         addSubview(progressBar)
         AlacrittyRegistry.shared.register(self, for: token)
         NotificationCenter.default.addObserver(
@@ -623,9 +617,24 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         kero_alacritty_snapshot(handle, &snapshot)
         applyHoveredURLUnderline(to: &snapshot)
         updateKittyGraphics(handle: handle)
-        updateMarkedTextOverlay(snapshot: snapshot)
+        // Capture the preedit anchor before the blink/focus logic below
+        // rewrites the snapshot's cursor: a hidden blink phase must not take
+        // the marked text down with the cursor.
+        let preedit: TerminalMarkedText? =
+            !markedText.isEmpty && snapshot.cursor_line >= 0 && snapshot.cursor_column >= 0
+                ? TerminalMarkedText(
+                    text: markedText,
+                    line: Int(snapshot.cursor_line),
+                    column: Int(snapshot.cursor_column)
+                )
+                : nil
         updateCursorBlinking(snapshot.cursor_blinking)
-        if cursorBlinking, !cursorVisible {
+        if preedit != nil {
+            // While the IME owns the text at the cursor, the cursor itself
+            // stays hidden, as in a native text field.
+            snapshot.cursor_line = -1
+            snapshot.cursor_column = -1
+        } else if cursorBlinking, !cursorVisible {
             snapshot.cursor_line = -1
             snapshot.cursor_column = -1
         } else if !(cursorHasFocus ?? hasEffectiveTerminalFocus),
@@ -656,6 +665,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         }
         let submitted = renderer.render(
             snapshot: snapshot,
+            markedText: preedit,
             kittyPlacements: kittyPlacements,
             metrics: metrics,
             padding: Self.padding,
@@ -771,40 +781,6 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         CATransaction.setDisableActions(true)
         presentationCoverLayer.isHidden = !visible
         CATransaction.commit()
-    }
-
-    private func updateMarkedTextOverlay(snapshot: KeroSnapshot) {
-        guard !markedText.isEmpty,
-              snapshot.cursor_line >= 0,
-              snapshot.cursor_column >= 0
-        else {
-            markedTextField.isHidden = true
-            return
-        }
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: metrics.regular,
-            .foregroundColor: Theme.terminal(
-                dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            ).foregroundNSColor,
-            .underlineStyle: NSUnderlineStyle.single.rawValue,
-        ]
-        let attributed = NSAttributedString(string: markedText, attributes: attributes)
-        markedTextField.attributedStringValue = attributed
-        markedTextField.backgroundColor = Theme.terminal(
-            dark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        ).backgroundNSColor
-        let width = max(
-            attributed.size().width.rounded(.up) + 2,
-            metrics.cellWidth
-        )
-        markedTextField.frame = NSRect(
-            x: Self.padding.x + CGFloat(snapshot.cursor_column) * metrics.cellWidth,
-            y: bounds.height - Self.padding.y
-                - CGFloat(snapshot.cursor_line + 1) * metrics.cellHeight,
-            width: width,
-            height: metrics.cellHeight
-        )
-        markedTextField.isHidden = false
     }
 
     private func updateCursorBlinking(_ blinking: Bool) {

--- a/kero/Alacritty/TerminalMetalRenderer.swift
+++ b/kero/Alacritty/TerminalMetalRenderer.swift
@@ -9,6 +9,15 @@ import MetalKit
 import QuartzCore
 import simd
 
+/// IME preedit state for one frame: the composed text plus the grid position
+/// it starts at. Captured separately from the snapshot's cursor fields so a
+/// hidden blink phase cannot take the preedit down with the cursor.
+struct TerminalMarkedText {
+    var text: String
+    var line: Int
+    var column: Int
+}
+
 /// GPU renderer for a terminal grid.
 ///
 /// One instanced draw call covers a frame: every cell background, glyph,
@@ -111,6 +120,7 @@ final class TerminalMetalRenderer {
     @discardableResult
     func render(
         snapshot: KeroSnapshot,
+        markedText: TerminalMarkedText?,
         kittyPlacements: [AlacrittyKittyPlacement],
         metrics: AlacrittyMetrics,
         padding: CGPoint,
@@ -131,7 +141,7 @@ final class TerminalMetalRenderer {
 
         let atlasGenerationBeforeBuild = atlas.generation
         build(
-            snapshot: snapshot, metrics: metrics, padding: padding,
+            snapshot: snapshot, markedText: markedText, metrics: metrics, padding: padding,
             atlas: atlas,
             dirtyRows: resetAtlas ? nil : dirtyRows,
             viewportSize: viewportSize
@@ -141,7 +151,7 @@ final class TerminalMetalRenderer {
             // frame. Its old UVs are invalid, including those in cached clean
             // rows, so rebuild the complete grid once against the new atlas.
             build(
-                snapshot: snapshot, metrics: metrics, padding: padding,
+                snapshot: snapshot, markedText: markedText, metrics: metrics, padding: padding,
                 atlas: atlas, dirtyRows: nil, viewportSize: viewportSize
             )
         }
@@ -306,6 +316,7 @@ final class TerminalMetalRenderer {
 
     private func build(
         snapshot: KeroSnapshot,
+        markedText: TerminalMarkedText?,
         metrics: AlacrittyMetrics,
         padding: CGPoint,
         atlas: TerminalGlyphAtlas,
@@ -361,6 +372,74 @@ final class TerminalMetalRenderer {
             padding: padding,
             blockInsertionIndex: blockCursorInsertionIndex(snapshot: snapshot)
         )
+        appendMarkedText(
+            markedText,
+            snapshot: snapshot,
+            metrics: metrics,
+            padding: padding,
+            atlas: atlas
+        )
+    }
+
+    /// IME preedit, drawn at its anchor cell with an underline so uncommitted
+    /// composition reads the way it does in a native text field. It lives
+    /// outside the per-row cache — it changes without grid damage — and above
+    /// all cell content, including the cursor.
+    private func appendMarkedText(
+        _ markedText: TerminalMarkedText?,
+        snapshot: KeroSnapshot,
+        metrics: AlacrittyMetrics,
+        padding: CGPoint,
+        atlas: TerminalGlyphAtlas
+    ) {
+        guard let markedText,
+              let cells = snapshot.cells,
+              markedText.line >= 0,
+              markedText.column >= 0,
+              markedText.line < snapshot.rows,
+              markedText.column < snapshot.columns
+        else { return }
+        let cellWidth = Float(metrics.cellWidth)
+        let cellHeight = Float(metrics.cellHeight)
+        let anchorCell = cells[markedText.line * snapshot.columns + markedText.column]
+        let color = Self.color(
+            AlacrittyRenderer.foreground(of: anchorCell, default: snapshot.background)
+        )
+        let top = Float(padding.y) + Float(markedText.line) * cellHeight
+        let baseline = top + Float(metrics.baseline)
+        var column = Float(markedText.column)
+        for character in markedText.text {
+            guard column < Float(snapshot.columns) else { break }
+            let left = Float(padding.x) + column * cellWidth
+            // Wide preedit characters (kana, hanzi) straddle two cells.
+            var advance: Float = 1
+            let key = TerminalGlyphAtlas.Key(
+                content: .cluster(Data(String(character).utf8)),
+                bold: false,
+                italic: false
+            )
+            if let entry = atlas.entry(for: key) {
+                if entry.size.x > cellWidth * 1.5 { advance = 2 }
+                instances.append(Instance(
+                    origin: SIMD2(
+                        left + entry.bearing.x,
+                        baseline - entry.bearing.y - entry.size.y
+                    ),
+                    size: entry.size,
+                    color: color,
+                    uvOrigin: entry.uvOrigin,
+                    uvSize: entry.uvSize,
+                    kind: entry.isColor ? 2 : 1
+                ))
+            }
+            instances.append(Instance(
+                origin: SIMD2(left, baseline + cellHeight * 0.12),
+                size: SIMD2(advance * cellWidth, 1),
+                color: color,
+                uvOrigin: .zero, uvSize: .zero, kind: 0
+            ))
+            column += advance
+        }
     }
 
     private func buildRow(


### PR DESCRIPTION
## Problem

Fixes #138.

With the Alacritty backend, the IME preedit (marked text) freezes mid-composition: typing `nihaoya` with a pinyin IME shows the inline preedit stuck at e.g. `ni hao` while the candidate window has already moved on, and it never catches up.

## Root cause

The preedit was shown through an `NSTextField` overlay subview. The terminal view's backing layer is swapped between a `CAMetalLayer` and a frozen `CALayer` on every focus change (`replaceBackingLayer`), and that swap breaks AppKit's view↔layer association for the subview: the field's value and frame keep tracking the composed text, but its texture never gets a display cycle again, so the pixels on screen freeze at whatever was composed when the association broke.

Verified with instrumentation: `setMarkedText` arrives on time with the full string and the field's value/frame update correctly, while the rendered texture stays stale — even a forced `needsDisplay` + `displayIfNeeded` doesn't bring it back.

## Fix

Draw the preedit in the Metal renderer alongside the grid instead of via an overlay view:

- `TerminalMetalRenderer` takes a `TerminalMarkedText` and appends preedit glyph + underline instances above all cell content, outside the per-row instance cache. It therefore tracks every `setMarkedText` exactly, even though composition produces no grid damage.
- The preedit anchor is captured before the blink/focus logic rewrites the snapshot cursor, so a hidden blink phase doesn't take the preedit down with it.
- The cursor is hidden while composing, matching native text fields.
- Wide preedit characters (kana, hanzi) advance two cells; color glyphs (emoji) keep their intrinsic colors; preedit is clipped at the grid's trailing edge.
- The `NSTextField` overlay and its plumbing are removed.

The frozen-frame path reuses `renderFrame`, so a parked/inactive surface freezes with the current preedit visible, exactly like grid content.

## Test

Manual on macOS 26.6 with the built-in pinyin IME: composed `nihaoya` (preedit tracks every keystroke), committed with space, cancelled with Esc, deleted with backspace, and repeated across window focus switches (the original trigger). All good.

## Out of scope (noted, not changed)

- `progressBar` is also a subview of the layer-swapped view and may share the stale-texture issue.
- `AlacrittyRenderer.drawMarkedText` (the old CoreText path) appears to have no callers left.