### PR TITLE
Add a global quick terminal overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+PROJECT := kero.xcodeproj
+SCHEME := kero
+CONFIGURATION := Debug
+ARCH ?= $(shell uname -m)
+DERIVED_DATA := $(CURDIR)/build/debug
+DEBUG_APP := $(DERIVED_DATA)/Build/Products/$(CONFIGURATION)/Kero Debug.app
+DEBUG_BUNDLE_ID := sh.kero.dev
+
+ifdef DEVELOPER_DIR
+XCODEBUILD := DEVELOPER_DIR="$(DEVELOPER_DIR)" xcodebuild
+else
+XCODEBUILD := xcodebuild
+endif
+
+.PHONY: run update stop
+
+# A stable DerivedData path lets `open` address the Debug bundle directly.
+run:
+	@$(XCODEBUILD) -project "$(PROJECT)" -scheme "$(SCHEME)" -configuration "$(CONFIGURATION)" -destination 'platform=macOS,arch=$(ARCH)' -derivedDataPath "$(DERIVED_DATA)" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
+	# Kero-hosted shells export these for the in-app CLI; inheriting them makes
+	# the Debug bundle immediately act as that CLI instead of launching its UI.
+	@/usr/bin/env -u KERO_CLI_STATE -u KERO_CLI_TOKEN /usr/bin/open -n "$(DEBUG_APP)"
+
+update:
+	@$(MAKE) stop
+	@$(MAKE) run
+
+# Give terminal sessions their normal shutdown path before forcing a stuck Debug app.
+stop:
+	@osascript -l JavaScript -e 'ObjC.import("AppKit"); const apps = $$.NSRunningApplication.runningApplicationsWithBundleIdentifier("$(DEBUG_BUNDLE_ID)"); for (let i = 0; i < apps.count; i += 1) { void apps.objectAtIndex(i).terminate; }'
+	@sleep 1
+	@osascript -l JavaScript -e 'ObjC.import("AppKit"); const apps = $$.NSRunningApplication.runningApplicationsWithBundleIdentifier("$(DEBUG_BUNDLE_ID)"); for (let i = 0; i < apps.count; i += 1) { void apps.objectAtIndex(i).forceTerminate; }'

--- a/kero.xcodeproj/project.pbxproj
+++ b/kero.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 110;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/kero/AgentCLISupportSettingsView.swift
+++ b/kero/AgentCLISupportSettingsView.swift
@@ -62,7 +62,6 @@ final class AgentCLISupportSettingsView: NSView {
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: toggle.leadingAnchor, constant: -16),
             toggle.trailingAnchor.constraint(equalTo: trailingAnchor),
             toggle.topAnchor.constraint(equalTo: topAnchor),
-            heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
         ])
     }
 
@@ -94,7 +93,7 @@ final class AgentCLISupportSettingsView: NSView {
     override var intrinsicContentSize: NSSize {
         NSSize(
             width: NSView.noIntrinsicMetric,
-            height: ceil(max(max(textStack.fittingSize.height, toggle.fittingSize.height), 44))
+            height: ceil(max(textStack.fittingSize.height, toggle.fittingSize.height))
         )
     }
 }

--- a/kero/Alacritty/AlacrittyTerminalView.swift
+++ b/kero/Alacritty/AlacrittyTerminalView.swift
@@ -33,6 +33,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     private var handle: OpaquePointer?
     private let token = AlacrittyRegistry.shared.nextToken()
     private var metrics: AlacrittyMetrics
+    private var backgroundOpacity: CGFloat = 1
     private var gridSize = (columns: 0, rows: 0)
     private var markedText = ""
     private let markedTextField = NSTextField(labelWithString: "")
@@ -200,7 +201,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     }
 
     private var shouldKeepMetalLayerActive: Bool {
-        isSurfaceVisible && NSApp.isActive && window?.isKeyWindow == true
+        isSurfaceVisible && window?.isKeyWindow == true
     }
 
     private func updateBackingLayerActivity(forceFrame: Bool = false) {
@@ -245,8 +246,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
         presentationCoverLayer.removeFromSuperlayer()
         let frozenLayer = CALayer()
-        frozenLayer.isOpaque = true
-        frozenLayer.backgroundColor = Theme.background.cgColor
+        frozenLayer.isOpaque = false
+        frozenLayer.backgroundColor = terminalBackgroundColor
         frozenLayer.contents = lastPresentedSurface
         frozenLayer.contentsScale = lastPresentedScale
             ?? window?.backingScaleFactor
@@ -322,8 +323,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     private func updateDirectoryPolling() {
         let shouldPoll =
-            !usesOSCWorkingDirectory
-            && isSurfaceVisible && NSApp.isActive && window?.isKeyWindow == true
+            !usesOSCWorkingDirectory && isSurfaceVisible && window?.isKeyWindow == true
         guard shouldPoll else {
             directoryTimer?.invalidate()
             directoryTimer = nil
@@ -395,8 +395,8 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             // multi-tab memory.
             presentationCoverLayer.removeFromSuperlayer()
             let parkedLayer = CALayer()
-            parkedLayer.isOpaque = true
-            parkedLayer.backgroundColor = Theme.background.cgColor
+            parkedLayer.isOpaque = false
+            parkedLayer.backgroundColor = terminalBackgroundColor
             parkedLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
             replaceBackingLayer(with: parkedLayer)
             lastPresentedSize = nil
@@ -418,7 +418,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             size: CGFloat(AppSettings.shared.fontSize),
             fontThicken: AppSettings.shared.fontThicken
         )
-        presentationCoverLayer.backgroundColor = Theme.background.cgColor
+        presentationCoverLayer.backgroundColor = terminalBackgroundColor
         var theme = AlacrittyTheme.current()
         if let handle {
             withUnsafePointer(to: &theme) { kero_alacritty_set_theme(handle, $0) }
@@ -431,6 +431,17 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         // A new cell size means a different column count.
         synchronizeGridSize()
         refreshFrozenFrame()
+    }
+
+    func setBackgroundOpacity(_ opacity: CGFloat) {
+        backgroundOpacity = min(max(opacity, 0), 1)
+        presentationCoverLayer.backgroundColor = terminalBackgroundColor
+        needsUnconditionalRedraw = true
+        if layer is CAMetalLayer {
+            scheduleRender(force: true)
+        } else {
+            refreshFrozenFrame()
+        }
     }
 
     var foregroundPid: pid_t? {
@@ -492,7 +503,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
 
     override var isFlipped: Bool { false }
 
-    override var isOpaque: Bool { true }
+    override var isOpaque: Bool { false }
 
     // MARK: - Drawing
 
@@ -505,7 +516,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         layer.device = metalDevice
         layer.pixelFormat = .bgra8Unorm
         layer.framebufferOnly = true
-        layer.isOpaque = true
+        layer.isOpaque = false
         // Terminal frames are cheap enough to keep up with the display link;
         // a third full-window drawable only adds one pane-sized IOSurface
         // (~15 MiB on a large Retina window) without improving throughput.
@@ -517,7 +528,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         layer.contentsGravity = .topLeft
         layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         layer.needsDisplayOnBoundsChange = true
-        presentationCoverLayer.backgroundColor = Theme.background.cgColor
+        presentationCoverLayer.backgroundColor = terminalBackgroundColor
         presentationCoverLayer.frame = layer.bounds
         presentationCoverLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         presentationCoverLayer.isHidden = false
@@ -660,6 +671,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
             metrics: metrics,
             padding: Self.padding,
             scale: scale,
+            backgroundOpacity: backgroundOpacity,
             dirtyRows: dirtyRows,
             in: drawable,
             viewportSize: size,
@@ -677,6 +689,10 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
         }
         AlacrittyRenderStats.shared.rebuilt(rows: dirtyRows?.count ?? snapshot.rows)
         return submitted
+    }
+
+    private var terminalBackgroundColor: CGColor {
+        Theme.background.withAlphaComponent(backgroundOpacity).cgColor
     }
 
     /// Snapshot cells are rebuilt by the bridge for every frame, so adding the
@@ -1104,7 +1120,7 @@ final class AlacrittyTerminalView: NSView, TerminalBackendSurface, NSUserInterfa
     }
 
     var hasEffectiveTerminalFocus: Bool {
-        NSApp.isActive && window?.isKeyWindow == true && window?.firstResponder === self
+        window?.isKeyWindow == true && window?.firstResponder === self
     }
 
     // MARK: - Find

--- a/kero/Alacritty/TerminalMetalRenderer.swift
+++ b/kero/Alacritty/TerminalMetalRenderer.swift
@@ -83,10 +83,9 @@ final class TerminalMetalRenderer {
         attachment.rgbBlendOperation = .add
         attachment.alphaBlendOperation = .add
         attachment.sourceRGBBlendFactor = .sourceAlpha
-        // The terminal framebuffer is always opaque. Preserve that alpha so
-        // the IOSurface retained for an inactive window composites exactly
-        // like the opaque CAMetalLayer; multiplying glyph coverage into alpha
-        // a second time makes antialiased edges look thinner after focus loss.
+        // Glyphs remain fully opaque over a potentially translucent terminal
+        // background, so their alpha must replace rather than inherit the
+        // background alpha in the retained IOSurface.
         attachment.sourceAlphaBlendFactor = .one
         attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
         attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
@@ -115,6 +114,7 @@ final class TerminalMetalRenderer {
         metrics: AlacrittyMetrics,
         padding: CGPoint,
         scale: CGFloat,
+        backgroundOpacity: CGFloat,
         dirtyRows: [Int]?,
         in drawable: CAMetalDrawable,
         viewportSize: CGSize,
@@ -133,6 +133,7 @@ final class TerminalMetalRenderer {
         build(
             snapshot: snapshot, metrics: metrics, padding: padding,
             atlas: atlas,
+            backgroundOpacity: backgroundOpacity,
             dirtyRows: resetAtlas ? nil : dirtyRows,
             viewportSize: viewportSize
         )
@@ -142,7 +143,10 @@ final class TerminalMetalRenderer {
             // rows, so rebuild the complete grid once against the new atlas.
             build(
                 snapshot: snapshot, metrics: metrics, padding: padding,
-                atlas: atlas, dirtyRows: nil, viewportSize: viewportSize
+                atlas: atlas,
+                backgroundOpacity: backgroundOpacity,
+                dirtyRows: nil,
+                viewportSize: viewportSize
             )
         }
 
@@ -151,11 +155,13 @@ final class TerminalMetalRenderer {
         pass.colorAttachments[0].loadAction = .clear
         pass.colorAttachments[0].storeAction = .store
         let background = Self.color(snapshot.background)
+        let alpha = Double(backgroundOpacity)
+        // Core Animation composites this transparent drawable as premultiplied alpha.
         pass.colorAttachments[0].clearColor = MTLClearColor(
-            red: Double(background.x),
-            green: Double(background.y),
-            blue: Double(background.z),
-            alpha: 1
+            red: Double(background.x) * alpha,
+            green: Double(background.y) * alpha,
+            blue: Double(background.z) * alpha,
+            alpha: alpha
         )
 
         guard let commands = queue.makeCommandBuffer(),
@@ -309,6 +315,7 @@ final class TerminalMetalRenderer {
         metrics: AlacrittyMetrics,
         padding: CGPoint,
         atlas: TerminalGlyphAtlas,
+        backgroundOpacity: CGFloat,
         dirtyRows: [Int]?,
         viewportSize: CGSize
     ) {
@@ -345,7 +352,9 @@ final class TerminalMetalRenderer {
             rowInstances[row] = buildRow(
                 row: row, cells: cells, columns: columns,
                 snapshot: snapshot, metrics: metrics, padding: padding,
-                atlas: atlas, viewportSize: viewportSize
+                atlas: atlas,
+                backgroundOpacity: backgroundOpacity,
+                viewportSize: viewportSize
             )
         }
 
@@ -371,6 +380,7 @@ final class TerminalMetalRenderer {
         metrics: AlacrittyMetrics,
         padding: CGPoint,
         atlas: TerminalGlyphAtlas,
+        backgroundOpacity: CGFloat,
         viewportSize: CGSize
     ) -> RowInstances {
         var instances: [Instance] = []
@@ -410,7 +420,7 @@ final class TerminalMetalRenderer {
                 instances.append(Instance(
                     origin: SIMD2(left, runTop),
                     size: SIMD2(max(right - left, 0), max(bottom - runTop, 0)),
-                    color: Self.color(background),
+                    color: Self.color(background, alpha: Float(backgroundOpacity)),
                     uvOrigin: .zero,
                     uvSize: .zero,
                     kind: 0
@@ -568,12 +578,12 @@ final class TerminalMetalRenderer {
         return precedingInstances + rowInstances[row].backgroundCount
     }
 
-    private static func color(_ packed: UInt32) -> SIMD4<Float> {
+    private static func color(_ packed: UInt32, alpha: Float = 1) -> SIMD4<Float> {
         SIMD4(
             Float((packed >> 16) & 0xff) / 255,
             Float((packed >> 8) & 0xff) / 255,
             Float(packed & 0xff) / 255,
-            1
+            alpha
         )
     }
 

--- a/kero/AppSettings.swift
+++ b/kero/AppSettings.swift
@@ -116,6 +116,11 @@ final class AppSettings: nonisolated ObservableObject {
     static let defaultSidebarFontSize: Double = 14
     static let sidebarFontSizeRange: ClosedRange<Double> = 9...18
     static let defaultToolbarVisibility: ToolbarVisibility = .hide
+    static let defaultQuickTerminalSize: Double = 0.75
+    static let quickTerminalSizeRange: ClosedRange<Double> = 0.35...0.95
+    static let defaultQuickTerminalOpacity: Double = 0.5
+    static let quickTerminalOpacityRange: ClosedRange<Double> = 0.05...1
+    static let defaultQuickTerminalShortcut = QuickTerminalShortcut.defaultValue
 
     /// The language this process launched with, kept separate from the pending
     /// selection so Settings can explain when a relaunch is required.
@@ -212,6 +217,20 @@ final class AppSettings: nonisolated ObservableObject {
         didSet { save() }
     }
 
+    /// Initial area and translucency for the global quick terminal. Per-use
+    /// adjustments stay with the overlay rather than changing these defaults.
+    @Published var quickTerminalSize: Double {
+        didSet { save() }
+    }
+
+    @Published var quickTerminalOpacity: Double {
+        didSet { save() }
+    }
+
+    @Published var quickTerminalShortcut: QuickTerminalShortcut {
+        didSet { save() }
+    }
+
     /// Link Kero's shared coordination skill plus the native lifecycle
     /// integrations whose provider APIs provide semantic turn events. Other
     /// agents retain process recognition without inferred progress state.
@@ -266,6 +285,19 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = toml["terminal.macos-option-as-alt"]?.bool ?? false
         wrapLines = toml["editor.wrap-lines"]?.bool ?? false
         restoreTerminalHistory = toml["terminal.restore-history"]?.bool ?? false
+        let quickTerminalSize = toml["quick-terminal.size"]?.double
+            ?? Self.defaultQuickTerminalSize
+        self.quickTerminalSize = Self.quickTerminalSizeRange.contains(quickTerminalSize)
+            ? quickTerminalSize
+            : Self.defaultQuickTerminalSize
+        let quickTerminalOpacity = toml["quick-terminal.opacity"]?.double
+            ?? Self.defaultQuickTerminalOpacity
+        self.quickTerminalOpacity = Self.quickTerminalOpacityRange.contains(quickTerminalOpacity)
+            ? quickTerminalOpacity
+            : Self.defaultQuickTerminalOpacity
+        quickTerminalShortcut = QuickTerminalShortcut(
+            persistedValue: toml["quick-terminal.shortcut"]?.string
+        ) ?? Self.defaultQuickTerminalShortcut
         aiEnabled = toml["ai.enabled"]?.bool ?? false
         terminalBackend = TerminalBackend(persisted: toml["terminal.backend"]?.string)
         applyAppearance()
@@ -317,6 +349,10 @@ final class AppSettings: nonisolated ObservableObject {
         macosOptionAsAlt = false
         wrapLines = false
         restoreTerminalHistory = false
+        quickTerminalSize = Self.defaultQuickTerminalSize
+        quickTerminalOpacity = Self.defaultQuickTerminalOpacity
+        quickTerminalShortcut = Self.defaultQuickTerminalShortcut
+        GlobalTerminalOverlay.shared.reloadHotkey()
         if aiEnabled {
             do {
                 try setAIEnabled(false)
@@ -404,6 +440,15 @@ final class AppSettings: nonisolated ObservableObject {
         }
         if restoreTerminalHistory {
             lines.append("terminal.restore-history = true")
+        }
+        if quickTerminalSize != Self.defaultQuickTerminalSize {
+            lines.append("quick-terminal.size = \(TOML.number(quickTerminalSize))")
+        }
+        if quickTerminalOpacity != Self.defaultQuickTerminalOpacity {
+            lines.append("quick-terminal.opacity = \(TOML.number(quickTerminalOpacity))")
+        }
+        if quickTerminalShortcut != Self.defaultQuickTerminalShortcut {
+            lines.append("quick-terminal.shortcut = \(TOML.quote(quickTerminalShortcut.persistedValue))")
         }
         if aiEnabled {
             lines.append("ai.enabled = true")

--- a/kero/FinderService.swift
+++ b/kero/FinderService.swift
@@ -18,6 +18,11 @@ final class KeroApplicationDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.servicesProvider = self
+        GlobalTerminalOverlay.shared.start()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        GlobalTerminalOverlay.shared.stop()
     }
 
     /// Opens every directory Finder placed on the service pasteboard as a

--- a/kero/GlobalTerminalOverlay.swift
+++ b/kero/GlobalTerminalOverlay.swift
@@ -1,0 +1,995 @@
+//
+//  GlobalTerminalOverlay.swift
+//  kero
+//
+
+import AppKit
+import Carbon.HIToolbox
+
+struct QuickTerminalShortcut: Equatable {
+    static let defaultValue = QuickTerminalShortcut(
+        keyCode: UInt32(kVK_ANSI_I),
+        modifiers: UInt32(cmdKey)
+    )
+
+    let keyCode: UInt32
+    let modifiers: UInt32
+
+    init(keyCode: UInt32, modifiers: UInt32) {
+        self.keyCode = keyCode
+        self.modifiers = modifiers & Self.supportedModifiers
+    }
+
+    init?(persistedValue: String?) {
+        guard let persistedValue else { return nil }
+        let components = persistedValue.split(separator: ":", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              let keyCode = UInt32(components[0]),
+              let modifiers = UInt32(components[1]),
+              Self.isValid(modifiers: modifiers)
+        else { return nil }
+        self.init(keyCode: keyCode, modifiers: modifiers)
+    }
+
+    init?(event: NSEvent) {
+        var modifiers: UInt32 = 0
+        if event.modifierFlags.contains(.command) { modifiers |= UInt32(cmdKey) }
+        if event.modifierFlags.contains(.option) { modifiers |= UInt32(optionKey) }
+        if event.modifierFlags.contains(.control) { modifiers |= UInt32(controlKey) }
+        if event.modifierFlags.contains(.shift) { modifiers |= UInt32(shiftKey) }
+        guard Self.isValid(modifiers: modifiers) else { return nil }
+        self.init(keyCode: UInt32(event.keyCode), modifiers: modifiers)
+    }
+
+    var persistedValue: String { "\(keyCode):\(modifiers)" }
+
+    var displayString: String {
+        var result = ""
+        if modifiers & UInt32(controlKey) != 0 { result += "⌃" }
+        if modifiers & UInt32(optionKey) != 0 { result += "⌥" }
+        if modifiers & UInt32(shiftKey) != 0 { result += "⇧" }
+        if modifiers & UInt32(cmdKey) != 0 { result += "⌘" }
+        return result + (Self.keyLabels[keyCode] ?? "Key \(keyCode)")
+    }
+
+    private static let supportedModifiers = UInt32(cmdKey | optionKey | controlKey | shiftKey)
+    private static let requiredModifiers = UInt32(cmdKey | optionKey | controlKey)
+
+    private static func isValid(modifiers: UInt32) -> Bool {
+        modifiers & requiredModifiers != 0
+    }
+
+    private static let keyLabels: [UInt32: String] = [
+        UInt32(kVK_ANSI_A): "A", UInt32(kVK_ANSI_B): "B",
+        UInt32(kVK_ANSI_C): "C", UInt32(kVK_ANSI_D): "D",
+        UInt32(kVK_ANSI_E): "E", UInt32(kVK_ANSI_F): "F",
+        UInt32(kVK_ANSI_G): "G", UInt32(kVK_ANSI_H): "H",
+        UInt32(kVK_ANSI_I): "I", UInt32(kVK_ANSI_J): "J",
+        UInt32(kVK_ANSI_K): "K", UInt32(kVK_ANSI_L): "L",
+        UInt32(kVK_ANSI_M): "M", UInt32(kVK_ANSI_N): "N",
+        UInt32(kVK_ANSI_O): "O", UInt32(kVK_ANSI_P): "P",
+        UInt32(kVK_ANSI_Q): "Q", UInt32(kVK_ANSI_R): "R",
+        UInt32(kVK_ANSI_S): "S", UInt32(kVK_ANSI_T): "T",
+        UInt32(kVK_ANSI_U): "U", UInt32(kVK_ANSI_V): "V",
+        UInt32(kVK_ANSI_W): "W", UInt32(kVK_ANSI_X): "X",
+        UInt32(kVK_ANSI_Y): "Y", UInt32(kVK_ANSI_Z): "Z",
+        UInt32(kVK_ANSI_0): "0", UInt32(kVK_ANSI_1): "1",
+        UInt32(kVK_ANSI_2): "2", UInt32(kVK_ANSI_3): "3",
+        UInt32(kVK_ANSI_4): "4", UInt32(kVK_ANSI_5): "5",
+        UInt32(kVK_ANSI_6): "6", UInt32(kVK_ANSI_7): "7",
+        UInt32(kVK_ANSI_8): "8", UInt32(kVK_ANSI_9): "9",
+        UInt32(kVK_Space): "Space", UInt32(kVK_Return): "Return",
+        UInt32(kVK_Tab): "Tab", UInt32(kVK_Delete): "Delete",
+        UInt32(kVK_LeftArrow): "←", UInt32(kVK_RightArrow): "→",
+        UInt32(kVK_UpArrow): "↑", UInt32(kVK_DownArrow): "↓",
+    ]
+}
+
+/// The independent quick terminal. An unpinned overlay owns a temporary shell
+/// only while it is focused; pinning changes that lifetime explicitly.
+@MainActor
+final class GlobalTerminalOverlay: NSObject {
+    static let shared = GlobalTerminalOverlay()
+
+    private static let hotkeySignature = OSType(0x4B45524F)
+    private static let hotkeyIdentifier: UInt32 = 1
+    private static let hotkeyHandler: EventHandlerUPP = { _, event, userData in
+        guard let event, let userData else { return noErr }
+
+        var receivedIdentifier = EventHotKeyID()
+        let status = GetEventParameter(
+            event,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &receivedIdentifier
+        )
+        guard status == noErr,
+              receivedIdentifier.signature == hotkeySignature,
+              receivedIdentifier.id == hotkeyIdentifier
+        else {
+            return noErr
+        }
+
+        let overlay = Unmanaged<GlobalTerminalOverlay>
+            .fromOpaque(userData)
+            .takeUnretainedValue()
+        Task { @MainActor in overlay.toggle() }
+        return noErr
+    }
+
+    private var hotkey: EventHotKeyRef?
+    private var hotkeyHandlerRef: EventHandlerRef?
+    private var terminalSession: TerminalSession?
+    private var terminalWindow: GlobalTerminalOverlayWindow?
+    private var backdropWindow: GlobalTerminalBackdropWindow?
+    private var previousApplication: NSRunningApplication?
+    private var isPinned = false
+
+    func start() {
+        guard hotkeyHandlerRef == nil else { return }
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        var handler: EventHandlerRef?
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            Self.hotkeyHandler,
+            1,
+            &eventType,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &handler
+        )
+        guard handlerStatus == noErr else {
+            NSLog("kero: could not install global terminal hotkey handler (\(handlerStatus))")
+            return
+        }
+        hotkeyHandlerRef = handler
+
+        _ = registerHotkey(AppSettings.shared.quickTerminalShortcut)
+    }
+
+    func stop() {
+        dismiss(restorePreviousApplication: false)
+        unregisterHotkey()
+        if let hotkeyHandlerRef { RemoveEventHandler(hotkeyHandlerRef) }
+        hotkeyHandlerRef = nil
+        backdropWindow?.close()
+        terminalWindow?.close()
+        terminalSession?.terminate()
+        backdropWindow = nil
+        terminalWindow = nil
+        terminalSession = nil
+    }
+
+    func beginHotkeyRecording() {
+        unregisterHotkey()
+    }
+
+    func endHotkeyRecording() {
+        guard hotkey == nil else { return }
+        _ = registerHotkey(AppSettings.shared.quickTerminalShortcut)
+    }
+
+    func reloadHotkey() {
+        guard hotkeyHandlerRef != nil else { return }
+        unregisterHotkey()
+        _ = registerHotkey(AppSettings.shared.quickTerminalShortcut)
+    }
+
+    func setHotkey(_ shortcut: QuickTerminalShortcut) -> Bool {
+        guard hotkeyHandlerRef != nil else {
+            AppSettings.shared.quickTerminalShortcut = shortcut
+            return true
+        }
+
+        unregisterHotkey()
+        guard registerHotkey(shortcut) else {
+            _ = registerHotkey(AppSettings.shared.quickTerminalShortcut)
+            return false
+        }
+        AppSettings.shared.quickTerminalShortcut = shortcut
+        return true
+    }
+
+    private func registerHotkey(_ shortcut: QuickTerminalShortcut) -> Bool {
+        guard hotkey == nil else { return true }
+
+        var registeredHotkey: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            shortcut.keyCode,
+            shortcut.modifiers,
+            EventHotKeyID(signature: Self.hotkeySignature, id: Self.hotkeyIdentifier),
+            GetApplicationEventTarget(),
+            0,
+            &registeredHotkey
+        )
+        guard status == noErr else {
+            NSLog("kero: could not register global terminal hotkey \(shortcut.displayString) (\(status))")
+            return false
+        }
+        hotkey = registeredHotkey
+        return true
+    }
+
+    private func unregisterHotkey() {
+        if let hotkey { UnregisterEventHotKey(hotkey) }
+        hotkey = nil
+    }
+
+    private func toggle() {
+        if terminalWindow?.isVisible == true {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    private func show() {
+        guard let screen = screenAtPointer() else { return }
+        if terminalSession == nil {
+            terminalSession = TerminalSession()
+        }
+        guard let terminalSession else { return }
+
+        if terminalWindow == nil {
+            let window = GlobalTerminalOverlayWindow(
+                session: terminalSession,
+                defaultSize: AppSettings.shared.quickTerminalSize,
+                defaultOpacity: AppSettings.shared.quickTerminalOpacity,
+                onPinChanged: { [weak self] pinned in
+                    self?.setPinned(pinned)
+                }
+            )
+            window.delegate = self
+            terminalWindow = window
+        }
+        guard let terminalWindow else { return }
+
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        previousApplication = frontmostApplication?.processIdentifier
+            == ProcessInfo.processInfo.processIdentifier
+            ? nil
+            : frontmostApplication
+
+        terminalWindow.prepareForPresentation(on: screen)
+        terminalSession.applyTheme()
+        terminalWindow.orderFrontRegardless()
+        terminalWindow.makeKey()
+        terminalWindow.revealTerminal()
+        updateBackdrop(on: screen)
+    }
+
+    private func dismiss(restorePreviousApplication: Bool = true) {
+        guard let terminalWindow, terminalWindow.isVisible else { return }
+
+        backdropWindow?.orderOut(nil)
+        terminalSession?.surface.setSurfaceVisible(false)
+        terminalWindow.orderOut(nil)
+
+        let application = previousApplication
+        previousApplication = nil
+        terminalSession?.terminate()
+        terminalSession = nil
+        terminalWindow.close()
+        self.terminalWindow = nil
+        isPinned = false
+
+        guard restorePreviousApplication,
+              NSApp.isActive,
+              let application,
+              !application.isTerminated
+        else { return }
+        DispatchQueue.main.async {
+            application.activate(options: [])
+        }
+    }
+
+    private func setPinned(_ pinned: Bool) {
+        isPinned = pinned
+        guard let terminalWindow, terminalWindow.isVisible,
+              let screen = screenForWindow(terminalWindow)
+        else { return }
+        updateBackdrop(on: screen)
+    }
+
+    private func updateBackdrop(on screen: NSScreen) {
+        guard !isPinned, let terminalWindow, terminalWindow.isVisible else {
+            backdropWindow?.orderOut(nil)
+            return
+        }
+        if backdropWindow == nil {
+            backdropWindow = GlobalTerminalBackdropWindow { [weak self] in
+                self?.dismiss()
+            }
+        }
+        guard let backdropWindow else { return }
+        backdropWindow.setFrame(screen.frame, display: false)
+        backdropWindow.orderFront(nil)
+        backdropWindow.order(.below, relativeTo: terminalWindow.windowNumber)
+    }
+
+    func dismissFromWindow() {
+        dismiss()
+    }
+
+    private func screenAtPointer() -> NSScreen? {
+        let pointer = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(pointer) } ?? NSScreen.main
+    }
+
+    private func screenForWindow(_ window: NSWindow) -> NSScreen? {
+        let center = NSPoint(x: window.frame.midX, y: window.frame.midY)
+        return NSScreen.screens.first { $0.frame.contains(center) } ?? NSScreen.main
+    }
+}
+
+extension GlobalTerminalOverlay: NSWindowDelegate {
+    func windowDidResignKey(_ notification: Notification) {
+        guard !isPinned else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let window = self.terminalWindow,
+                  window.isVisible,
+                  !window.isKeyWindow,
+                  !window.isShowingSettings
+            else { return }
+            self.dismiss()
+        }
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard let terminalWindow,
+              terminalWindow.isVisible,
+              let screen = screenForWindow(terminalWindow)
+        else { return }
+        updateBackdrop(on: screen)
+    }
+}
+
+@MainActor
+private final class GlobalTerminalOverlayWindow: NSPanel {
+    private var content: GlobalTerminalContentView!
+    private let defaultSize: CGFloat
+    private var areaFraction: CGFloat
+    private var resizeStartFrame: NSRect?
+    private var resizeStartMouse: NSPoint?
+    private var settingsPopover: NSPopover?
+    private(set) var isPinned = false
+    private var hasConfiguredFrame = false
+
+    init(
+        session: TerminalSession,
+        defaultSize: Double,
+        defaultOpacity: Double,
+        onPinChanged: @escaping (Bool) -> Void
+    ) {
+        self.defaultSize = CGFloat(defaultSize)
+        areaFraction = CGFloat(defaultSize)
+        self.onPinChanged = onPinChanged
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.borderless, .resizable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        level = .statusBar
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .canJoinAllApplications,
+            .fullScreenAuxiliary,
+            .stationary,
+            .ignoresCycle,
+        ]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        hidesOnDeactivate = false
+        isMovable = true
+        isMovableByWindowBackground = false
+        minSize = NSSize(width: 420, height: 260)
+
+        content = GlobalTerminalContentView(
+            session: session,
+            opacity: CGFloat(defaultOpacity),
+            isPinned: false,
+            togglePinned: { [weak self] in
+                guard let self else { return }
+                self.setPinned(!self.isPinned)
+            },
+            showSettings: { [weak self] button in self?.showSettings(from: button) },
+            beginResize: { [weak self] event in self?.beginResize(with: event) },
+            resize: { [weak self] event in self?.resize(with: event) },
+            endResize: { [weak self] in self?.endResize() }
+        )
+        contentView = content
+        content.setBackgroundOpacity(CGFloat(defaultOpacity))
+        content.setPinState(false)
+    }
+
+    private let onPinChanged: (Bool) -> Void
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .keyDown, event.keyCode == UInt16(kVK_Escape) {
+            GlobalTerminalOverlay.shared.dismissFromWindow()
+            return
+        }
+        super.sendEvent(event)
+    }
+
+    func setPinned(_ pinned: Bool) {
+        isPinned = pinned
+        content.setPinState(pinned)
+        onPinChanged(pinned)
+    }
+
+    func prepareForPresentation(on screen: NSScreen) {
+        if !hasConfiguredFrame {
+            let visibleFrame = screen.visibleFrame
+            let scale = sqrt(max(defaultSize, 0.01))
+            let size = NSSize(
+                width: visibleFrame.width * scale,
+                height: visibleFrame.height * scale
+            )
+            setFrame(
+                NSRect(
+                    x: visibleFrame.midX - size.width / 2,
+                    y: visibleFrame.midY - size.height / 2,
+                    width: size.width,
+                    height: size.height
+                ),
+                display: false
+            )
+            hasConfiguredFrame = true
+        } else if !screen.frame.contains(NSPoint(x: frame.midX, y: frame.midY)) {
+            let visibleFrame = screen.visibleFrame
+            setFrameOrigin(NSPoint(
+                x: visibleFrame.midX - frame.width / 2,
+                y: visibleFrame.midY - frame.height / 2
+            ))
+            resizeForAreaFraction(areaFraction)
+        }
+    }
+
+    func revealTerminal() {
+        content.revealTerminal()
+    }
+
+    var isShowingSettings: Bool {
+        settingsPopover?.isShown == true
+    }
+
+    private func showSettings(from button: NSButton) {
+        let popover = settingsPopover ?? NSPopover()
+        popover.behavior = .transient
+        popover.contentViewController = GlobalTerminalAdjustmentsViewController(
+            size: { [weak self] in self?.currentAreaFraction ?? self?.areaFraction ?? 0.75 },
+            setSize: { [weak self] value in self?.resizeForAreaFraction(value) },
+            opacity: { [weak self] in self?.content.backgroundOpacity ?? 0.5 },
+            setOpacity: { [weak self] value in self?.content.setBackgroundOpacity(value) }
+        )
+        settingsPopover = popover
+        popover.show(
+            relativeTo: button.bounds,
+            of: button,
+            preferredEdge: .maxY
+        )
+    }
+
+    private var currentAreaFraction: CGFloat {
+        guard let screen = screenContainingCenter else {
+            return areaFraction
+        }
+        let visible = screen.visibleFrame
+        return min(
+            max((frame.width * frame.height) / (visible.width * visible.height),
+                CGFloat(AppSettings.quickTerminalSizeRange.lowerBound)),
+            CGFloat(AppSettings.quickTerminalSizeRange.upperBound)
+        )
+    }
+
+    private func resizeForAreaFraction(_ value: CGFloat) {
+        let fraction = min(
+            max(value, CGFloat(AppSettings.quickTerminalSizeRange.lowerBound)),
+            CGFloat(AppSettings.quickTerminalSizeRange.upperBound)
+        )
+        areaFraction = fraction
+        guard let screen = screenContainingCenter else {
+            return
+        }
+        let visible = screen.visibleFrame
+        let aspect = max(frame.width / max(frame.height, 1), 0.5)
+        let center = NSPoint(x: frame.midX, y: frame.midY)
+        let maxWidth = max(minSize.width, 2 * min(center.x - visible.minX, visible.maxX - center.x))
+        let maxHeight = max(minSize.height, 2 * min(center.y - visible.minY, visible.maxY - center.y))
+        let height = sqrt(visible.width * visible.height * fraction / aspect)
+        let scale = min(1, maxWidth / (height * aspect), maxHeight / height)
+        let size = NSSize(width: height * aspect * scale, height: height * scale)
+        setFrame(
+            NSRect(
+                x: center.x - size.width / 2,
+                y: center.y - size.height / 2,
+                width: size.width,
+                height: size.height
+            ),
+            display: true
+        )
+    }
+
+    private func beginResize(with event: NSEvent) {
+        resizeStartFrame = frame
+        resizeStartMouse = NSEvent.mouseLocation
+    }
+
+    private func resize(with event: NSEvent) {
+        guard let startFrame = resizeStartFrame,
+              let startMouse = resizeStartMouse,
+              let screen = screenContaining(center: NSPoint(
+                  x: startFrame.midX,
+                  y: startFrame.midY
+              ))
+        else { return }
+        let mouse = NSEvent.mouseLocation
+        let visible = screen.visibleFrame
+        let center = NSPoint(x: startFrame.midX, y: startFrame.midY)
+        let maxWidth = max(minSize.width, 2 * min(center.x - visible.minX, visible.maxX - center.x))
+        let maxHeight = max(minSize.height, 2 * min(center.y - visible.minY, visible.maxY - center.y))
+        let width = min(
+            max(minSize.width, startFrame.width + 2 * (mouse.x - startMouse.x)),
+            maxWidth
+        )
+        let height = min(
+            max(minSize.height, startFrame.height + 2 * (startMouse.y - mouse.y)),
+            maxHeight
+        )
+        setFrame(
+            NSRect(
+                x: center.x - width / 2,
+                y: center.y - height / 2,
+                width: width,
+                height: height
+            ),
+            display: true
+        )
+        areaFraction = currentAreaFraction
+    }
+
+    private func endResize() {
+        resizeStartFrame = nil
+        resizeStartMouse = nil
+    }
+
+    private var screenContainingCenter: NSScreen? {
+        screenContaining(center: NSPoint(x: frame.midX, y: frame.midY))
+    }
+
+    private func screenContaining(center: NSPoint) -> NSScreen? {
+        NSScreen.screens.first { $0.frame.contains(center) } ?? NSScreen.main
+    }
+}
+
+@MainActor
+private final class GlobalTerminalContentView: NSView {
+    private let terminal: any TerminalBackendSurface
+    private let materialBackground: NSVisualEffectView
+    private let titlebar: GlobalTerminalTitlebarView
+    private let resizeHandle: GlobalTerminalResizeHandle
+    private var shouldActivateTerminal = false
+    private(set) var backgroundOpacity: CGFloat
+
+    init(
+        session: TerminalSession,
+        opacity: CGFloat,
+        isPinned: Bool,
+        togglePinned: @escaping () -> Void,
+        showSettings: @escaping (NSButton) -> Void,
+        beginResize: @escaping (NSEvent) -> Void,
+        resize: @escaping (NSEvent) -> Void,
+        endResize: @escaping () -> Void
+    ) {
+        terminal = session.surface
+        materialBackground = NSVisualEffectView()
+        backgroundOpacity = opacity
+        titlebar = GlobalTerminalTitlebarView(
+            isPinned: isPinned,
+            togglePinned: togglePinned,
+            showSettings: showSettings
+        )
+        resizeHandle = GlobalTerminalResizeHandle(
+            beginResize: beginResize,
+            resize: resize,
+            endResize: endResize
+        )
+        super.init(frame: .zero)
+
+        wantsLayer = true
+        layer?.cornerRadius = 12
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = true
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.25).cgColor
+
+        materialBackground.material = .hudWindow
+        materialBackground.blendingMode = .behindWindow
+        materialBackground.state = .active
+        materialBackground.alphaValue = 1
+        materialBackground.translatesAutoresizingMaskIntoConstraints = false
+        titlebar.translatesAutoresizingMaskIntoConstraints = false
+        terminal.translatesAutoresizingMaskIntoConstraints = false
+        resizeHandle.translatesAutoresizingMaskIntoConstraints = false
+        terminal.setBackgroundOpacity(backgroundOpacity)
+        addSubview(materialBackground)
+        addSubview(titlebar)
+        addSubview(terminal)
+        addSubview(resizeHandle)
+        NSLayoutConstraint.activate([
+            materialBackground.leadingAnchor.constraint(equalTo: leadingAnchor),
+            materialBackground.trailingAnchor.constraint(equalTo: trailingAnchor),
+            materialBackground.topAnchor.constraint(equalTo: topAnchor),
+            materialBackground.bottomAnchor.constraint(equalTo: bottomAnchor),
+            titlebar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titlebar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            titlebar.topAnchor.constraint(equalTo: topAnchor),
+            titlebar.heightAnchor.constraint(equalToConstant: 32),
+            terminal.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
+            terminal.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            terminal.topAnchor.constraint(equalTo: titlebar.bottomAnchor),
+            terminal.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+            resizeHandle.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3),
+            resizeHandle.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -3),
+            resizeHandle.widthAnchor.constraint(equalToConstant: 16),
+            resizeHandle.heightAnchor.constraint(equalToConstant: 16),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setPinState(_ pinned: Bool) {
+        titlebar.setPinState(pinned)
+    }
+
+    func setBackgroundOpacity(_ opacity: CGFloat) {
+        backgroundOpacity = min(
+            max(opacity, CGFloat(AppSettings.quickTerminalOpacityRange.lowerBound)),
+            CGFloat(AppSettings.quickTerminalOpacityRange.upperBound)
+        )
+        terminal.setBackgroundOpacity(backgroundOpacity)
+    }
+
+    func revealTerminal() {
+        shouldActivateTerminal = true
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+    }
+
+    override func layout() {
+        super.layout()
+        guard shouldActivateTerminal,
+              let window,
+              terminal.window === window,
+              terminal.bounds.width > 0,
+              terminal.bounds.height > 0
+        else { return }
+
+        shouldActivateTerminal = false
+        terminal.setSurfaceVisible(true)
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let window = self.window,
+                  window.isKeyWindow,
+                  self.terminal.window === window
+            else { return }
+            window.makeFirstResponder(self.terminal)
+        }
+    }
+}
+
+@MainActor
+private final class GlobalTerminalTitlebarView: NSView {
+    private let pinButton = NSButton()
+    private let settingsButton = NSButton()
+    private let togglePinned: () -> Void
+    private let showSettings: (NSButton) -> Void
+
+    init(
+        isPinned: Bool,
+        togglePinned: @escaping () -> Void,
+        showSettings: @escaping (NSButton) -> Void
+    ) {
+        self.togglePinned = togglePinned
+        self.showSettings = showSettings
+        super.init(frame: .zero)
+
+        configure(
+            pinButton,
+            imageName: isPinned ? "pin.fill" : "pin",
+            label: String(localized: "Pin quick terminal"),
+            tooltip: String(localized: "Pin quick terminal")
+        )
+        configure(
+            settingsButton,
+            imageName: "gearshape",
+            label: String(localized: "Temporary terminal settings"),
+            tooltip: String(localized: "Temporary terminal settings")
+        )
+        pinButton.target = self
+        pinButton.action = #selector(pinPressed)
+        settingsButton.target = self
+        settingsButton.action = #selector(settingsPressed)
+
+        pinButton.translatesAutoresizingMaskIntoConstraints = false
+        settingsButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(pinButton)
+        addSubview(settingsButton)
+        NSLayoutConstraint.activate([
+            pinButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 7),
+            pinButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            pinButton.widthAnchor.constraint(equalToConstant: 24),
+            pinButton.heightAnchor.constraint(equalToConstant: 24),
+            settingsButton.leadingAnchor.constraint(equalTo: pinButton.trailingAnchor, constant: 2),
+            settingsButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            settingsButton.widthAnchor.constraint(equalToConstant: 24),
+            settingsButton.heightAnchor.constraint(equalToConstant: 24),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setPinState(_ pinned: Bool) {
+        pinButton.image = NSImage(
+            systemSymbolName: pinned ? "pin.fill" : "pin",
+            accessibilityDescription: nil
+        )
+        pinButton.toolTip = String(localized: pinned ? "Unpin quick terminal" : "Pin quick terminal")
+        pinButton.setAccessibilityLabel(
+            String(localized: pinned ? "Unpin quick terminal" : "Pin quick terminal")
+        )
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
+    }
+
+    @objc private func pinPressed() {
+        togglePinned()
+    }
+
+    @objc private func settingsPressed() {
+        showSettings(settingsButton)
+    }
+
+    private func configure(
+        _ button: NSButton,
+        imageName: String,
+        label: String,
+        tooltip: String
+    ) {
+        button.image = NSImage(systemSymbolName: imageName, accessibilityDescription: nil)
+        button.isBordered = false
+        button.bezelStyle = .recessed
+        button.imageScaling = .scaleProportionallyDown
+        button.contentTintColor = .secondaryLabelColor
+        button.focusRingType = .none
+        button.toolTip = tooltip
+        button.setAccessibilityLabel(label)
+    }
+}
+
+@MainActor
+private final class GlobalTerminalResizeHandle: NSView {
+    private let beginResize: (NSEvent) -> Void
+    private let resize: (NSEvent) -> Void
+    private let endResize: () -> Void
+
+    init(
+        beginResize: @escaping (NSEvent) -> Void,
+        resize: @escaping (NSEvent) -> Void,
+        endResize: @escaping () -> Void
+    ) {
+        self.beginResize = beginResize
+        self.resize = resize
+        self.endResize = endResize
+        super.init(frame: .zero)
+        toolTip = String(localized: "Resize quick terminal")
+        setAccessibilityLabel(String(localized: "Resize quick terminal"))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        beginResize(event)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        resize(event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        endResize()
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let path = NSBezierPath()
+        path.lineWidth = 1
+        for offset in stride(from: 5, through: 11, by: 3) {
+            path.move(to: NSPoint(x: offset, y: 2))
+            path.line(to: NSPoint(x: 14, y: 14 - offset + 2))
+        }
+        NSColor.secondaryLabelColor.withAlphaComponent(0.55).setStroke()
+        path.stroke()
+    }
+}
+
+@MainActor
+private final class GlobalTerminalBackdropWindow: NSPanel {
+    init(dismiss: @escaping () -> Void) {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue - 1)
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .canJoinAllApplications,
+            .fullScreenAuxiliary,
+            .stationary,
+            .ignoresCycle,
+        ]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        hidesOnDeactivate = false
+        contentView = GlobalTerminalBackdropView(dismiss: dismiss)
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+private final class GlobalTerminalBackdropView: NSView {
+    private let dismissAction: () -> Void
+
+    init(dismiss: @escaping () -> Void) {
+        dismissAction = dismiss
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) { dismissAction() }
+    override func rightMouseDown(with event: NSEvent) { dismissAction() }
+    override func otherMouseDown(with event: NSEvent) { dismissAction() }
+}
+
+@MainActor
+private final class GlobalTerminalAdjustmentsViewController: NSViewController {
+    private let readSize: () -> CGFloat
+    private let setSize: (CGFloat) -> Void
+    private let readOpacity: () -> CGFloat
+    private let setOpacity: (CGFloat) -> Void
+    private let sizeSlider = NSSlider()
+    private let opacitySlider = NSSlider()
+    private let sizeValue = NSTextField(labelWithString: "")
+    private let opacityValue = NSTextField(labelWithString: "")
+
+    init(
+        size: @escaping () -> CGFloat,
+        setSize: @escaping (CGFloat) -> Void,
+        opacity: @escaping () -> CGFloat,
+        setOpacity: @escaping (CGFloat) -> Void
+    ) {
+        readSize = size
+        self.setSize = setSize
+        readOpacity = opacity
+        self.setOpacity = setOpacity
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        sizeSlider.minValue = AppSettings.quickTerminalSizeRange.lowerBound
+        sizeSlider.maxValue = AppSettings.quickTerminalSizeRange.upperBound
+        sizeSlider.isContinuous = true
+        sizeSlider.target = self
+        sizeSlider.action = #selector(sizeChanged)
+        sizeSlider.setAccessibilityLabel(String(localized: "Temporary terminal size"))
+
+        opacitySlider.minValue = AppSettings.quickTerminalOpacityRange.lowerBound
+        opacitySlider.maxValue = AppSettings.quickTerminalOpacityRange.upperBound
+        opacitySlider.isContinuous = true
+        opacitySlider.target = self
+        opacitySlider.action = #selector(opacityChanged)
+        opacitySlider.setAccessibilityLabel(String(localized: "Temporary terminal opacity"))
+
+        [sizeValue, opacityValue].forEach {
+            $0.alignment = .right
+            $0.font = .monospacedDigitSystemFont(
+                ofSize: NSFont.smallSystemFontSize,
+                weight: .regular
+            )
+            $0.textColor = .secondaryLabelColor
+            $0.widthAnchor.constraint(equalToConstant: 42).isActive = true
+        }
+
+        let stack = NSStackView(views: [
+            row(title: String(localized: "Size"), slider: sizeSlider, value: sizeValue),
+            row(title: String(localized: "Opacity"), slider: opacitySlider, value: opacityValue),
+        ])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 9
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 270, height: 74))
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: root.topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: root.bottomAnchor, constant: -12),
+        ])
+        view = root
+        updateValues()
+    }
+
+    @objc private func sizeChanged() {
+        setSize(sizeSlider.cgFloatValue)
+        updateValues()
+    }
+
+    @objc private func opacityChanged() {
+        setOpacity(opacitySlider.cgFloatValue)
+        updateValues()
+    }
+
+    private func updateValues() {
+        sizeSlider.doubleValue = Double(readSize())
+        opacitySlider.doubleValue = Double(readOpacity())
+        sizeValue.stringValue = "\(Int((sizeSlider.doubleValue * 100).rounded()))%"
+        opacityValue.stringValue = "\(Int((opacitySlider.doubleValue * 100).rounded()))%"
+    }
+
+    private func row(
+        title: String,
+        slider: NSSlider,
+        value: NSTextField
+    ) -> NSStackView {
+        let label = NSTextField(labelWithString: title)
+        label.widthAnchor.constraint(equalToConstant: 58).isActive = true
+        slider.widthAnchor.constraint(equalToConstant: 145).isActive = true
+        let row = NSStackView(views: [label, slider, value])
+        row.orientation = .horizontal
+        row.spacing = 7
+        return row
+    }
+}
+
+private extension NSSlider {
+    var cgFloatValue: CGFloat { CGFloat(doubleValue) }
+}

--- a/kero/KeroTerminalView+Ghostty.swift
+++ b/kero/KeroTerminalView+Ghostty.swift
@@ -22,7 +22,7 @@ extension KeroTerminalView {
         let controller = TerminalController(
             configSource: .none,
             theme: Self.ghosttyTheme(),
-            terminalConfiguration: Self.terminalConfiguration(command: launch.commandLine)
+            terminalConfiguration: terminalConfiguration(command: launch.commandLine)
         )
         ghosttyController = controller
         delegate = self
@@ -41,7 +41,7 @@ extension KeroTerminalView {
     func applyAppearance() {
         guard let ghosttyController else { return }
         _ = ghosttyController.setTerminalConfiguration(
-            Self.terminalConfiguration(command: launchCommand)
+            terminalConfiguration(command: launchCommand)
         )
         _ = ghosttyController.setTheme(Self.ghosttyTheme())
         let isDark = NSApp.effectiveAppearance.bestMatch(
@@ -59,7 +59,7 @@ extension KeroTerminalView {
 
     // MARK: - Configuration
 
-    private static func terminalConfiguration(command: String) -> TerminalConfiguration {
+    private func terminalConfiguration(command: String) -> TerminalConfiguration {
         let settings = AppSettings.shared
         let family = settings.fontFamily.isEmpty
             ? TerminalFont.bundledFamily : settings.fontFamily
@@ -128,6 +128,7 @@ extension KeroTerminalView {
                 settings.macosOptionAsAlt ? "true" : "false"
             )
             builder.withCustom("scrollbar", "never")
+            builder.withBackgroundOpacity(backgroundOpacity)
             // Terminal-program clipboard access via OSC 52, matching the
             // Ghostty app defaults: reads prompt the user per request
             // (TerminalSession presents the confirmation sheet), writes

--- a/kero/KeroTerminalView.swift
+++ b/kero/KeroTerminalView.swift
@@ -37,6 +37,7 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
     private var isCapturingHistoryExport = false
     private var capturedHistoryExportPath: String?
     private var isSurfaceVisible = false
+    private(set) var backgroundOpacity = 1.0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -57,6 +58,11 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
     override func setSurfaceVisible(_ visible: Bool) {
         isSurfaceVisible = visible
         super.setSurfaceVisible(visible)
+    }
+
+    func setBackgroundOpacity(_ opacity: CGFloat) {
+        backgroundOpacity = min(max(Double(opacity), 0), 1)
+        applyAppearance()
     }
 
     func clearScreen() {
@@ -155,10 +161,9 @@ final class KeroTerminalView: AppTerminalView, TerminalBackendSurface {
         return true
     }
 
-    /// The terminal is effectively focused only while Kero itself is active,
-    /// its window is key, and this exact surface owns the first responder.
+    /// The quick-terminal panel can be key without activating Kero.
     var hasEffectiveTerminalFocus: Bool {
-        NSApp.isActive && window?.isKeyWindow == true && window?.firstResponder === self
+        window?.isKeyWindow == true && window?.firstResponder === self
     }
 
     override func isAccessibilityElement() -> Bool { isSurfaceVisible }

--- a/kero/Localizable.xcstrings
+++ b/kero/Localizable.xcstrings
@@ -4640,6 +4640,22 @@
         }
       }
     },
+    "Opacity" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不透明度"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不透明度"
+          }
+        }
+      }
+    },
     "Paste" : {
       "localizations" : {
         "ja" : {
@@ -4732,6 +4748,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "端口"
+          }
+        }
+      }
+    },
+    "Press shortcut" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカットを押してください"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按下快捷键"
           }
         }
       }
@@ -5020,6 +5052,86 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "推送"
+          }
+        }
+      }
+    },
+    "Quick Terminal" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックターミナル"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端"
+          }
+        }
+      }
+    },
+    "Quick Terminal default opacity" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックターミナルのデフォルト不透明度"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端默认不透明度"
+          }
+        }
+      }
+    },
+    "Quick Terminal default shortcut" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックターミナルのデフォルトショートカット"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端默认快捷键"
+          }
+        }
+      }
+    },
+    "Quick Terminal default size" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックターミナルのデフォルトサイズ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端默认大小"
+          }
+        }
+      }
+    },
+    "Quick Terminal shortcut" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックターミナルのショートカット"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端快捷键"
           }
         }
       }
@@ -5880,6 +5992,22 @@
         }
       }
     },
+    "Shortcut" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカット"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷键"
+          }
+        }
+      }
+    },
     "Session" : {
       "localizations" : {
         "ja" : {
@@ -6624,6 +6752,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签页"
+          }
+        }
+      }
+    },
+    "Temporary terminal opacity" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時ターミナルの不透明度"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端不透明度"
+          }
+        }
+      }
+    },
+    "Temporary terminal size" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時ターミナルのサイズ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时终端大小"
           }
         }
       }

--- a/kero/SettingsView.swift
+++ b/kero/SettingsView.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Carbon.HIToolbox
 import GhosttyTheme
 import SwiftUI
 
@@ -218,6 +219,11 @@ struct SettingsView: View {
                 }
             }
 
+            Section("Quick Terminal") {
+                QuickTerminalDefaultsSettingsView()
+                    .frame(height: 80)
+            }
+
             Section("Text Editing") {
                 Toggle("Wrap lines to editor width", isOn: $settings.wrapLines)
             }
@@ -227,7 +233,6 @@ struct SettingsView: View {
                     isEnabled: settings.aiEnabled,
                     onChange: { try settings.setAIEnabled($0) }
                 )
-                .frame(minHeight: 44)
             }
 
             Section("Updates") {
@@ -262,6 +267,9 @@ struct SettingsView: View {
                         && settings.toolbarVisibility == AppSettings.defaultToolbarVisibility
                         && !settings.wrapLines
                         && !settings.restoreTerminalHistory
+                        && settings.quickTerminalSize == AppSettings.defaultQuickTerminalSize
+                        && settings.quickTerminalOpacity == AppSettings.defaultQuickTerminalOpacity
+                        && settings.quickTerminalShortcut == AppSettings.defaultQuickTerminalShortcut
                         && !settings.aiEnabled
                         && settings.terminalBackend == .fallback)
                 }
@@ -441,6 +449,206 @@ private struct CappedIdealHeight: Layout {
             anchor: .topLeading,
             proposal: ProposedViewSize(bounds.size)
         )
+    }
+}
+
+private struct QuickTerminalDefaultsSettingsView: NSViewRepresentable {
+    @ObservedObject private var settings = AppSettings.shared
+
+    func makeNSView(context: Context) -> QuickTerminalDefaultsView {
+        QuickTerminalDefaultsView()
+    }
+
+    func updateNSView(_ view: QuickTerminalDefaultsView, context: Context) {
+        view.update(
+            size: settings.quickTerminalSize,
+            opacity: settings.quickTerminalOpacity,
+            shortcut: settings.quickTerminalShortcut
+        )
+    }
+}
+
+private final class QuickTerminalDefaultsView: NSView {
+    private let sizeSlider = NSSlider()
+    private let opacitySlider = NSSlider()
+    private let sizeValue = NSTextField(labelWithString: "")
+    private let opacityValue = NSTextField(labelWithString: "")
+    private let shortcutRecorder = QuickTerminalShortcutRecorder()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        sizeSlider.minValue = AppSettings.quickTerminalSizeRange.lowerBound
+        sizeSlider.maxValue = AppSettings.quickTerminalSizeRange.upperBound
+        sizeSlider.isContinuous = true
+        sizeSlider.target = self
+        sizeSlider.action = #selector(sizeChanged)
+        sizeSlider.setAccessibilityLabel(String(localized: "Quick Terminal default size"))
+
+        opacitySlider.minValue = AppSettings.quickTerminalOpacityRange.lowerBound
+        opacitySlider.maxValue = AppSettings.quickTerminalOpacityRange.upperBound
+        opacitySlider.isContinuous = true
+        opacitySlider.target = self
+        opacitySlider.action = #selector(opacityChanged)
+        opacitySlider.setAccessibilityLabel(String(localized: "Quick Terminal default opacity"))
+
+        shortcutRecorder.onShortcutChanged = { shortcut in
+            GlobalTerminalOverlay.shared.setHotkey(shortcut)
+        }
+
+        [sizeValue, opacityValue].forEach {
+            $0.alignment = .right
+            $0.font = .monospacedDigitSystemFont(
+                ofSize: NSFont.smallSystemFontSize,
+                weight: .regular
+            )
+            $0.textColor = .secondaryLabelColor
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            $0.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        }
+
+        let stack = NSStackView(views: [
+            shortcutRow(),
+            row(title: String(localized: "Size"), slider: sizeSlider, value: sizeValue),
+            row(title: String(localized: "Opacity"), slider: opacitySlider, value: opacityValue),
+        ])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(size: Double, opacity: Double, shortcut: QuickTerminalShortcut) {
+        sizeSlider.doubleValue = size
+        opacitySlider.doubleValue = opacity
+        sizeValue.stringValue = "\(Int((size * 100).rounded()))%"
+        opacityValue.stringValue = "\(Int((opacity * 100).rounded()))%"
+        shortcutRecorder.setShortcut(shortcut)
+    }
+
+    @objc private func sizeChanged() {
+        AppSettings.shared.quickTerminalSize = sizeSlider.doubleValue
+    }
+
+    @objc private func opacityChanged() {
+        AppSettings.shared.quickTerminalOpacity = opacitySlider.doubleValue
+    }
+
+    private func row(
+        title: String,
+        slider: NSSlider,
+        value: NSTextField
+    ) -> NSStackView {
+        let label = NSTextField(labelWithString: title)
+        label.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        slider.widthAnchor.constraint(equalToConstant: 220).isActive = true
+        let row = NSStackView(views: [label, slider, value])
+        row.orientation = .horizontal
+        row.spacing = 8
+        return row
+    }
+
+    private func shortcutRow() -> NSStackView {
+        let label = NSTextField(labelWithString: String(localized: "Shortcut"))
+        label.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        shortcutRecorder.widthAnchor.constraint(equalToConstant: 220).isActive = true
+        let row = NSStackView(views: [label, shortcutRecorder])
+        row.orientation = .horizontal
+        row.spacing = 8
+        return row
+    }
+}
+
+private final class QuickTerminalShortcutRecorder: NSButton {
+    var onShortcutChanged: ((QuickTerminalShortcut) -> Bool)?
+
+    private var shortcut = AppSettings.defaultQuickTerminalShortcut
+    private var isRecording = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        bezelStyle = .rounded
+        controlSize = .small
+        font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        target = self
+        action = #selector(startRecording)
+        setAccessibilityLabel(String(localized: "Quick Terminal shortcut"))
+        toolTip = String(localized: "Quick Terminal shortcut")
+        updateTitle()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        guard super.becomeFirstResponder() else { return false }
+        guard !isRecording else { return true }
+        isRecording = true
+        title = String(localized: "Press shortcut")
+        GlobalTerminalOverlay.shared.beginHotkeyRecording()
+        return true
+    }
+
+    override func resignFirstResponder() -> Bool {
+        guard super.resignFirstResponder() else { return false }
+        guard isRecording else { return true }
+        isRecording = false
+        GlobalTerminalOverlay.shared.endHotkeyRecording()
+        updateTitle()
+        return true
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard isRecording else { return super.performKeyEquivalent(with: event) }
+        keyDown(with: event)
+        return true
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == UInt16(kVK_Escape) {
+            window?.makeFirstResponder(nil)
+            return
+        }
+        guard let shortcut = QuickTerminalShortcut(event: event) else {
+            NSSound.beep()
+            return
+        }
+        guard onShortcutChanged?(shortcut) ?? true else {
+            NSSound.beep()
+            return
+        }
+        self.shortcut = shortcut
+        window?.makeFirstResponder(nil)
+    }
+
+    func setShortcut(_ shortcut: QuickTerminalShortcut) {
+        self.shortcut = shortcut
+        guard !isRecording else { return }
+        updateTitle()
+    }
+
+    @objc private func startRecording() {
+        window?.makeFirstResponder(self)
+    }
+
+    private func updateTitle() {
+        title = shortcut.displayString
     }
 }
 

--- a/kero/TerminalBackend.swift
+++ b/kero/TerminalBackend.swift
@@ -182,6 +182,10 @@ protocol TerminalBackendSurface: NSView {
     /// to pick up a new font, color theme, or input setting in place.
     func applyAppearance()
 
+    /// Adjusts only the terminal background's alpha. Pane terminals stay
+    /// opaque; the global quick terminal opts into this per surface.
+    func setBackgroundOpacity(_ opacity: CGFloat)
+
     /// Releases the emulator and its child process bookkeeping. The view
     /// itself outlives this call so teardown never pulls a pane out from
     /// under the layout mid-frame.

--- a/scripts/build-alacritty-bridge.sh
+++ b/scripts/build-alacritty-bridge.sh
@@ -36,6 +36,25 @@ if ! command -v cargo > /dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v rustc > /dev/null 2>&1; then
+  echo "error: rustc not found. Kero's Alacritty backend needs a complete Rust toolchain." >&2
+  exit 1
+fi
+
+rust_target_is_installed() {
+  local target="$1"
+
+  if command -v rustup > /dev/null 2>&1; then
+    rustup target list --installed | grep -qx "${target}"
+    return
+  fi
+
+  # Homebrew Rust does not ship rustup; its installed targets live under rustc's sysroot.
+  local target_libdir
+  target_libdir="$(rustc --print target-libdir --target "${target}" 2>/dev/null)" || return 1
+  [[ -d "${target_libdir}" ]]
+}
+
 mkdir -p "${BUILD_DIR}" "${OUTPUT_DIR}"
 # Copy rather than symlink: cargo resolves the manifest's real path, and a
 # symlinked manifest lands back in the read-only source tree.
@@ -51,10 +70,15 @@ for arch in ${=ARCHS}; do
     *) echo "error: unsupported architecture ${arch}" >&2; exit 1 ;;
   esac
 
-  if ! rustup target list --installed 2>/dev/null | grep -qx "${target}"; then
+  if ! rust_target_is_installed "${target}"; then
     # Installing writes to ~/.rustup, which the script sandbox forbids, so say
     # so here instead of failing later with an unexplained linker error.
-    echo "error: Rust target ${target} is not installed. Run: rustup target add ${target}" >&2
+    if command -v rustup > /dev/null 2>&1; then
+      hint="Run: rustup target add ${target}"
+    else
+      hint="Install a Rust toolchain that includes ${target}."
+    fi
+    echo "error: Rust target ${target} is not installed. ${hint}" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

Adds an independent quick terminal that can be invoked from anywhere on macOS without opening or reusing a workspace tab. The overlay owns a temporary shell and is intended for short, in-context commands.

## User-facing behavior

- Registers `Command-I` as the default global shortcut. The shortcut is configurable in Settings; recording temporarily unregisters the old hotkey and restores it when recording ends or is cancelled.
- Opens on the display containing the pointer, centered at 75% of that displays visible area by default. The panel joins all Spaces, can join other applications, and is a full-screen auxiliary panel so it can appear above another app, including full-screen apps.
- Creates a new temporary shell when opened. Unpinned overlays dismiss when they lose focus or when the transparent backdrop is clicked. Escape, the global shortcut while visible, and backdrop dismissal explicitly terminate the shell.
- Pinning keeps only the current overlay alive after it loses focus. Explicit dismissal still terminates that shell, resets the pin state, and makes the next invocation a fresh unpinned terminal.
- The title bar supports dragging, pinning, a per-invocation size/opacity popover, and a center-anchored resize handle. Resizing retains the current visual center. Reopening on a different display recalculates the size from the stored area fraction instead of retaining dimensions from a larger display.
- Settings persist the default shortcut, default size, and default background opacity. Defaults are 75% area and 50% opacity; opacity accepts 5%-100%. Per-invocation adjustments do not overwrite defaults.
- Adds Chinese and Japanese localization for the settings, accessibility labels, tooltips, shortcut recorder, and temporary adjustments.

## Rendering and focus integration

- Adds a per-surface background-opacity API to both Ghostty and Alacritty backends. Only terminal backgrounds are translucent; glyph opacity is unchanged.
- Updates the Alacritty Metal clear and cell-background paths to use premultiplied alpha, avoiding pale/outlined glyph edges when compositing a transparent terminal.
- Lets terminal surfaces receive effective focus when the non-activating quick-terminal panel is key, even if Kero itself is not the active application.
- Keeps ordinary pane terminals opaque and unchanged.

## Debug build workflow and compatibility

- Adds `make run`, `make stop`, and `make update` for the isolated `sh.kero.dev` Debug app. The Makefile selects the local architecture and honors an externally supplied `DEVELOPER_DIR`; it does not hardcode a developer-specific Xcode path.
- `run` removes Kero CLI environment variables before opening the Debug bundle, avoiding accidental in-app CLI behavior. `stop` targets only the Debug bundle id, and `update` performs `stop` then `run`.
- Lowers the Xcode project object version to 77 so the project can be opened by released Xcode versions while still building with newer Xcode installations. The Alacritty bridge script now detects Rust targets using either rustup or a Homebrew toolchain and emits actionable errors when prerequisites are missing.

## Settings layout polish

- Adds a compact Quick Terminal settings section with shortcut, size, and opacity controls.
- Removes redundant fixed heights from the Automation settings row so the AI control background hugs its contents.

## Validation

- `xcodebuild -quiet -project kero.xcodeproj -scheme kero -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath build/debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `git diff --check`
- `make -n run`
- `make -n update`
- `make -n stop`

The Debug build completed successfully. Existing unrelated warnings remain: one main-actor isolation warning in `TerminalHistory.swift`, plus linker warnings because the Rust archive targets macOS 26 while the app link target is macOS 15.6.

## Manual verification to perform on macOS

- Invoke the shortcut with Kero inactive, on each display, and while another app is full-screen.
- Confirm pointer-display centering, the 75% default area, and display-relative resizing after closing on a large display then reopening on a smaller one.
- Confirm unpinned focus loss/backdrop dismissal closes the shell; confirm pinning preserves it only until an explicit dismissal.
- Confirm size, per-use opacity, persisted defaults, shortcut recording/cancellation, and Chinese/Japanese labels.
- Confirm translucent backgrounds retain normal text opacity and no glyph halo in both available terminal backends.